### PR TITLE
Do not silently skip mods with null id. Throw error instead. 

### DIFF
--- a/Test/DatabaseLoaderTests.cs
+++ b/Test/DatabaseLoaderTests.cs
@@ -178,6 +178,12 @@ namespace Test
         }
 
         [Test]
+        public void CompactFormReading()
+        {
+            Assert.AreEqual(2, PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "sampleModFileDouble.txt")).Count());
+        }
+
+        [Test]
         public void Modification_read_write_into_proteinDb()
         {
             Loaders.LoadElements(Path.Combine(TestContext.CurrentContext.TestDirectory, "elements2.dat"));

--- a/Test/DatabaseLoaderTests.cs
+++ b/Test/DatabaseLoaderTests.cs
@@ -160,6 +160,24 @@ namespace Test
         }
 
         [Test]
+        public void SampleModFileLoadingFail5()
+        {
+            Assert.That(() => PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "sampleModFileFail5.txt")).ToList(),
+                                            Throws.TypeOf<PtmListLoaderException>()
+                                            .With.Property("Message")
+                                            .EqualTo("id is null"));
+        }
+
+        [Test]
+        public void SampleModFileLoadingFail6()
+        {
+            Assert.That(() => PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "sampleModFileFail6.txt")).ToList(),
+                                            Throws.TypeOf<PtmListLoaderException>()
+                                            .With.Property("Message")
+                                            .EqualTo("modificationType of lalaMod is null"));
+        }
+
+        [Test]
         public void Modification_read_write_into_proteinDb()
         {
             Loaders.LoadElements(Path.Combine(TestContext.CurrentContext.TestDirectory, "elements2.dat"));

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -133,6 +133,9 @@
     <Content Include="sampleModFileFail5.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="sampleModFileDouble.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <Content Include="xml2.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -127,6 +127,12 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <None Include="sampleModFileFail6.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <Content Include="sampleModFileFail5.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="xml2.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/Test/sampleModFileDouble.txt
+++ b/Test/sampleModFileDouble.txt
@@ -1,0 +1,6 @@
+﻿ID   lalaMod
+TG   Nxs or Nxt
+PP   Anywhere.
+MM   15.995
+MT   nice
+//

--- a/Test/sampleModFileFail5.txt
+++ b/Test/sampleModFileFail5.txt
@@ -1,0 +1,7 @@
+﻿TG   Nxs or Nxt
+PP   Anywhere.
+MM   15.995
+NL   0 or 15.995
+OM   15.995 or 4.995
+DI   50 or 60
+//

--- a/Test/sampleModFileFail6.txt
+++ b/Test/sampleModFileFail6.txt
@@ -1,0 +1,8 @@
+﻿ID   lalaMod
+TG   Nxs or Nxt
+PP   Anywhere.
+MM   15.995
+NL   0 or 15.995
+OM   15.995 or 4.995
+DI   50 or 60
+//

--- a/UsefulProteomicsDatabases/PtmListLoader.cs
+++ b/UsefulProteomicsDatabases/PtmListLoader.cs
@@ -244,9 +244,15 @@ namespace UsefulProteomicsDatabases
                             break;
 
                         case "//":
-                            // Not CROSSLNK. LIPID and MOD_RES is fine.
-                            if ((uniprotFT == null || !uniprotFT.Equals("CROSSLNK")) && terminusLocalizationString != null && motifs != null && id != null)
-                            {
+                            if (id == null)
+                                throw new PtmListLoaderException("id is null");
+                            if (uniprotFT != null && uniprotFT.Equals("CROSSLNK"))
+                                break;
+                            if (uniprotAC != null)
+                                modificationType = "uniprot";
+                            if (modificationType == null)
+                                throw new PtmListLoaderException("modificationType of " + id + " is null");
+                            if (terminusLocalizationString != null && motifs != null)
                                 if (ModificationWithLocation.terminusLocalizationTypeCodes.TryGetValue(terminusLocalizationString, out ModificationSites terminusLocalization))
                                 {
                                     foreach (var singleTarget in motifs)
@@ -259,9 +265,6 @@ namespace UsefulProteomicsDatabases
                                         if (ModificationMotif.TryGetMotif(theMotif, out ModificationMotif motif))
                                         {
                                             // Add the modification!
-
-                                            if (uniprotAC != null)
-                                                modificationType = "uniprot";
 
                                             if (!monoisotopicMass.HasValue)
                                             {
@@ -301,7 +304,6 @@ namespace UsefulProteomicsDatabases
                                 }
                                 else
                                     throw new PtmListLoaderException("Could not get modification site from " + terminusLocalizationString);
-                            }
                             break;
                     }
                 }

--- a/UsefulProteomicsDatabases/PtmListLoader.cs
+++ b/UsefulProteomicsDatabases/PtmListLoader.cs
@@ -173,8 +173,6 @@ namespace UsefulProteomicsDatabases
             IEnumerable<double> diagnosticIons = null;
             string modificationType = null;
 
-            ModificationWithLocation result = null;
-
             foreach (string line in specification)
             {
                 if (line.Length >= 2)

--- a/UsefulProteomicsDatabases/PtmListLoader.cs
+++ b/UsefulProteomicsDatabases/PtmListLoader.cs
@@ -277,7 +277,7 @@ namespace UsefulProteomicsDatabases
                                                     if (correctionFormula == null)
                                                     {
                                                         // Return modification with mass
-                                                        result = new ModificationWithMass(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F5", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, monoisotopicMass.Value, externalDatabaseLinks,
+                                                        result = new ModificationWithMass(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F3", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, monoisotopicMass.Value, externalDatabaseLinks,
                                                             neutralLoss,
                                                             massesObserved ?? new HashSet<double> { monoisotopicMass.Value },
                                                             diagnosticIons,
@@ -286,7 +286,7 @@ namespace UsefulProteomicsDatabases
                                                     else
                                                     {
                                                         // Return modification with complete information!
-                                                        result = new ModificationWithMassAndCf(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F5", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, correctionFormula, monoisotopicMass.Value, externalDatabaseLinks,
+                                                        result = new ModificationWithMassAndCf(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F3", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, correctionFormula, monoisotopicMass.Value, externalDatabaseLinks,
                                                             neutralLoss,
                                                             massesObserved ?? new HashSet<double> { monoisotopicMass.Value },
                                                             diagnosticIons,

--- a/UsefulProteomicsDatabases/PtmListLoader.cs
+++ b/UsefulProteomicsDatabases/PtmListLoader.cs
@@ -89,8 +89,8 @@ namespace UsefulProteomicsDatabases
 
                             case "//":
                                 modification_specification.Add(line);
-                                ModificationWithLocation m = ReadMod(modification_specification);
-                                if (m != null) yield return m;
+                                foreach (var mod in ReadMod(modification_specification))
+                                    yield return mod;
                                 modification_specification = new List<string>();
                                 break;
                         }
@@ -136,8 +136,8 @@ namespace UsefulProteomicsDatabases
 
                             case "//":
                                 modification_specification.Add(line);
-                                ModificationWithLocation m = ReadMod(modification_specification);
-                                if (m != null) yield return m;
+                                foreach (var mod in ReadMod(modification_specification))
+                                    yield return mod;
                                 modification_specification = new List<string>();
                                 break;
                         }
@@ -155,7 +155,7 @@ namespace UsefulProteomicsDatabases
         /// </summary>
         /// <param name="specification"></param>
         /// <returns></returns>
-        private static ModificationWithLocation ReadMod(List<string> specification)
+        private static IEnumerable<ModificationWithLocation> ReadMod(List<string> specification)
         {
             // UniProt fields
             string id = null;
@@ -269,7 +269,7 @@ namespace UsefulProteomicsDatabases
                                             if (!monoisotopicMass.HasValue)
                                             {
                                                 // Return modification
-                                                result = new ModificationWithLocation(id + (motifs.Count == 1 ? "" : " of " + motif.Motif), uniprotAC, motif, terminusLocalization, externalDatabaseLinks, modificationType);
+                                                yield return new ModificationWithLocation(id + (motifs.Count == 1 ? "" : " of " + motif.Motif), uniprotAC, motif, terminusLocalization, externalDatabaseLinks, modificationType);
                                             }
                                             else
                                             {
@@ -280,7 +280,7 @@ namespace UsefulProteomicsDatabases
                                                     if (correctionFormula == null)
                                                     {
                                                         // Return modification with mass
-                                                        result = new ModificationWithMass(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F3", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, monoisotopicMass.Value, externalDatabaseLinks,
+                                                        yield return new ModificationWithMass(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F3", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, monoisotopicMass.Value, externalDatabaseLinks,
                                                             neutralLoss,
                                                             massesObserved ?? new HashSet<double> { monoisotopicMass.Value },
                                                             diagnosticIons,
@@ -289,7 +289,7 @@ namespace UsefulProteomicsDatabases
                                                     else
                                                     {
                                                         // Return modification with complete information!
-                                                        result = new ModificationWithMassAndCf(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F3", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, correctionFormula, monoisotopicMass.Value, externalDatabaseLinks,
+                                                        yield return new ModificationWithMassAndCf(id + (motifs.Count == 1 ? "" : " of " + motif.Motif) + (neutralLosses.Count == 1 ? "" : " NL:" + neutralLoss.ToString("F3", CultureInfo.InvariantCulture)), uniprotAC, motif, terminusLocalization, correctionFormula, monoisotopicMass.Value, externalDatabaseLinks,
                                                             neutralLoss,
                                                             massesObserved ?? new HashSet<double> { monoisotopicMass.Value },
                                                             diagnosticIons,
@@ -308,7 +308,6 @@ namespace UsefulProteomicsDatabases
                     }
                 }
             }
-            return result;
         }
 
         #endregion Private Methods


### PR DESCRIPTION
Also modification type is mandatory now, except for uniprot ptmlist which doesnt have it.