### PR TITLE
Filter the same way for XML modifications and PTM lists; also return the errors and filtered modifications in an `out` variable

### DIFF
--- a/Test/DatabaseTests/DatabaseLoaderTests.cs
+++ b/Test/DatabaseTests/DatabaseLoaderTests.cs
@@ -33,7 +33,7 @@ namespace Test
         [Test]
         public static void LoadModWithNl()
         {
-            var hah = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "cfInNL.txt")).First() as Modification;
+            var hah = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "cfInNL.txt"), out var errors).First() as Modification;
             int count = 0;
             foreach (KeyValuePair<MassSpectrometry.DissociationType, List<double>> item in hah.NeutralLosses)
             {
@@ -153,7 +153,7 @@ namespace Test
                 }
             }
 
-            var sampleModList = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "test.txt")).ToList();
+            var sampleModList = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "test.txt"), out var errors).ToList();
 
             Assert.AreEqual(2973, sampleModList.Count());
             string s = "";
@@ -195,27 +195,27 @@ namespace Test
         [Test]
         public void SampleModFileLoading()
         {
-            PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFile.txt"));
+            PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFile.txt"), out var errors);
         }
 
         [Test]
         public void SampleModFileLoadingFail1()
         {
-            var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail1.txt"));
+            var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail1.txt"), out var errors);
             Assert.AreEqual(0,b.Count());
         }
 
         [Test]
         public void SampleModFileLoadingFail2()
         {
-            var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail2.txt"));
+            var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail2.txt"), out var errors);
             Assert.AreEqual(0, b.Count());
         }
 
         [Test]
         public void SampleModFileLoadingFail3()
         {
-            Assert.That(() => PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail3.txt")).ToList(),
+            Assert.That(() => PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail3.txt"), out var errors).ToList(),
                                             Throws.TypeOf<MzLibException>()
                                             .With.Property("Message")
                                             .EqualTo("Input string for chemical formula was in an incorrect format: $%&$%"));
@@ -224,7 +224,7 @@ namespace Test
         [Test]
         public void SampleModFileLoadingFail4()
         {
-            Assert.That(() => PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "m.txt")).ToList(),
+            Assert.That(() => PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "m.txt"), out var errors).ToList(),
                                             Throws.TypeOf<MzLibException>()
                                             .With.Property("Message")
                                             .EqualTo("0 or 238.229666 is not a valid monoisotopic mass"));
@@ -233,34 +233,34 @@ namespace Test
         [Test]
         public void SampleModFileLoadingFail5()
         {
-            var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail5.txt"));
+            var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail5.txt"), out var errors);
             Assert.AreEqual(0, b.Count());
         }
 
         [Test]
         public void SampleModFileLoadingFail6()
         {
-            var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail5.txt"));
+            var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail5.txt"), out var errors);
             Assert.AreEqual(0,b.Count());
         }
 
         [Test]
         public void CompactFormReading()
         {
-            Assert.AreEqual(2, PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileDouble.txt")).Count());
+            Assert.AreEqual(2, PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileDouble.txt"), out var errors).Count());
         }
 
         [Test]
         public void CompactFormReading2()
         {
-            Assert.AreEqual(2, PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileDouble2.txt")).Count());
+            Assert.AreEqual(2, PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileDouble2.txt"), out var errors).Count());
         }
 
         [Test]
         public void Modification_read_write_into_proteinDb()
         {
             Loaders.LoadElements(Path.Combine(TestContext.CurrentContext.TestDirectory, "elements2.dat"));
-            var sampleModList = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "z.txt")).ToList();
+            var sampleModList = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "z.txt"), out var errors).ToList();
             Assert.AreEqual(1, sampleModList.OfType<Modification>().Count());
             Protein protein = new Protein("MCSSSSSSSSSS", "accession", "organism", new List<Tuple<string, string>>(), new Dictionary<int, List<Modification>> { { 2, sampleModList.OfType<Modification>().ToList() } }, null, "name", "full_name", false, false, new List<DatabaseReference>(), new List<SequenceVariation>(), new List<DisulfideBond>());
             Assert.AreEqual(1, protein.OneBasedPossibleLocalizedModifications[2].OfType<Modification>().Count());
@@ -319,7 +319,7 @@ namespace Test
         public void DoNotWriteSameModTwiceAndDoNotWriteInHeaderSinceDifferent()
         {
             Loaders.LoadElements(Path.Combine(TestContext.CurrentContext.TestDirectory, "elements2.dat"));
-            var sampleModList = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "z.txt")).ToList();
+            var sampleModList = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "z.txt"), out var errors).ToList();
             Protein protein = new Protein("MCSSSSSSSSSS", "accession", "organism", new List<Tuple<string, string>>(), new Dictionary<int, List<Modification>> { { 2, sampleModList.OfType<Modification>().ToList() } }, null, "name", "full_name", false, false, new List<DatabaseReference>(), new List<SequenceVariation>(), new List<DisulfideBond>());
             Assert.AreEqual(1, protein.OneBasedPossibleLocalizedModifications[2].OfType<Modification>().Count());
 

--- a/Test/DatabaseTests/TestProteinReader.cs
+++ b/Test/DatabaseTests/TestProteinReader.cs
@@ -393,7 +393,7 @@ KW   Oxidation.
 DR   RESID; AA0581.
 DR   PSI-MOD; MOD:00720.
 //";
-            var a = PtmListLoader.ReadModsFromString(aString).First();
+            var a = PtmListLoader.ReadModsFromString(aString, out var errorsA).First();
 
             string bString =
 @"ID   Oxidation of M
@@ -402,7 +402,7 @@ PP   Anywhere.
 MT   Common Variable
 CF   O1
 //";
-            var b = PtmListLoader.ReadModsFromString(bString).First();
+            var b = PtmListLoader.ReadModsFromString(bString, out var errorsB).First();
 
             Assert.IsTrue(Math.Abs((double)(a as Modification).MonoisotopicMass - (double)(b as Modification).MonoisotopicMass) < 1e-6);
             Assert.IsTrue(Math.Abs((double)(a as Modification).MonoisotopicMass - (double)(b as Modification).MonoisotopicMass) > 1e-7);

--- a/Test/DatabaseTests/TestProteomicsReadWrite.cs
+++ b/Test/DatabaseTests/TestProteomicsReadWrite.cs
@@ -430,7 +430,7 @@ namespace Test
         [Test]
         public void TestModificationGeneralToString()
         {
-            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", "CommonBiological.txt")).ToList();
+            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", "CommonBiological.txt"), out var errors).ToList();
             char[] myChar = { '"' };
             string output = a.First().ToString();
             Assert.AreEqual(output.TrimStart(myChar).TrimEnd(myChar), "ID   4-carboxyglutamate on E\r\nMT   Biological\r\nTG   E\r\nPP   Anywhere.\r\nCF   CO2\r\nMM   43.989829\r\n");
@@ -439,8 +439,8 @@ namespace Test
         [Test]
         public void TestModificationGeneral_Equals()
         {
-            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", "CommonBiological.txt")).ToList();
-            var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", "CommonBiological.txt")).ToList();
+            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", "CommonBiological.txt"), out var errors).ToList();
+            var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", "CommonBiological.txt"), out errors).ToList();
 
             Assert.IsTrue(a.First().Equals(b.First()));
         }

--- a/Test/TestModifications.cs
+++ b/Test/TestModifications.cs
@@ -334,11 +334,11 @@ namespace Test
         {
             // Now we'll check the mass of modified peptide with 2 neutral loss mods
             ModificationMotif.TryGetMotif("Q", out ModificationMotif motifone);
-            Modification modone = new Modification(_originalId: "ammonia", _modificationType: "testModType", _target: motifone, _monoisotopicMass: 0, _neutralLosses: new Dictionary<DissociationType, 
+            Modification modone = new Modification(_originalId: "ammonia", _modificationType: "testModType", _target: motifone, _monoisotopicMass: 0, _neutralLosses: new Dictionary<DissociationType,
                 List<double>> { { DissociationType.HCD, new List<double> { ChemicalFormula.ParseFormula("H3 N1").MonoisotopicMass } } }, _locationRestriction: "Anywhere.");
 
             ModificationMotif.TryGetMotif("T", out ModificationMotif motiftwo);
-            Modification modtwo = new Modification(_originalId: "phospho", _modificationType: "testModType", _target: motiftwo, _chemicalFormula: ChemicalFormula.ParseFormula("H1 O3 P1"), _neutralLosses: new Dictionary<DissociationType, 
+            Modification modtwo = new Modification(_originalId: "phospho", _modificationType: "testModType", _target: motiftwo, _chemicalFormula: ChemicalFormula.ParseFormula("H1 O3 P1"), _neutralLosses: new Dictionary<DissociationType,
                 List<double>> { { DissociationType.HCD, new List<double> { ChemicalFormula.ParseFormula("H3 O4 P1").MonoisotopicMass } } }, _locationRestriction: "Anywhere.");
 
             List<Modification> modlistone = new List<Modification> { modone };
@@ -360,7 +360,7 @@ namespace Test
             HashSet<int> expectedMasses = new HashSet<int> { 98, 227, 355, 536, 649, 764, 438, 551, 666, 338, 519, 632, 747, // b-ions with and without neutral losses
                                                              148, 263, 376, 557, 685, 814, 668, 797, 459, 587, 716, //y ions with and without neutral losses
                                                                813, 894, }; //molecular ion with neutral losses (phospho and ammonia respectively)
-            
+
             Assert.That(neutralMasses.SetEquals(expectedMasses));
         }
 
@@ -406,7 +406,7 @@ namespace Test
             148, 263, 376, 540, 637, 766, 557, 654, 783,          // y and y-17 ions
             133, 248, 361, 525, 622, 751, 542, 639, 768,         // z+1 and z+1-17 ions
             863 };//Molecular ions minus ammonia
-            
+
             Assert.That(expectedMassesHCD.SetEquals(neutralMassesHCD));
         }
 
@@ -455,19 +455,19 @@ namespace Test
 
             var messageTypes = typeof(PeptideWithSetModifications);
             var ser = new NetSerializer.Serializer(new List<Type> { messageTypes });
-            
+
             using (var file = System.IO.File.Create(path))
             {
                 ser.Serialize(file, peptide);
             }
-            
+
             using (var file = System.IO.File.OpenRead(path))
             {
                 deserializedPeptide = (PeptideWithSetModifications)ser.Deserialize(file);
             }
 
             deserializedPeptide.SetNonSerializedPeptideInfo(new Dictionary<string, Modification>(), new Dictionary<string, Protein>());
-            
+
             // not asserting any protein properties - since the peptide was created from a sequence string it didn't have a protein to begin with
 
             Assert.That(peptide.Equals(deserializedPeptide));
@@ -498,7 +498,7 @@ namespace Test
 
             var messageTypes = typeof(PeptideWithSetModifications);
             var ser = new NetSerializer.Serializer(new List<Type> { messageTypes });
-            
+
             using (var file = System.IO.File.Create(path))
             {
                 ser.Serialize(file, peptide);
@@ -540,7 +540,7 @@ namespace Test
             };
 
             Modification mod = new Modification(_originalId: "phospho", _modificationType: "testModType", _target: motif, _chemicalFormula: ChemicalFormula.ParseFormula("H1 O3 P1"), _neutralLosses: myNeutralLosses, _locationRestriction: "Anywhere.");
-            
+
             Dictionary<int, List<Modification>> mods = new Dictionary<int, List<Modification>> { { 4, new List<Modification> { mod } } };
 
             Protein protein = new Protein("PEPTIDE", "Accession1", name: "MyProtein", oneBasedModifications: mods);
@@ -568,7 +568,7 @@ namespace Test
             Dictionary<string, Modification> stringToMod = new Dictionary<string, Modification> { { mods.Values.First().First().IdWithMotif, mods.Values.First().First() } };
 
             deserializedPeptide.SetNonSerializedPeptideInfo(stringToMod, new Dictionary<string, Protein> { { protein.Accession, protein } });
-            
+
             Assert.That(peptide.Equals(deserializedPeptide));
             Assert.That(deserializedPeptide.Protein.Name == peptide.Protein.Name);
             Assert.That(deserializedPeptide.MonoisotopicMass == peptide.MonoisotopicMass);

--- a/Test/TestModifications.cs
+++ b/Test/TestModifications.cs
@@ -59,7 +59,7 @@ namespace Test
             var mod1 = new Modification(_originalId: "mod of M", _modificationType: "type", _target: motif, _locationRestriction: "Anywhere.", _chemicalFormula: ChemicalFormula.ParseFormula("H"), _monoisotopicMass: ChemicalFormula.ParseFormula("H").MonoisotopicMass);
             var mod1string = mod1.ToString();
             Assert.IsTrue(mod1string.Contains("MM"));
-            var modAfterWriteRead = PtmListLoader.ReadModsFromString(mod1string + Environment.NewLine + "//").First() as Modification;
+            var modAfterWriteRead = PtmListLoader.ReadModsFromString(mod1string + Environment.NewLine + "//", out var errors).First() as Modification;
 
             Assert.IsTrue(modAfterWriteRead.Equals(mod1));
         }

--- a/Test/TestPtmListLoader.cs
+++ b/Test/TestPtmListLoader.cs
@@ -1,5 +1,6 @@
 ﻿using MzLibUtil;
 using NUnit.Framework;
+using Proteomics;
 using System.IO;
 using System.Linq;
 using UsefulProteomicsDatabases;
@@ -10,36 +11,33 @@ namespace Test
     public sealed class TestPtmListLoader
     {
         [Test]
-        public static void Test_ReadAllModsFromFile()
+        public static void SampleModFileLoading()
         {
-            string testModificationsFileLocation = Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", @"CommonArtifacts.txt");
-            var a = PtmListLoader.ReadModsFromFile(testModificationsFileLocation);
-            Assert.AreEqual(33, a.Select(m => m.IdWithMotif).ToList().Count);
-
-            testModificationsFileLocation = Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", @"CommonBiological.txt");
-            var b = PtmListLoader.ReadModsFromFile(testModificationsFileLocation);
-            Assert.AreEqual(35, b.Select(m => m.IdWithMotif).ToList().Count);
+            PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFile.txt"), out var errors);
         }
 
         [Test]
-        public static void Test_ModsFromFileAreSorted()
+        [TestCase("CommonArtifacts.txt", 33)]
+        [TestCase("CommonBiological.txt", 35)]
+        public static void Test_ReadAllModsFromFile(string filename, int modCount)
         {
-            string testModificationsFileLocation = Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", @"CommonArtifacts.txt");
-            var a = PtmListLoader.ReadModsFromFile(testModificationsFileLocation);
+            string testModificationsFileLocation = Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", filename);
+            var a = PtmListLoader.ReadModsFromFile(testModificationsFileLocation, out var errors);
+            Assert.AreEqual(modCount, a.Count());
+        }
 
-            string id1 = a.First().IdWithMotif.ToString();
+        [Test]
+        [TestCase("CommonArtifacts.txt")]
+        [TestCase("CommonBiological.txt")]
+        public static void Test_ModsFromFileAreSorted(string filename)
+        {
+            string testModificationsFileLocation = Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", filename);
+            var a = PtmListLoader.ReadModsFromFile(testModificationsFileLocation, out var errors);
+
+            string id1 = a.First().IdWithMotif;
             foreach (string modId in a.Select(m => m.IdWithMotif))
             {
                 Assert.GreaterOrEqual(modId, id1);
-            }
-
-            testModificationsFileLocation = Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", @"CommonBiological.txt");
-            var b = PtmListLoader.ReadModsFromFile(testModificationsFileLocation);
-
-            string id2 = b.First().IdWithMotif.ToString();
-            foreach (string modId in b.Select(m => m.IdWithMotif))
-            {
-                Assert.GreaterOrEqual(modId, id2);
             }
         }
 
@@ -47,15 +45,15 @@ namespace Test
         public static void Test_ModsWithComments()
         {
             string testModificationsFileLocation = Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", @"ModsWithComments.txt");
-            var a = PtmListLoader.ReadModsFromFile(testModificationsFileLocation).ToList();
+            var a = PtmListLoader.ReadModsFromFile(testModificationsFileLocation, out var errors).ToList();
             Assert.AreEqual(4, a.Select(m => m.IdWithMotif).ToList().Count);
 
             Assert.AreEqual("Deamidation on N", a[0].IdWithMotif.ToString());
             Assert.AreEqual("Sodium on D", a[2].IdWithMotif.ToString());//this has trailing whitespace that shouldn't be in the name
 
             //Make sure comments are okay on DR key and that key value pairs are still split correctly
-            var someMod = a[2];
-            var test = (Proteomics.Modification)someMod;
+            Modification someMod = a[2];
+            Modification test = someMod;
             var residValueTest = test.DatabaseReference.First().Value.First();
             var residKeyTest = test.DatabaseReference.First().Key;
             Assert.AreEqual("RESID", residKeyTest);
@@ -63,128 +61,42 @@ namespace Test
         }
 
         [Test]
-        public static void Test_ReadAllModsFromFileGeneral()
+        [TestCase("sampleModFileFail1.txt")] // TG is not valid
+        [TestCase("sampleModFileFail2.txt")]
+        [TestCase("sampleModFileFail5.txt")] // ID is missing
+        [TestCase("sampleModFileFail6.txt")] // modification type is missing
+        [TestCase("sampleModFileFail_missingPosition.txt")] // missing position
+        [TestCase("sampleModFileFail_missingChemicalFormulaAndMonoisotopicMass.txt")]
+        public static void SampleModFileLoadingFail1General(string filename) 
         {
-            string testModificationsFileLocation = Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", @"CommonArtifacts.txt");
-            var a = PtmListLoader.ReadModsFromFile(testModificationsFileLocation);
-            Assert.AreEqual(33, a.Select(m => m.IdWithMotif).ToList().Count);
-
-            testModificationsFileLocation = Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", @"CommonBiological.txt");
-            var b = PtmListLoader.ReadModsFromFile(testModificationsFileLocation);
-            Assert.AreEqual(35, b.Select(m => m.IdWithMotif).ToList().Count);
-        }
-
-        [Test]
-        public static void Test_ModsWithCommentsGeneral()
-        {
-            string testModificationsFileLocation = Path.Combine(TestContext.CurrentContext.TestDirectory, "ModificationTests", @"ModsWithComments.txt");
-            var a = PtmListLoader.ReadModsFromFile(testModificationsFileLocation).ToList();
-            Assert.AreEqual(4, a.Select(m => m.IdWithMotif).ToList().Count);
-
-            Assert.AreEqual("Deamidation on N", a[0].IdWithMotif.ToString());
-            Assert.AreEqual("Sodium on D", a[2].IdWithMotif.ToString());//this has trailing whitespace that shouldn't be in the name
-
-            //Make sure comments are okay on DR key and that key value pairs are still split correctly
-            var someMod = a[2];
-            var test = (Proteomics.Modification)someMod;
-            var residValueTest = test.DatabaseReference.First().Value.First();
-            var residKeyTest = test.DatabaseReference.First().Key;
-            Assert.AreEqual("RESID", residKeyTest);
-            Assert.AreEqual("AA0441", residValueTest);
-        }
-
-        [Test]
-        public static void SampleModFileLoadingGeneral()
-        {
-            PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFile.txt"));
-        }
-
-        [Test]
-        public static void SampleModFileLoadingFail1General() //TG is not valide
-        {
-            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail1.txt")).ToList();
-            Assert.AreEqual(0, a.Count());
-        }
-
-        [Test]
-        public static void SampleModFileLoadingFail2General()
-        {
-            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail2.txt")).ToList();
-            Assert.AreEqual(0, a.Count()); ;
+            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", filename), out var errors).ToList();
+            Assert.AreEqual(0, a.Count);
         }
 
         [Test]
         public static void PTMListLoader_ModWithComments_Equals_ModWithoutComments()
         {
-            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "SampleMod_Comments.txt")).ToList();
-            var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "SampleMod_NoComments.txt")).ToList();
+            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "SampleMod_Comments.txt"), out var errors).ToList();
+            var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "SampleMod_NoComments.txt"), out var errors2).ToList();
             Assert.IsTrue(a.First().Equals(b.First()));
         }
 
         [Test]
-        public static void PTMListLoaderGeneral_ModWithComments_Equals_ModWithoutComments()
+        [TestCase("sampleModFileFail3.txt", "Input string for chemical formula was in an incorrect format: $%&$%")]
+        [TestCase("m.txt",                  "0 or 238.229666 is not a valid monoisotopic mass")]
+        public static void SampleModFileLoadingFail3General(string filename, string errorMessage)
         {
-            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "SampleMod_Comments.txt")).ToList();
-            var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "SampleMod_NoComments.txt")).ToList();
-            Assert.IsTrue(a.First().Equals(b.First()));
+            Assert.That(() => 
+                PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", filename), out var errors).ToList(),
+                Throws.TypeOf<MzLibException>().With.Property("Message").EqualTo(errorMessage));
         }
 
         [Test]
-        public static void SampleModFileLoadingFail3General()
+        [TestCase("sampleModFileDouble.txt")]
+        [TestCase("sampleModFileDouble2.txt")]
+        public static void CompactFormReadingGeneral(string filename)
         {
-            Assert.That(() => PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail3.txt")).ToList(),
-                                            Throws.TypeOf<MzLibException>()
-                                            .With.Property("Message")
-                                            .EqualTo("Input string for chemical formula was in an incorrect format: $%&$%"));
-        }
-
-        [Test]
-        public static void SampleModFileLoadingFail4General()
-        {
-            Assert.That(() => PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "m.txt")).ToList(),
-                                            Throws.TypeOf<MzLibException>()
-                                            .With.Property("Message")
-                                            .EqualTo("0 or 238.229666 is not a valid monoisotopic mass"));
-        }
-
-        [Test]
-        public static void SampleModFileLoadingFail5General()
-        {
-            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail5.txt")).ToList();
-            Assert.AreEqual(0, a.Count()); // ID is missing
-        }
-
-        [Test]
-        public static void SampleModFileLoadingFail6General()
-        {
-            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail6.txt")).ToList();
-            Assert.AreEqual(0, a.Count()); // modification type is missing
-        }
-
-        [Test]
-        public static void SampleModFileLoadingFail5General_missingPosition()
-        {
-            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail_missingPosition.txt")).ToList();
-            Assert.AreEqual(0, a.Count()); // ID is missing
-        }
-
-        [Test]
-        public static void SampleModFileLoadingFail5General_missingMonoisotopicMassAndChemicalFormula()
-        {
-            var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail_missingChemicalFormulaAndMonoisotopicMass.txt")).ToList();
-            Assert.AreEqual(0, a.Count()); // ID is missing
-        }
-
-        [Test]
-        public static void CompactFormReadingGeneral()
-        {
-            Assert.AreEqual(2, PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileDouble.txt")).Count());
-        }
-
-        [Test]
-        public static void CompactFormReading2General()
-        {
-            Assert.AreEqual(2, PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileDouble2.txt")).Count());
+            Assert.AreEqual(2, PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", filename), out var errors).Count());
         }
 
         [Test]
@@ -195,10 +107,9 @@ namespace Test
             string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "detacher.txt");
             File.WriteAllLines(path, new string[] { modText });
             
-            var mods = PtmListLoader.ReadModsFromFile(path).ToList();
+            var mods = PtmListLoader.ReadModsFromFile(path, out var errors).ToList();
             var motifs = mods.Select(p => p.Target.ToString()).Distinct().ToList();
             var ids = mods.Select(p => p.IdWithMotif).Distinct().ToList();
-
 
             Assert.That(mods.Count == 6);
             Assert.That(motifs.Count == 6);

--- a/Test/TestPtmListLoader.cs
+++ b/Test/TestPtmListLoader.cs
@@ -67,7 +67,7 @@ namespace Test
         [TestCase("sampleModFileFail6.txt")] // modification type is missing
         [TestCase("sampleModFileFail_missingPosition.txt")] // missing position
         [TestCase("sampleModFileFail_missingChemicalFormulaAndMonoisotopicMass.txt")]
-        public static void SampleModFileLoadingFail1General(string filename) 
+        public static void SampleModFileLoadingFail1General(string filename)
         {
             var a = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", filename), out var errors).ToList();
             Assert.AreEqual(0, a.Count);
@@ -83,10 +83,10 @@ namespace Test
 
         [Test]
         [TestCase("sampleModFileFail3.txt", "Input string for chemical formula was in an incorrect format: $%&$%")]
-        [TestCase("m.txt",                  "0 or 238.229666 is not a valid monoisotopic mass")]
+        [TestCase("m.txt", "0 or 238.229666 is not a valid monoisotopic mass")]
         public static void SampleModFileLoadingFail3General(string filename, string errorMessage)
         {
-            Assert.That(() => 
+            Assert.That(() =>
                 PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", filename), out var errors).ToList(),
                 Throws.TypeOf<MzLibException>().With.Property("Message").EqualTo(errorMessage));
         }
@@ -106,7 +106,7 @@ namespace Test
 
             string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "detacher.txt");
             File.WriteAllLines(path, new string[] { modText });
-            
+
             var mods = PtmListLoader.ReadModsFromFile(path, out var errors).ToList();
             var motifs = mods.Select(p => p.Target.ToString()).Distinct().ToList();
             var ids = mods.Select(p => p.IdWithMotif).Distinct().ToList();

--- a/UsefulProteomicsDatabases/Loaders.cs
+++ b/UsefulProteomicsDatabases/Loaders.cs
@@ -167,7 +167,7 @@ namespace UsefulProteomicsDatabases
             {
                 UpdateUniprot(uniprotLocation);
             }
-            return PtmListLoader.ReadModsFromFile(uniprotLocation, formalChargesDictionary).OfType<Modification>();
+            return PtmListLoader.ReadModsFromFile(uniprotLocation, formalChargesDictionary, out var errors).OfType<Modification>();
         }
 
         private static bool FilesAreEqual_Hash(string first, string second)

--- a/UsefulProteomicsDatabases/ProteinDbLoader.cs
+++ b/UsefulProteomicsDatabases/ProteinDbLoader.cs
@@ -133,7 +133,7 @@ namespace UsefulProteomicsDatabases
                                     //This block of code does not process information in any of the entries.
                                     protein_xml_modlist_general = storedKnownModificationsBuilder.Length <= 0 ?
                                         new List<Modification>() :
-                                        PtmListLoader.ReadModsFromString(storedKnownModificationsBuilder.ToString()).ToList();
+                                        PtmListLoader.ReadModsFromString(storedKnownModificationsBuilder.ToString(), out var errors).ToList();
                                     break;
                                 }
                             }

--- a/UsefulProteomicsDatabases/PtmListLoader.cs
+++ b/UsefulProteomicsDatabases/PtmListLoader.cs
@@ -106,7 +106,11 @@ namespace UsefulProteomicsDatabases
                     {
                         foreach (var mod in ReadMod(null, modification_specification, new Dictionary<string, int>()))
                         {
-                            yield return mod;
+                            // Filter out the modifications that don't meet validation
+                            if (mod.ValidModification)
+                            {
+                                yield return mod;
+                            }
                         }
                         modification_specification = new List<string>();
                     }

--- a/UsefulProteomicsDatabases/PtmListLoader.cs
+++ b/UsefulProteomicsDatabases/PtmListLoader.cs
@@ -50,9 +50,9 @@ namespace UsefulProteomicsDatabases
         /// </summary>
         /// <param name="ptmListLocation"></param>
         /// <returns></returns>
-        public static IEnumerable<Modification> ReadModsFromFile(string ptmListLocation)
+        public static IEnumerable<Modification> ReadModsFromFile(string ptmListLocation, out List<(Modification, string)> filteredModificationsWithWarnings)
         {
-            return ReadModsFromFile(ptmListLocation, new Dictionary<string, int>()).OrderBy(b => b.IdWithMotif);
+            return ReadModsFromFile(ptmListLocation, new Dictionary<string, int>(), out filteredModificationsWithWarnings).OrderBy(b => b.IdWithMotif);
         }
 
         /// <summary>
@@ -60,8 +60,10 @@ namespace UsefulProteomicsDatabases
         /// </summary>
         /// <param name="ptmListLocation"></param>
         /// <returns></returns>
-        public static IEnumerable<Modification> ReadModsFromFile(string ptmListLocation, Dictionary<string, int> formalChargesDictionary)
+        public static IEnumerable<Modification> ReadModsFromFile(string ptmListLocation, Dictionary<string, int> formalChargesDictionary, out List<(Modification, string)> filteredModificationsWithWarnings)
         {
+            List<Modification> acceptedModifications = new List<Modification>();
+            filteredModificationsWithWarnings = new List<(Modification filteredMod, string warningString)>();
             using (StreamReader uniprot_mods = new StreamReader(ptmListLocation))
             {
                 List<string> modification_specification = new List<string>();
@@ -78,13 +80,18 @@ namespace UsefulProteomicsDatabases
                             // Filter out the modifications that don't meet validation
                             if (mod.ValidModification)
                             {
-                                yield return mod;
+                                acceptedModifications.Add(mod);
+                            }
+                            else
+                            {
+                                filteredModificationsWithWarnings.Add((mod, mod.ModificationErrorsToString()));
                             }
                         }
                         modification_specification = new List<string>();
                     }
                 }
             }
+            return acceptedModifications;
         }
 
         /// <summary>
@@ -92,8 +99,10 @@ namespace UsefulProteomicsDatabases
         /// </summary>
         /// <param name="storedModifications"></param>
         /// <returns></returns>
-        public static IEnumerable<Modification> ReadModsFromString(string storedModifications)
+        public static IEnumerable<Modification> ReadModsFromString(string storedModifications, out List<(Modification, string)> filteredModificationsWithWarnings)
         {
+            List<Modification> acceptedModifications = new List<Modification>();
+            filteredModificationsWithWarnings = new List<(Modification filteredMod, string warningString)>();
             using (StringReader uniprot_mods = new StringReader(storedModifications))
             {
                 List<string> modification_specification = new List<string>();
@@ -109,13 +118,18 @@ namespace UsefulProteomicsDatabases
                             // Filter out the modifications that don't meet validation
                             if (mod.ValidModification)
                             {
-                                yield return mod;
+                                acceptedModifications.Add(mod);
+                            }
+                            else
+                            {
+                                filteredModificationsWithWarnings.Add((mod, mod.ModificationErrorsToString()));
                             }
                         }
                         modification_specification = new List<string>();
                     }
                 }
             }
+            return acceptedModifications;
         }
 
         /// <summary>


### PR DESCRIPTION
currently, xml-listed modifications aren't validated... expectations of ptmlists should be the same