### PR TITLE
peptide RAM improvements

### DIFF
--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -24,7 +24,6 @@ namespace Proteomics.ProteolyticDigestion
         [NonSerialized] private bool? _hasChemicalFormulas;
         [NonSerialized] private string _sequenceWithChemicalFormulas;
         [NonSerialized] private double? _monoisotopicMass;
-        [NonSerialized] private Dictionary<FragmentationTerminus, CompactPeptide> _compactPeptides;
         [NonSerialized] private DigestionParams _digestionParams;
         private static readonly double WaterMonoisotopicMass = PeriodicTable.GetElement("H").PrincipalIsotope.AtomicMass * 2 + PeriodicTable.GetElement("O").PrincipalIsotope.AtomicMass;
         private readonly string DigestionParamString; // used to get digestion param object after deserialization
@@ -207,7 +206,7 @@ namespace Proteomics.ProteolyticDigestion
                 // we're separating the N and C terminal masses and computing a separate compact peptide for each one
                 // this speeds calculations up without producing unnecessary terminus fragment info
                 FragmentationTerminus temporaryFragmentationTerminus = TerminusSpecificProductTypes.ProductTypeToFragmentationTerminus[productType];
-                NeutralTerminusFragment[] terminalMasses = CompactPeptide(temporaryFragmentationTerminus).TerminalMasses;
+                NeutralTerminusFragment[] terminalMasses = new CompactPeptide(this, temporaryFragmentationTerminus).TerminalMasses;
 
                 for (int f = 0; f < terminalMasses.Length; f++)
                 {
@@ -318,33 +317,7 @@ namespace Proteomics.ProteolyticDigestion
                 yield return (ProductType.zPlusOne, BaseSequence.Length - i);
             }
         }
-
-        public CompactPeptide CompactPeptide(FragmentationTerminus fragmentationTerminus)
-        {
-            // need this for deserialization
-            if (_compactPeptides == null)
-            {
-                _compactPeptides = new Dictionary<FragmentationTerminus, CompactPeptide>();
-            }
-
-            if (_compactPeptides.TryGetValue(fragmentationTerminus, out CompactPeptide compactPeptide))
-            {
-                return compactPeptide;
-            }
-
-            CompactPeptide cp = new CompactPeptide(this, fragmentationTerminus);
-
-            lock (_compactPeptides)
-            {
-                if (!_compactPeptides.ContainsKey(fragmentationTerminus))
-                {
-                    _compactPeptides.Add(fragmentationTerminus, cp);
-                }
-            }
-
-            return cp;
-        }
-
+        
         public PeptideWithSetModifications Localize(int j, double massToLocalize)
         {
             var dictWithLocalizedMass = new Dictionary<int, Modification>(AllModsOneIsNterminus);

--- a/Test/TestMetaMorpheus.cs
+++ b/Test/TestMetaMorpheus.cs
@@ -20,7 +20,7 @@ namespace Test
             DigestionParams digestionParams = new DigestionParams(minPeptideLength: 2);
             var aPeptideWithSetModifications = p.Digest(digestionParams, new List<Modification>(), new List<Modification>()).First();
 
-            var aCompactPeptide = aPeptideWithSetModifications.CompactPeptide(FragmentationTerminus.Both);
+            var aCompactPeptide = new CompactPeptide(aPeptideWithSetModifications, FragmentationTerminus.Both);
             
             //evaluate N-terminal masses
             var nTerminalMasses = aCompactPeptide.TerminalMasses.Where(v => v.Terminus == FragmentationTerminus.N);
@@ -42,7 +42,7 @@ namespace Test
             DigestionParams digestionParams = new DigestionParams(minPeptideLength: 2);
             var aPeptideWithSetModifications = p.Digest(digestionParams, new List<Modification> { phosphorylation }, new List<Modification>()).First();
 
-            var aCompactPeptide = aPeptideWithSetModifications.CompactPeptide(FragmentationTerminus.Both);
+            var aCompactPeptide = new CompactPeptide(aPeptideWithSetModifications, FragmentationTerminus.Both);
             
             //evaluate N-terminal masses
             var nTerminalMasses = aCompactPeptide.TerminalMasses.Where(v => v.Terminus == FragmentationTerminus.N);
@@ -64,7 +64,7 @@ namespace Test
             DigestionParams digestionParams = new DigestionParams(minPeptideLength: 2);
             var aPeptideWithSetModifications = p.Digest(digestionParams, new List<Modification> { phosphorylation }, new List<Modification>()).First();
 
-            var aCompactPeptide = aPeptideWithSetModifications.CompactPeptide(FragmentationTerminus.Both);
+            var aCompactPeptide = new CompactPeptide(aPeptideWithSetModifications, FragmentationTerminus.Both);
             
             //evaluate N-terminal masses
             var nTerminalMasses = aCompactPeptide.TerminalMasses.Where(v => v.Terminus == FragmentationTerminus.N);
@@ -86,7 +86,7 @@ namespace Test
             DigestionParams digestionParams = new DigestionParams(minPeptideLength: 2);
             var aPeptideWithSetModifications = p.Digest(digestionParams, new List<Modification> { phosphorylation }, new List<Modification>()).First();
 
-            var aCompactPeptide = aPeptideWithSetModifications.CompactPeptide(FragmentationTerminus.Both);
+            var aCompactPeptide = new CompactPeptide(aPeptideWithSetModifications, FragmentationTerminus.Both);
 
             //evaluate N-terminal masses
             var nTerminalMasses = aCompactPeptide.TerminalMasses.Where(v => v.Terminus == FragmentationTerminus.N);
@@ -112,7 +112,7 @@ namespace Test
             DigestionParams digestionParams = new DigestionParams(minPeptideLength: 2);
             var aPeptideWithSetModifications = p.Digest(digestionParams, new List<Modification> { phosphorylation }, new List<Modification>()).First();
 
-            var aCompactPeptide = aPeptideWithSetModifications.CompactPeptide(FragmentationTerminus.Both);
+            var aCompactPeptide = new CompactPeptide(aPeptideWithSetModifications, FragmentationTerminus.Both);
 
             //evaluate N-terminal masses
             var nTerminalMasses = aCompactPeptide.TerminalMasses.Where(v => v.Terminus == FragmentationTerminus.N);
@@ -134,7 +134,7 @@ namespace Test
             DigestionParams digestionParams = new DigestionParams(minPeptideLength: 2);
             var aPeptideWithSetModifications = p.Digest(digestionParams, new List<Modification> { phosphorylation }, new List<Modification>()).First();
 
-            var aCompactPeptide = aPeptideWithSetModifications.CompactPeptide(FragmentationTerminus.Both);
+            var aCompactPeptide = new CompactPeptide(aPeptideWithSetModifications, FragmentationTerminus.Both);
 
             //var nTerminalMasses = aCompactPeptide.TerminalMasses.Where(v => v.Terminus == FragmentationTerminus.N);
             var nTerminalMasses = aCompactPeptide.TerminalMasses.Where(v => v.Terminus == FragmentationTerminus.N);
@@ -159,9 +159,7 @@ namespace Test
             Modification phosphorylation = new Modification(_originalId: "phospho", _modificationType: "CommonBiological", _target: motif, _locationRestriction: "Anywhere.", _chemicalFormula: ChemicalFormula.ParseFormula("H1O3P1"), _neutralLosses: new Dictionary<DissociationType, List<double>> { { MassSpectrometry.DissociationType.HCD, new List<double> { 0, ChemicalFormula.ParseFormula("H3O4P1").MonoisotopicMass } } });
             DigestionParams digestionParams = new DigestionParams(minPeptideLength: 2);
             var aPeptideWithSetModifications = p.Digest(digestionParams, new List<Modification> { phosphorylation }, new List<Modification>()).First();
-
-            var aCompactPeptide = aPeptideWithSetModifications.CompactPeptide(FragmentationTerminus.Both);
-
+            
             var allFragmentNeutralMasses = aPeptideWithSetModifications.Fragment(DissociationType.HCD, FragmentationTerminus.Both);
             
             //evaluate N-terminal masses
@@ -184,7 +182,7 @@ namespace Test
             DigestionParams digestionParams = new DigestionParams(minPeptideLength: 2);
             var aPeptideWithSetModifications = p.Digest(digestionParams, new List<Modification> { phosphorylation }, new List<Modification>()).First();
 
-            var aCompactPeptide = aPeptideWithSetModifications.CompactPeptide(FragmentationTerminus.Both);
+            var aCompactPeptide = new CompactPeptide(aPeptideWithSetModifications, FragmentationTerminus.Both);
 
             //evaluate N-terminal masses
             var nTerminalMasses = aCompactPeptide.TerminalMasses.Where(v => v.Terminus == FragmentationTerminus.N);
@@ -206,7 +204,7 @@ namespace Test
             DigestionParams digestionParams = new DigestionParams(minPeptideLength: 2);
             var aPeptideWithSetModifications = p.Digest(digestionParams, new List<Modification> { phosphorylation }, new List<Modification>()).First();
 
-            var aCompactPeptide = aPeptideWithSetModifications.CompactPeptide(FragmentationTerminus.Both);
+            var aCompactPeptide = new CompactPeptide(aPeptideWithSetModifications, FragmentationTerminus.Both);
 
             //evaluate N-terminal masses
             var nTerminalMasses = aCompactPeptide.TerminalMasses.Where(v => v.Terminus == FragmentationTerminus.N);

--- a/Test/TestModifications.cs
+++ b/Test/TestModifications.cs
@@ -449,7 +449,7 @@ namespace Test
             // has the same properties as before it was serialized. This peptide is unmodified
             string sequence = "PEPTIDE";
             PeptideWithSetModifications p = new PeptideWithSetModifications(sequence, new Dictionary<string, Modification>(), 0, null, null, 0, 7, 0, null);
-            CompactPeptide cp = p.CompactPeptide(FragmentationTerminus.Both);
+            CompactPeptide cp = new CompactPeptide(p, FragmentationTerminus.Both);
             CompactPeptide deserializedCp = null;
 
             string dir = System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory, "TestCompactPeptideSerialization");


### PR DESCRIPTION
noticed some RAM issues in MetaMorpheus. I wrote a quick benchmark unit test that digested a yeast DB and stored each peptide.

before the changes in this PR: 58 sec, 6 GB RAM used
after changes: 45s, 980 MB 