### PR TITLE
fix file extension capitlizaiton

### DIFF
--- a/Test/TestMzML.cs
+++ b/Test/TestMzML.cs
@@ -47,9 +47,9 @@ namespace Test
 
             FakeMsDataFile f = new FakeMsDataFile(scans);
 
-            MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(f, Path.Combine(TestContext.CurrentContext.TestDirectory, "what.mzml"), false);
+            MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(f, Path.Combine(TestContext.CurrentContext.TestDirectory, "what.mzML"), false);
 
-            Mzml ok = Mzml.LoadAllStaticData(Path.Combine(TestContext.CurrentContext.TestDirectory, "what.mzml"));
+            Mzml ok = Mzml.LoadAllStaticData(Path.Combine(TestContext.CurrentContext.TestDirectory, "what.mzML"));
 
             var scanWithPrecursor = ok.Last(b => b is IMsDataScanWithPrecursor<IMzSpectrum<IMzPeak>>) as IMsDataScanWithPrecursor<IMzSpectrum<IMzPeak>>;
 
@@ -74,9 +74,9 @@ namespace Test
 
             FakeMsDataFile f = new FakeMsDataFile(scans);
 
-            MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(f, Path.Combine(TestContext.CurrentContext.TestDirectory, "asdfefsf.mzml"), false);
+            MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(f, Path.Combine(TestContext.CurrentContext.TestDirectory, "asdfefsf.mzML"), false);
 
-            Mzml ok = Mzml.LoadAllStaticData(Path.Combine(TestContext.CurrentContext.TestDirectory, "asdfefsf.mzml"));
+            Mzml ok = Mzml.LoadAllStaticData(Path.Combine(TestContext.CurrentContext.TestDirectory, "asdfefsf.mzML"));
 
             Assert.AreEqual(MZAnalyzerType.Orbitrap, ok.First().MzAnalyzer);
             Assert.AreEqual(MZAnalyzerType.IonTrap3D, ok.Last().MzAnalyzer);

--- a/TestThermo/TestThermo.cs
+++ b/TestThermo/TestThermo.cs
@@ -196,8 +196,8 @@ namespace TestThermo
         public void WriteIndexedMzmlFromThermoTest()
         {
             var smallThermo = ThermoStaticData.LoadAllStaticData(@"small.raw");
-            MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(smallThermo, Path.Combine(TestContext.CurrentContext.TestDirectory, "Hi.mzml"), true);
-            var smallMzml = Mzml.LoadAllStaticData(@"hi.mzml");
+            MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(smallThermo, Path.Combine(TestContext.CurrentContext.TestDirectory, "Hi.mzML"), true);
+            var smallMzml = Mzml.LoadAllStaticData(@"hi.mzML");
             Assert.AreEqual(smallMzml.NumSpectra, 48);
             Assert.AreEqual(smallMzml.GetOneBasedScan(8).OneBasedScanNumber, 8);
             Assert.AreEqual(smallThermo.GetOneBasedScan(5).RetentionTime, smallMzml.GetOneBasedScan(5).RetentionTime);


### PR DESCRIPTION
Change file extension capitalization of test mzML files so that test files are compatible with TDPortal