### PR TITLE
Make the id's for short-hand modification notations unique

### DIFF
--- a/Proteomics/ModificationMotif.cs
+++ b/Proteomics/ModificationMotif.cs
@@ -16,14 +16,14 @@ namespace Proteomics
 
         private ModificationMotif(string motif)
         {
-            this.Motif = motif;
+            Motif = motif;
         }
 
         #endregion Private Constructors
 
         #region Public Properties
 
-        public string Motif { get; private set; }
+        public string Motif { get; }
 
         #endregion Public Properties
 

--- a/UsefulProteomicsDatabases/ProteinDbLoader.cs
+++ b/UsefulProteomicsDatabases/ProteinDbLoader.cs
@@ -329,7 +329,7 @@ namespace UsefulProteomicsDatabases
         [SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         public static List<Modification> GetPtmListFromProteinXml(string proteinDbLocation)
         {
-            if (last_database_location.Equals(proteinDbLocation))
+            if (proteinDbLocation.Equals(last_database_location))
                 return protein_xml_modlist;
             last_database_location = proteinDbLocation;
 

--- a/UsefulProteomicsDatabases/PtmListLoader.cs
+++ b/UsefulProteomicsDatabases/PtmListLoader.cs
@@ -2,6 +2,7 @@
 using Proteomics;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -276,7 +277,7 @@ namespace UsefulProteomicsDatabases
                                                     if (correctionFormula == null)
                                                     {
                                                         // Return modification with mass
-                                                        result = new ModificationWithMass(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss), uniprotAC, motif, terminusLocalization, monoisotopicMass.Value, externalDatabaseLinks,
+                                                        result = new ModificationWithMass(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F5", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, monoisotopicMass.Value, externalDatabaseLinks,
                                                             neutralLoss,
                                                             massesObserved ?? new HashSet<double> { monoisotopicMass.Value },
                                                             diagnosticIons,
@@ -285,7 +286,7 @@ namespace UsefulProteomicsDatabases
                                                     else
                                                     {
                                                         // Return modification with complete information!
-                                                        result = new ModificationWithMassAndCf(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss), uniprotAC, motif, terminusLocalization, correctionFormula, monoisotopicMass.Value, externalDatabaseLinks,
+                                                        result = new ModificationWithMassAndCf(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F5", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, correctionFormula, monoisotopicMass.Value, externalDatabaseLinks,
                                                             neutralLoss,
                                                             massesObserved ?? new HashSet<double> { monoisotopicMass.Value },
                                                             diagnosticIons,

--- a/UsefulProteomicsDatabases/PtmListLoader.cs
+++ b/UsefulProteomicsDatabases/PtmListLoader.cs
@@ -160,14 +160,14 @@ namespace UsefulProteomicsDatabases
             string id = null;
             Tuple<string, string> uniprotAC = null;
             string uniprotFT = null;
-            IEnumerable<string> motifs = null;
+            List<string> motifs = null;
             string terminusLocalizationString = null;
             ChemicalFormula correctionFormula = null;
             double? monoisotopicMass = null;
             var externalDatabaseLinks = new Dictionary<string, IList<string>>();
 
             // Custom fields
-            IEnumerable<double> neutralLosses = null;
+            HashSet<double> neutralLosses = null;
             IEnumerable<double> massesObserved = null;
             IEnumerable<double> diagnosticIons = null;
             string modificationType = null;
@@ -265,7 +265,7 @@ namespace UsefulProteomicsDatabases
                                             if (!monoisotopicMass.HasValue)
                                             {
                                                 // Return modification
-                                                result = new ModificationWithLocation(id, uniprotAC, motif, terminusLocalization, externalDatabaseLinks, modificationType);
+                                                result = new ModificationWithLocation(id + (motifs.Count == 1 ? "" : " of " + motif.Motif), uniprotAC, motif, terminusLocalization, externalDatabaseLinks, modificationType);
                                             }
                                             else
                                             {
@@ -276,7 +276,7 @@ namespace UsefulProteomicsDatabases
                                                     if (correctionFormula == null)
                                                     {
                                                         // Return modification with mass
-                                                        result = new ModificationWithMass(id, uniprotAC, motif, terminusLocalization, monoisotopicMass.Value, externalDatabaseLinks,
+                                                        result = new ModificationWithMass(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss), uniprotAC, motif, terminusLocalization, monoisotopicMass.Value, externalDatabaseLinks,
                                                             neutralLoss,
                                                             massesObserved ?? new HashSet<double> { monoisotopicMass.Value },
                                                             diagnosticIons,
@@ -285,7 +285,7 @@ namespace UsefulProteomicsDatabases
                                                     else
                                                     {
                                                         // Return modification with complete information!
-                                                        result = new ModificationWithMassAndCf(id, uniprotAC, motif, terminusLocalization, correctionFormula, monoisotopicMass.Value, externalDatabaseLinks,
+                                                        result = new ModificationWithMassAndCf(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss), uniprotAC, motif, terminusLocalization, correctionFormula, monoisotopicMass.Value, externalDatabaseLinks,
                                                             neutralLoss,
                                                             massesObserved ?? new HashSet<double> { monoisotopicMass.Value },
                                                             diagnosticIons,

--- a/UsefulProteomicsDatabases/PtmListLoader.cs
+++ b/UsefulProteomicsDatabases/PtmListLoader.cs
@@ -277,7 +277,7 @@ namespace UsefulProteomicsDatabases
                                                     if (correctionFormula == null)
                                                     {
                                                         // Return modification with mass
-                                                        result = new ModificationWithMass(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F5", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, monoisotopicMass.Value, externalDatabaseLinks,
+                                                        result = new ModificationWithMass(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F3", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, monoisotopicMass.Value, externalDatabaseLinks,
                                                             neutralLoss,
                                                             massesObserved ?? new HashSet<double> { monoisotopicMass.Value },
                                                             diagnosticIons,
@@ -286,7 +286,7 @@ namespace UsefulProteomicsDatabases
                                                     else
                                                     {
                                                         // Return modification with complete information!
-                                                        result = new ModificationWithMassAndCf(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F5", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, correctionFormula, monoisotopicMass.Value, externalDatabaseLinks,
+                                                        result = new ModificationWithMassAndCf(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F3", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, correctionFormula, monoisotopicMass.Value, externalDatabaseLinks,
                                                             neutralLoss,
                                                             massesObserved ?? new HashSet<double> { monoisotopicMass.Value },
                                                             diagnosticIons,


### PR DESCRIPTION
thus making the modification reading consistent.

The original idea was that specifying multiple targets for a modification such as 
```
ID Deamidation
TG N or Q
```
would result in reading two modifications. This was working fine until I realized that the modifications that are being read in have identical IDs. To make this consistent, the two modifications now have id "Deamidation of N" and "Deamidation of Q".
Same logic for the neutral losses. 

It is not clear that those **should** be different modification objects, but they **are** right now, and I'm trying to make them work by giving them different id's.

Oh, and writing them is always separate right now, the only way of writing modification in such a condensed notation is by hand.