### PR TITLE
added GoTerm constructors

### DIFF
--- a/mzLib/Proteomics/GoTerm.cs
+++ b/mzLib/Proteomics/GoTerm.cs
@@ -11,6 +11,18 @@ namespace Proteomics
         public string id { get; set; }
         public string description { get; set; }
         public Aspect aspect { get; set; }
+
+        public GoTerm()
+        {
+
+        }
+
+        public GoTerm(string _id, string _description, Aspect _aspect)
+        {
+            this.id = _id;
+            this.description = _description;
+            this.aspect = _aspect;
+        }
     }
 
     public enum Aspect


### PR DESCRIPTION
since we use the GoTerm class form mzlib in proteoform suite, I can no longer edit in proteoform suite. I need these new constructors for testing
