### PR TITLE
Serializable pep with set mods

### DIFF
--- a/Proteomics/Fragmentation/NeutralTerminusFragment.cs
+++ b/Proteomics/Fragmentation/NeutralTerminusFragment.cs
@@ -3,6 +3,13 @@ using System;
 
 namespace Proteomics.Fragmentation
 {
+    /// <summary>
+    /// This object has the neutral mass, the fragment terminus, and the amino acid position of the last amino acid in the fragment next to the 
+    /// break in the peptide backbone. N-terminal amino acid is numbered 1.
+    /// See for Reference the following two web-pages.
+    /// http://www.matrixscience.com/help/fragmentation_help.html
+    /// http://www.matrixscience.com/help/aa_help.html
+    /// </summary>
     [Serializable]
     public class NeutralTerminusFragment
     {
@@ -10,14 +17,7 @@ namespace Proteomics.Fragmentation
         public readonly double NeutralMass;
         public readonly int FragmentNumber;
         public readonly int AminoAcidPosition;
-
-        /// <summary>
-        /// This object has the neutral mass, the fragment terminus, and the amino acid position of the last amino acid in the fragment next to the 
-        /// break in the peptide backbone. N-terminal amino acid is numbered 1.
-        /// See for Reference the following two web-pages.
-        /// http://www.matrixscience.com/help/fragmentation_help.html
-        /// http://www.matrixscience.com/help/aa_help.html
-        /// </summary>
+        
         public NeutralTerminusFragment(FragmentationTerminus terminus, double neutralMass, int fragmentNumber, int aminoAcidPosition)
         {
             this.Terminus = terminus;

--- a/Proteomics/Fragmentation/NeutralTerminusFragment.cs
+++ b/Proteomics/Fragmentation/NeutralTerminusFragment.cs
@@ -1,7 +1,9 @@
 ﻿using Chemistry;
+using System;
 
 namespace Proteomics.Fragmentation
 {
+    [Serializable]
     public class NeutralTerminusFragment
     {
         public readonly FragmentationTerminus Terminus;
@@ -10,7 +12,8 @@ namespace Proteomics.Fragmentation
         public readonly int AminoAcidPosition;
 
         /// <summary>
-        ///This object has the neutral mass, the fragment terminus, and the amino acid position of the last amino acid in the fragment next to the break in the peptide backbone. N-terminal amino acid is numbered 1.
+        /// This object has the neutral mass, the fragment terminus, and the amino acid position of the last amino acid in the fragment next to the 
+        /// break in the peptide backbone. N-terminal amino acid is numbered 1.
         /// See for Reference the following two web-pages.
         /// http://www.matrixscience.com/help/fragmentation_help.html
         /// http://www.matrixscience.com/help/aa_help.html

--- a/Proteomics/ProteolyticDigestion/DigestionParams.cs
+++ b/Proteomics/ProteolyticDigestion/DigestionParams.cs
@@ -1,4 +1,5 @@
 ﻿using Proteomics.Fragmentation;
+using System;
 
 namespace Proteomics.ProteolyticDigestion
 {
@@ -24,7 +25,7 @@ namespace Proteomics.ProteolyticDigestion
             SemiProteaseDigestion = semiProteaseDigestion;
             TerminusTypeSemiProtease = terminusTypeSemiProtease;
         }
-
+        
         public int MaxMissedCleavages { get; private set; }
         public InitiatorMethionineBehavior InitiatorMethionineBehavior { get; private set; }
         public int MinPeptideLength { get; private set; }
@@ -50,7 +51,7 @@ namespace Proteomics.ProteolyticDigestion
                 && this.SemiProteaseDigestion.Equals(a.SemiProteaseDigestion)
                 && this.TerminusTypeSemiProtease.Equals(a.TerminusTypeSemiProtease);
         }
-
+        
         public override int GetHashCode()
         {
             return
@@ -58,6 +59,31 @@ namespace Proteomics.ProteolyticDigestion
                 ^ InitiatorMethionineBehavior.GetHashCode()
                 ^ MaxModificationIsoforms.GetHashCode()
                 ^ MaxModsForPeptide.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return MaxMissedCleavages + "," + InitiatorMethionineBehavior + "," + MinPeptideLength + "," + MaxPeptideLength + "," 
+                + MaxModificationIsoforms + "," + MaxModsForPeptide + "," + Protease.Name + "," + SemiProteaseDigestion + ","
+                + TerminusTypeSemiProtease;
+        }
+
+        /// <summary>
+        /// Creates a DigestionParams object from string. Used after deserializing a PeptideWithSetModifications
+        /// </summary>
+        public static DigestionParams FromString(string str)
+        {
+            string[] split = str.Split(',');
+            return new DigestionParams(
+                protease: split[6], 
+                maxMissedCleavages: int.Parse(split[0]), 
+                minPeptideLength: int.Parse(split[2]), 
+                maxPeptideLength: int.Parse(split[3]), 
+                maxModificationIsoforms: int.Parse(split[4]), 
+                initiatorMethionineBehavior: (InitiatorMethionineBehavior)Enum.Parse(typeof(InitiatorMethionineBehavior), split[1]),
+                maxModsForPeptides: int.Parse(split[5]), 
+                semiProteaseDigestion: bool.Parse(split[7]),
+                terminusTypeSemiProtease: (FragmentationTerminus)Enum.Parse(typeof(FragmentationTerminus), split[8]));
         }
     }
 }

--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -348,11 +348,11 @@ namespace Proteomics.ProteolyticDigestion
         /// <summary>
         /// This should be run after deserialization of a PeptideWithSetModifications, in order to set its Protein and Modification objects, which were not serialized
         /// </summary>
-        public static void SetNonSerializedPeptideInfo(Dictionary<string, Modification> idToMod, Dictionary<string, Protein> accessionToProtein, PeptideWithSetModifications peptide)
+        public void SetNonSerializedPeptideInfo(Dictionary<string, Modification> idToMod, Dictionary<string, Protein> accessionToProtein)
         {
-            peptide.GetModsAfterDeserialization(idToMod, out string baseSequence);
-            peptide.GetProteinAfterDeserialization(accessionToProtein);
-            peptide.GetDigestionParamsAfterDeserialization();
+            GetModsAfterDeserialization(idToMod, out string baseSequence);
+            GetProteinAfterDeserialization(accessionToProtein);
+            GetDigestionParamsAfterDeserialization();
         }
 
         private void GetDigestionParamsAfterDeserialization()

--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -9,57 +9,47 @@ using System.Text;
 
 namespace Proteomics.ProteolyticDigestion
 {
+    [Serializable]
     public class PeptideWithSetModifications : ProteolyticPeptide
     {
-        /// <summary>
-        /// dictionary of modifications on a peptide the N terminus is index 1
-        /// key indicates which residue modification is on (with 1 being N terminus)
-        /// </summary>
-        public readonly Dictionary<int, Modification> AllModsOneIsNterminus; //we currently only allow one mod per position
-
-        public readonly DigestionParams DigestionParams;
+        [NonSerialized] public readonly DigestionParams DigestionParams;
+        public string Sequence { get; private set; }
         public readonly int NumFixedMods;
 
+        /// <summary>
+        /// Dictionary of modifications on the peptide. The N terminus is index 1.
+        /// The key indicates which residue modification is on (with 1 being N terminus).
+        /// </summary>
+        [NonSerialized] private Dictionary<int, Modification> _allModsOneIsNterminus; //we currently only allow one mod per position
+        [NonSerialized] private bool? HasChemicalFormulas;
+        [NonSerialized] private string _sequenceWithChemicalFormulas;
+        [NonSerialized] private double? _monoisotopicMass;
+        [NonSerialized] private Dictionary<FragmentationTerminus, CompactPeptide> _compactPeptides;
+        private readonly string ProteinAccession; // used to get protein object after deserialization
         private static readonly double WaterMonoisotopicMass = PeriodicTable.GetElement("H").PrincipalIsotope.AtomicMass * 2 + PeriodicTable.GetElement("O").PrincipalIsotope.AtomicMass;
-        private bool? HasChemicalFormulas;
-        private readonly Dictionary<FragmentationTerminus, CompactPeptide> _compactPeptides = new Dictionary<FragmentationTerminus, CompactPeptide>();
-        private string _sequence;
-        private string _sequenceWithChemicalFormulas;
-        private double? _monoisotopicMass;
 
-        public PeptideWithSetModifications(PeptideWithSetModifications modsFromThisOne, int proteinOneBasedStart, int proteinOneBasedEnd)
-            : base(modsFromThisOne.Protein, proteinOneBasedStart, proteinOneBasedEnd, proteinOneBasedEnd - proteinOneBasedStart,
-            modsFromThisOne.PeptideDescription)
-        {
-            AllModsOneIsNterminus = modsFromThisOne.AllModsOneIsNterminus
-                .Where(b => b.Key > (1 + proteinOneBasedStart - modsFromThisOne.OneBasedStartResidueInProtein)
-                    && b.Key <= (2 + proteinOneBasedEnd - modsFromThisOne.OneBasedStartResidueInProtein))
-                .ToDictionary(b => (b.Key + modsFromThisOne.OneBasedStartResidueInProtein - proteinOneBasedStart), b => b.Value);
-        }
-
-        public PeptideWithSetModifications(int numFixedMods, Protein protein, int proteinOneBasedStart, int proteinOneBasedEnd,
-            Dictionary<int, Modification> allModsOneIsNterminus = null, int missedCleavages = 0)
-            : base(protein, proteinOneBasedStart, proteinOneBasedEnd, missedCleavages, null)
-        {
-            NumFixedMods = numFixedMods;
-            AllModsOneIsNterminus = allModsOneIsNterminus ?? new Dictionary<int, Modification>();
-        }
-
+        
+        
+        /// <summary>
+        /// Creates a PeptideWithSetModifications object from a protein. Used when a Protein is digested.
+        /// </summary>
         public PeptideWithSetModifications(Protein protein, DigestionParams digestionParams, int oneBasedStartResidueInProtein,
             int oneBasedEndResidueInProtein, string peptideDescription, int missedCleavages,
            Dictionary<int, Modification> allModsOneIsNterminus, int numFixedMods)
            : base(protein, oneBasedStartResidueInProtein, oneBasedEndResidueInProtein, missedCleavages, peptideDescription)
         {
-            AllModsOneIsNterminus = allModsOneIsNterminus;
+            _allModsOneIsNterminus = allModsOneIsNterminus;
             NumFixedMods = numFixedMods;
             DigestionParams = digestionParams;
+            DetermineFullSequence();
+            this.ProteinAccession = protein.Accession;
         }
 
         /// <summary>
         /// Creates a PeptideWithSetModifications object from a sequence string.
         /// Useful for reading in MetaMorpheus search engine output into mzLib objects
         /// </summary>
-        public PeptideWithSetModifications(string sequence, IEnumerable<Modification> allKnownModifications, int numFixedMods = 0,
+        public PeptideWithSetModifications(string sequence, Dictionary<string, Modification> allKnownMods, int numFixedMods = 0,
             DigestionParams digestionParams = null, Protein p = null, int oneBasedStartResidueInProtein = int.MinValue,
             int oneBasedEndResidueInProtein = int.MinValue, int missedCleavages = int.MinValue, string peptideDescription = null)
             : base(p, oneBasedStartResidueInProtein, oneBasedEndResidueInProtein, missedCleavages, peptideDescription)
@@ -69,65 +59,20 @@ namespace Proteomics.ProteolyticDigestion
                 throw new MzLibUtil.MzLibException("Ambiguous peptide cannot be parsed from string: " + sequence);
             }
 
-            AllModsOneIsNterminus = new Dictionary<int, Modification>();
-            StringBuilder baseSequence = new StringBuilder();
-            StringBuilder currentModification = new StringBuilder();
-            int currentModificationLocation = 1;
-            bool currentlyReadingMod = false;
-
-            for (int r = 0; r < sequence.Length; r++)
-            {
-                char c = sequence[r];
-
-                switch (c)
-                {
-                    case '[':
-                        currentlyReadingMod = true;
-                        break;
-
-                    case ']':
-
-                        Modification mod = null;
-
-                        try
-                        {
-                            var split = currentModification.ToString().Split(new char[] { ':' });
-                            string modType = split[0];
-                            string id = split[1];
-                            mod = allKnownModifications.Where(m => m.Id == id && m.ModificationType == modType).FirstOrDefault();
-                        }
-                        catch (Exception e)
-                        {
-                            throw new MzLibUtil.MzLibException("Error while trying to parse string into peptide: " + e.Message);
-                        }
-
-                        if (mod == null)
-                        {
-                            throw new MzLibUtil.MzLibException("Could not find modification while reading string: " + sequence);
-                        }
-
-                        AllModsOneIsNterminus.Add(currentModificationLocation, mod);
-                        currentlyReadingMod = false;
-                        currentModification = new StringBuilder();
-                        break;
-
-                    default:
-                        if (currentlyReadingMod)
-                        {
-                            currentModification.Append(c);
-                        }
-                        else
-                        {
-                            currentModificationLocation++;
-                            baseSequence.Append(c);
-                        }
-                        break;
-                }
-            }
-
-            _baseSequence = baseSequence.ToString();
+            Sequence = sequence;
+            GetModsAfterDeserialization(allKnownMods, out _baseSequence);
             NumFixedMods = numFixedMods;
             DigestionParams = digestionParams;
+
+            if (p != null)
+            {
+                ProteinAccession = p.Accession;
+            }
+        }
+
+        public Dictionary<int, Modification> AllModsOneIsNterminus
+        {
+            get { return _allModsOneIsNterminus; }
         }
 
         public double MonoisotopicMass
@@ -144,42 +89,6 @@ namespace Proteomics.ProteolyticDigestion
                     _monoisotopicMass += BaseSequence.Select(b => Residue.ResidueMonoisotopicMass[b]).Sum();
                 }
                 return (double)ClassExtensions.RoundedDouble(_monoisotopicMass.Value);
-            }
-        }
-
-        public virtual string Sequence
-        {
-            get
-            {
-                if (_sequence == null)
-                {
-                    var subsequence = new StringBuilder();
-
-                    // variable modification on peptide N-terminus
-                    if (AllModsOneIsNterminus.TryGetValue(1, out Modification pep_n_term_variable_mod))
-                    {
-                        subsequence.Append('[' + pep_n_term_variable_mod.ModificationType + ":" + pep_n_term_variable_mod.Id + ']');
-                    }
-
-                    for (int r = 0; r < Length; r++)
-                    {
-                        subsequence.Append(this[r]);
-                        // variable modification on this residue
-                        if (AllModsOneIsNterminus.TryGetValue(r + 2, out Modification residue_variable_mod))
-                        {
-                            subsequence.Append('[' + residue_variable_mod.ModificationType + ":" + residue_variable_mod.Id + ']');
-                        }
-                    }
-
-                    // variable modification on peptide C-terminus
-                    if (AllModsOneIsNterminus.TryGetValue(Length + 2, out Modification pep_c_term_variable_mod))
-                    {
-                        subsequence.Append('[' + pep_c_term_variable_mod.ModificationType + ":" + pep_c_term_variable_mod.Id + ']');
-                    }
-
-                    _sequence = subsequence.ToString();
-                }
-                return _sequence;
             }
         }
 
@@ -366,6 +275,10 @@ namespace Proteomics.ProteolyticDigestion
 
         public CompactPeptide CompactPeptide(FragmentationTerminus fragmentationTerminus)
         {
+            if (_compactPeptides == null)
+            {
+                _compactPeptides = new Dictionary<FragmentationTerminus, CompactPeptide>();
+            }
             if (_compactPeptides.TryGetValue(fragmentationTerminus, out CompactPeptide compactPeptide))
             {
                 return compactPeptide;
@@ -380,18 +293,20 @@ namespace Proteomics.ProteolyticDigestion
 
         public PeptideWithSetModifications Localize(int j, double massToLocalize)
         {
-            var vvv = new Dictionary<int, Modification>(AllModsOneIsNterminus);
+            var dictWithLocalizedMass = new Dictionary<int, Modification>(AllModsOneIsNterminus);
             double massOfExistingMod = 0;
-            if (vvv.TryGetValue(j + 2, out Modification modToReplace))
+            if (dictWithLocalizedMass.TryGetValue(j + 2, out Modification modToReplace))
             {
                 massOfExistingMod = (double)modToReplace.MonoisotopicMass;
-                vvv.Remove(j + 2);
+                dictWithLocalizedMass.Remove(j + 2);
             }
 
-            vvv.Add(j + 2, new Modification(_locationRestriction: "Anywhere.", _monoisotopicMass: massToLocalize + massOfExistingMod));
-            var hm = new PeptideWithSetModifications(NumFixedMods, Protein, OneBasedStartResidueInProtein, OneBasedEndResidueInProtein, vvv, MissedCleavages);
+            dictWithLocalizedMass.Add(j + 2, new Modification(_locationRestriction: "Anywhere.", _monoisotopicMass: massToLocalize + massOfExistingMod));
 
-            return hm;
+            var peptideWithLocalizedMass = new PeptideWithSetModifications(Protein, DigestionParams, OneBasedStartResidueInProtein, OneBasedEndResidueInProtein,
+                PeptideDescription, MissedCleavages, dictWithLocalizedMass, NumFixedMods);
+
+            return peptideWithLocalizedMass;
         }
 
         public override string ToString()
@@ -402,6 +317,12 @@ namespace Proteomics.ProteolyticDigestion
         public override bool Equals(object obj)
         {
             var q = obj as PeptideWithSetModifications;
+
+            if (Protein == null && q.Protein == null)
+            {
+                return q.Sequence.Equals(Sequence);
+            }
+
             return q != null
                 && q.Sequence.Equals(Sequence)
                 && q.OneBasedStartResidueInProtein == OneBasedStartResidueInProtein
@@ -411,6 +332,116 @@ namespace Proteomics.ProteolyticDigestion
         public override int GetHashCode()
         {
             return Sequence.GetHashCode();
+        }
+
+        /// <summary>
+        /// This should be run after deserialization of a PeptideWithSetModifications, in order to set its Protein and Modification objects, which were not serialized
+        /// </summary>
+        public static void SetNonSerializedPeptideInfo(Dictionary<string, Modification> idToMod, Dictionary<string, Protein> accessionToProtein, PeptideWithSetModifications peptide)
+        {
+            peptide.GetModsAfterDeserialization(idToMod, out string baseSequence);
+            peptide.GetProteinAfterDeserialization(accessionToProtein);
+        }
+
+        private void GetModsAfterDeserialization(Dictionary<string, Modification> idToMod, out string baseSequence)
+        {
+            _allModsOneIsNterminus = new Dictionary<int, Modification>();
+            StringBuilder baseSequenceSb = new StringBuilder();
+            StringBuilder currentModification = new StringBuilder();
+            int currentModificationLocation = 1;
+            bool currentlyReadingMod = false;
+
+            for (int r = 0; r < Sequence.Length; r++)
+            {
+                char c = Sequence[r];
+
+                switch (c)
+                {
+                    case '[':
+                        currentlyReadingMod = true;
+                        break;
+
+                    case ']':
+                        string modId = null;
+
+                        try
+                        {
+                            var split = currentModification.ToString().Split(new char[] { ':' });
+                            string modType = split[0];
+                            modId = split[1];
+                        }
+                        catch (Exception e)
+                        {
+                            throw new MzLibUtil.MzLibException("Error while trying to parse string into peptide: " + e.Message);
+                        }
+
+                        if (!idToMod.TryGetValue(modId, out Modification mod))
+                        {
+                            throw new MzLibUtil.MzLibException("Could not find modification while reading string: " + Sequence);
+                        }
+
+                        AllModsOneIsNterminus.Add(currentModificationLocation, mod);
+                        currentlyReadingMod = false;
+                        currentModification = new StringBuilder();
+                        break;
+
+                    default:
+                        if (currentlyReadingMod)
+                        {
+                            currentModification.Append(c);
+                        }
+                        else
+                        {
+                            currentModificationLocation++;
+                            baseSequenceSb.Append(c);
+                        }
+                        break;
+                }
+            }
+
+            baseSequence = baseSequenceSb.ToString();
+        }
+
+        private void GetProteinAfterDeserialization(Dictionary<string, Protein> idToProtein)
+        {
+            Protein protein = null;
+
+            if (ProteinAccession != null && !idToProtein.TryGetValue(ProteinAccession, out protein))
+            {
+                throw new MzLibUtil.MzLibException("Could not find protein accession after deserialization! " + ProteinAccession);
+            }
+
+            Protein = protein;
+        }
+
+        private void DetermineFullSequence()
+        {
+            var subsequence = new StringBuilder();
+
+            // modification on peptide N-terminus
+            if (AllModsOneIsNterminus.TryGetValue(1, out Modification mod))
+            {
+                subsequence.Append('[' + mod.ModificationType + ":" + mod.Id + ']');
+            }
+
+            for (int r = 0; r < Length; r++)
+            {
+                subsequence.Append(this[r]);
+
+                // modification on this residue
+                if (AllModsOneIsNterminus.TryGetValue(r + 2, out mod))
+                {
+                    subsequence.Append('[' + mod.ModificationType + ":" + mod.Id + ']');
+                }
+            }
+
+            // modification on peptide C-terminus
+            if (AllModsOneIsNterminus.TryGetValue(Length + 2, out mod))
+            {
+                subsequence.Append('[' + mod.ModificationType + ":" + mod.Id + ']');
+            }
+
+            Sequence = subsequence.ToString();
         }
     }
 }

--- a/Proteomics/ProteolyticDigestion/ProteolyticPeptide.cs
+++ b/Proteomics/ProteolyticDigestion/ProteolyticPeptide.cs
@@ -8,25 +8,26 @@ namespace Proteomics.ProteolyticDigestion
     /// Product of digesting a protein
     /// Contains methods for modified peptide combinitorics
     /// </summary>
+    [Serializable]
     public class ProteolyticPeptide
     {
         protected string _baseSequence;
 
         internal ProteolyticPeptide(Protein protein, int oneBasedStartResidueInProtein, int oneBasedEndResidueInProtein, int missedCleavages, string peptideDescription = null)
         {
-            Protein = protein;
+            _protein = protein;
             OneBasedStartResidueInProtein = oneBasedStartResidueInProtein;
             OneBasedEndResidueInProtein = oneBasedEndResidueInProtein;
             MissedCleavages = missedCleavages;
             PeptideDescription = peptideDescription;
         }
 
-        public Protein Protein { get; }// protein from which this peptide came
-        public int OneBasedStartResidueInProtein { get; }// if the first residue in a protein is 1 this is the number of the residue at which the peptide begins
-        public int OneBasedEndResidueInProtein { get; }// if the first residue in a protien is 1 this is the number of the residue at which the peptide ends
-        public int MissedCleavages { get; set; }// the number of missed cleavages this peptide has considerign what protease was supposed to generate it?
+        [NonSerialized] private Protein _protein; // protein that this peptide is a digestion product of
+        public int OneBasedStartResidueInProtein { get; } // the residue number at which the peptide begins (the first residue in a protein is 1)
+        public int OneBasedEndResidueInProtein { get; } // the residue number at which the peptide ends
+        public int MissedCleavages { get; } // the number of missed cleavages this peptide has with respect to the digesting protease
         public string PeptideDescription { get; }
-        public int Length { get { return BaseSequence.Length; } }//how many residues llong the peptide is (calculated from oneBased Starts and End Residues)
+        public int Length { get { return BaseSequence.Length; } } //how many residues long the peptide is
 
         public virtual char PreviousAminoAcid
         {
@@ -42,6 +43,12 @@ namespace Proteomics.ProteolyticDigestion
             {
                 return OneBasedEndResidueInProtein < Protein.Length ? Protein[OneBasedEndResidueInProtein] : '-';
             }
+        }
+
+        public Protein Protein
+        {
+            get { return _protein; }
+            protected set { _protein = value; }
         }
 
         public string BaseSequence

--- a/Test/MyPeptideTest.cs
+++ b/Test/MyPeptideTest.cs
@@ -240,7 +240,7 @@ namespace Test
             string sequence = "HQVC[Common Fixed:Carbamidomethyl of C]TPGGTTIAGLC[Common Fixed:Carbamidomethyl of C]VMEEK";
 
             // parse the peptide from the string
-            PeptideWithSetModifications peptide = new PeptideWithSetModifications(sequence, new List<Modification>() { carbamidomethylOfC });
+            PeptideWithSetModifications peptide = new PeptideWithSetModifications(sequence, new Dictionary<string, Modification> { { carbamidomethylOfC.Id, carbamidomethylOfC } });
 
             // test base sequence and full sequence
             Assert.That(peptide.BaseSequence == "HQVCTPGGTTIAGLCVMEEK");

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -33,6 +33,9 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="NetSerializer, Version=4.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetSerializer.4.1.0\lib\net45\NetSerializer.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>

--- a/Test/TestModifications.cs
+++ b/Test/TestModifications.cs
@@ -466,7 +466,7 @@ namespace Test
                 deserializedPeptide = (PeptideWithSetModifications)ser.Deserialize(file);
             }
 
-            PeptideWithSetModifications.SetNonSerializedPeptideInfo(new Dictionary<string, Modification>(), new Dictionary<string, Protein>(), deserializedPeptide);
+            deserializedPeptide.SetNonSerializedPeptideInfo(new Dictionary<string, Modification>(), new Dictionary<string, Protein>());
             
             // not asserting any protein properties - since the peptide was created from a sequence string it didn't have a protein to begin with
 
@@ -509,8 +509,7 @@ namespace Test
                 deserializedPeptide = (PeptideWithSetModifications)ser.Deserialize(file);
             }
 
-            PeptideWithSetModifications.SetNonSerializedPeptideInfo(
-                new Dictionary<string, Modification>(), new Dictionary<string, Protein> { { protein.Accession, protein } }, deserializedPeptide);
+            deserializedPeptide.SetNonSerializedPeptideInfo(new Dictionary<string, Modification>(), new Dictionary<string, Protein> { { protein.Accession, protein } });
 
             Assert.That(peptide.DigestionParams.Equals(deserializedPeptide.DigestionParams));
             Assert.That(peptide.Equals(deserializedPeptide));
@@ -568,8 +567,7 @@ namespace Test
 
             Dictionary<string, Modification> stringToMod = new Dictionary<string, Modification> { { mods.Values.First().First().Id, mods.Values.First().First() } };
 
-            PeptideWithSetModifications.SetNonSerializedPeptideInfo(
-                stringToMod, new Dictionary<string, Protein> { { protein.Accession, protein } }, deserializedPeptide);
+            deserializedPeptide.SetNonSerializedPeptideInfo(stringToMod, new Dictionary<string, Protein> { { protein.Accession, protein } });
             
             Assert.That(peptide.Equals(deserializedPeptide));
             Assert.That(deserializedPeptide.Protein.Name == peptide.Protein.Name);

--- a/Test/TestModifications.cs
+++ b/Test/TestModifications.cs
@@ -511,7 +511,8 @@ namespace Test
 
             PeptideWithSetModifications.SetNonSerializedPeptideInfo(
                 new Dictionary<string, Modification>(), new Dictionary<string, Protein> { { protein.Accession, protein } }, deserializedPeptide);
-            
+
+            Assert.That(peptide.DigestionParams.Equals(deserializedPeptide.DigestionParams));
             Assert.That(peptide.Equals(deserializedPeptide));
             Assert.That(deserializedPeptide.Protein.Name == peptide.Protein.Name);
             Assert.That(deserializedPeptide.MonoisotopicMass == peptide.MonoisotopicMass);

--- a/Test/packages.config
+++ b/Test/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="NetSerializer" version="4.1.0" targetFramework="net471" />
   <package id="NUnit" version="3.10.1" targetFramework="net471" />
   <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
I did a rough performance benchmark to test serializing PepWithSetMods (PWSM) vs. CompactPeptide. The benchmark was to digest a yeast fasta with no fixed/variable mods, make a HashSet of the respective objects (PWSM or CompactPeptide), serialize it, and deserialize it.

![capture](https://user-images.githubusercontent.com/24705713/43927642-db8f7474-9bf3-11e8-8b5c-24a137a1ef57.PNG)

We added a bunch of stuff to CompactPeptide annotation-wise, and now it's pretty slow and takes up a lot of space to serialize, though it's still serializable if we need it to be for some reason.

PWSM file size is much smaller. Not sure why RAM is higher. It's about the same speed. We can work on making it more efficient - but PWSM is much easier to work with, and we can skip the whole "matching compact peptides to PWSM" bit in MetaMorpheus, so that will be faster.

4 new unit tests check to make sure properties are the same before+after serialization. 

You do need to run a method, SetNonSerializedPeptideInfo(), after deserializing to get the mods, Protein, and DigestionParams objects back since these are not serialized.