### PR TITLE
Allow modifications on sequence variations

### DIFF
--- a/Proteomics/Protein/Protein.cs
+++ b/Proteomics/Protein/Protein.cs
@@ -74,7 +74,7 @@ namespace Proteomics
         public string Name { get; }
         public string FullName { get; }
         public bool IsContaminant { get; }
-        private IDictionary<int, List<Modification>> OriginalModifications { get; set; }
+        internal IDictionary<int, List<Modification>> OriginalModifications { get; set; }
 
         public char this[int zeroBasedIndex]
         {

--- a/Proteomics/Protein/Protein.cs
+++ b/Proteomics/Protein/Protein.cs
@@ -48,6 +48,7 @@ namespace Proteomics
         /// The list of gene names consists of tuples, where Item1 is the type of gene name, and Item2 is the name. There may be many genes and names of a certain type produced when reading an XML protein database.
         /// </summary>
         public IEnumerable<Tuple<string, string>> GeneNames { get; }
+
         public string Accession { get; }
         public string BaseSequence { get; }
         public string Organism { get; }
@@ -57,6 +58,7 @@ namespace Proteomics
         public IEnumerable<ProteolysisProduct> ProteolysisProducts { get; }
         public IEnumerable<DatabaseReference> DatabaseReferences { get; }
         public string DatabaseFilePath { get; }
+
         public int Length
         {
             get
@@ -64,6 +66,7 @@ namespace Proteomics
                 return BaseSequence.Length;
             }
         }
+
         public string FullDescription
         {
             get
@@ -71,6 +74,7 @@ namespace Proteomics
                 return Accession + "|" + Name + "|" + FullName;
             }
         }
+
         public string Name { get; }
         public string FullName { get; }
         public bool IsContaminant { get; }

--- a/Proteomics/Protein/ProteinWithAppliedVariants.cs
+++ b/Proteomics/Protein/ProteinWithAppliedVariants.cs
@@ -118,8 +118,8 @@ namespace Proteomics
         }
 
         /// <summary>
-        /// Eliminates proteolysis products that overlap sequence variations. 
-        /// Since frameshift indels are written across the remaining sequence, 
+        /// Eliminates proteolysis products that overlap sequence variations.
+        /// Since frameshift indels are written across the remaining sequence,
         /// this eliminates proteolysis products that conflict with large deletions and other structural variations.
         /// </summary>
         /// <param name="variants"></param>

--- a/Proteomics/Protein/ProteinWithAppliedVariants.cs
+++ b/Proteomics/Protein/ProteinWithAppliedVariants.cs
@@ -93,7 +93,7 @@ namespace Proteomics
                         string seqBefore = BaseSequence.Substring(0, variant.OneBasedBeginPosition - 1);
                         string seqVariant = variant.VariantSequence;
                         List<ProteolysisProduct> adjustedProteolysisProducts = AdjustProteolysisProductIndices(variant, ProteolysisProducts);
-                        Dictionary<int, List<Modification>> adjustedModifications = AdjustModificationIndices(variant, OneBasedPossibleLocalizedModifications);
+                        Dictionary<int, List<Modification>> adjustedModifications = AdjustModificationIndices(variant, Protein.OriginalModifications);
                         int afterIdx = variant.OneBasedBeginPosition + variant.OriginalSequence.Length - 1;
                         if (intersectsAppliedRegionIncompletely)
                         {

--- a/Proteomics/Protein/SequenceVariation.cs
+++ b/Proteomics/Protein/SequenceVariation.cs
@@ -1,33 +1,38 @@
-﻿namespace Proteomics
+﻿using System.Collections.Generic;
+
+namespace Proteomics
 {
     public class SequenceVariation
     {
         /// <summary>
         /// For longer sequence variations, where a range of sequence is replaced. Point mutations should be specified with the same begin and end positions.
         /// </summary>
-        /// <param name="OneBasedBeginPosition"></param>
-        /// <param name="OneBasedEndPosition"></param>
-        /// <param name="OriginalSequence"></param>
-        /// <param name="VariantSequence"></param>
-        public SequenceVariation(int OneBasedBeginPosition, int OneBasedEndPosition, string OriginalSequence, string VariantSequence, string Description)
+        /// <param name="oneBasedBeginPosition"></param>
+        /// <param name="oneBasedEndPosition"></param>
+        /// <param name="originalSequence"></param>
+        /// <param name="variantSequence"></param>
+        /// <param name="oneBasedModifications"></param>
+        public SequenceVariation(int oneBasedBeginPosition, int oneBasedEndPosition, string originalSequence, string variantSequence, string description, Dictionary<int, List<Modification>> oneBasedModifications = null)
         {
-            this.OneBasedBeginPosition = OneBasedBeginPosition;
-            this.OneBasedEndPosition = OneBasedEndPosition;
-            this.OriginalSequence = OriginalSequence ?? "";
-            this.VariantSequence = VariantSequence ?? "";
-            this.Description = Description ?? "";
+            OneBasedBeginPosition = oneBasedBeginPosition;
+            OneBasedEndPosition = oneBasedEndPosition;
+            OriginalSequence = originalSequence ?? "";
+            VariantSequence = variantSequence ?? "";
+            Description = description ?? "";
+            OneBasedModifications = oneBasedModifications ?? new Dictionary<int, List<Modification>>();
         }
 
         /// <summary>
         /// For variations with only position information (not begin and end).
         /// Sets the end to the end of the original protein sequence to which this variation applies.
         /// </summary>
-        /// <param name="OneBasedPosition"></param>
-        /// <param name="OriginalSequence"></param>
-        /// <param name="VariantSequence"></param>
-        /// <param name="Description"></param>
-        public SequenceVariation(int OneBasedPosition, string OriginalSequence, string VariantSequence, string Description)
-            : this(OneBasedPosition, OneBasedPosition + OriginalSequence.Length - 1, OriginalSequence, VariantSequence, Description)
+        /// <param name="oneBasedPosition"></param>
+        /// <param name="originalSequence"></param>
+        /// <param name="variantSequence"></param>
+        /// <param name="description"></param>
+        /// <param name="oneBasedModifications"></param>
+        public SequenceVariation(int oneBasedPosition, string originalSequence, string variantSequence, string description, Dictionary<int, List<Modification>> oneBasedModifications = null)
+            : this(oneBasedPosition, oneBasedPosition + originalSequence.Length - 1, originalSequence, variantSequence, description, oneBasedModifications)
         { }
 
         /// <summary>
@@ -54,6 +59,11 @@
         /// Description of this variation (optional)
         /// </summary>
         public string Description { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public Dictionary<int, List<Modification>> OneBasedModifications { get; }
 
         public override bool Equals(object obj)
         {

--- a/Proteomics/Protein/SequenceVariation.cs
+++ b/Proteomics/Protein/SequenceVariation.cs
@@ -61,7 +61,7 @@ namespace Proteomics
         public string Description { get; }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public Dictionary<int, List<Modification>> OneBasedModifications { get; }
 

--- a/Test/DatabaseTests/DatabaseLoaderTests.cs
+++ b/Test/DatabaseTests/DatabaseLoaderTests.cs
@@ -48,6 +48,17 @@ namespace Test
         }
 
         [Test]
+        public static void LoadOriginalMismatchedModifications()
+        {
+            var protein = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "oblm.xml"), true,
+                DecoyType.Reverse, null, false, null, out var unknownModifications);
+            Assert.AreEqual(0, protein[0].OneBasedPossibleLocalizedModifications.Count);
+            var variant = protein[0].GetVariantProteins()[0];
+            protein[0].RestoreUnfilteredModifications();
+            Assert.AreEqual(1, protein[0].OneBasedPossibleLocalizedModifications.Count);
+        }
+
+        [Test]
         public void TestUpdateUnimod()
         {
             var unimodLocation = Path.Combine(TestContext.CurrentContext.TestDirectory, "unimod_tables.xml");

--- a/Test/DatabaseTests/DatabaseLoaderTests.cs
+++ b/Test/DatabaseTests/DatabaseLoaderTests.cs
@@ -138,7 +138,7 @@ namespace Test
 
             Assert.AreEqual(2, neutralLossCount);
             var psiModDeserialized = Loaders.LoadPsiMod(Path.Combine(TestContext.CurrentContext.TestDirectory, "PSI-MOD.obo2.xml"));
-            
+
             // N6,N6,N6-trimethyllysine
             var trimethylLysine = psiModDeserialized.Items.OfType<UsefulProteomicsDatabases.Generated.oboTerm>().First(b => b.id.Equals("MOD:00083"));
             Assert.AreEqual("1+", trimethylLysine.xref_analog.First(b => b.dbname.Equals("FormalCharge")).name);
@@ -177,7 +177,7 @@ namespace Test
                     myOtherList.Add(mod);
                 }
             }
-            
+
             var thisMod = myOtherList.First();
             Assert.IsTrue(thisMod.MonoisotopicMass > 42);
             Assert.IsTrue(thisMod.MonoisotopicMass < 43);
@@ -195,7 +195,7 @@ namespace Test
 
             Assert.That(testMod.ValidModification);
             Assert.That(testMod.Target.ToString().Equals("msgRgk"));
-            
+
             Protein protein = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "modified_start.xml"), true, DecoyType.None, allKnownMods, false, new List<string>(), out var unk).First();
 
             Assert.That(protein.BaseSequence.StartsWith("MSGRGK"));
@@ -213,7 +213,7 @@ namespace Test
         public void SampleModFileLoadingFail1()
         {
             var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail1.txt"), out var errors);
-            Assert.AreEqual(0,b.Count());
+            Assert.AreEqual(0, b.Count());
         }
 
         [Test]
@@ -252,7 +252,7 @@ namespace Test
         public void SampleModFileLoadingFail6()
         {
             var b = PtmListLoader.ReadModsFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "sampleModFileFail5.txt"), out var errors);
-            Assert.AreEqual(0,b.Count());
+            Assert.AreEqual(0, b.Count());
         }
 
         [Test]
@@ -412,6 +412,7 @@ namespace Test
             new_proteins = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, filename), true, DecoyType.None, new List<Modification>(), false, new List<string>(), out um);
             Assert.That(new_proteins.First().OneBasedPossibleLocalizedModifications.First().Value.First().DiagnosticIons.First().Value.Count == 2);
         }
+
         [Test]
         public void TestWritePtmWithNeutralLossAndDiagnosticIons()
         {

--- a/Test/DatabaseTests/TestVariantProtein.cs
+++ b/Test/DatabaseTests/TestVariantProtein.cs
@@ -1,11 +1,10 @@
 ﻿using NUnit.Framework;
 using Proteomics;
-using System.Collections.Generic;
-using System.Linq;
-using System.IO;
-using UsefulProteomicsDatabases;
-using System;
 using Proteomics.ProteolyticDigestion;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UsefulProteomicsDatabases;
 
 namespace Test
 {
@@ -31,7 +30,6 @@ namespace Test
 
             List<PeptideWithSetModifications> peptides = variantProteins.SelectMany(vp => vp.Digest(new DigestionParams(), null, null)).ToList();
         }
-
 
         [Test]
         public static void LoadSeqVarModifications()

--- a/Test/DatabaseTests/TestVariantProtein.cs
+++ b/Test/DatabaseTests/TestVariantProtein.cs
@@ -32,6 +32,28 @@ namespace Test
             List<PeptideWithSetModifications> peptides = variantProteins.SelectMany(vp => vp.Digest(new DigestionParams(), null, null)).ToList();
         }
 
+
+        [Test]
+        public static void LoadSeqVarModifications()
+        {
+            var proteins = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "oblm2.xml"), true,
+                DecoyType.None, null, false, null, out var unknownModifications);
+            Assert.AreEqual(0, proteins[0].OneBasedPossibleLocalizedModifications.Count);
+            Assert.AreEqual(1, proteins[0].SequenceVariations.Count());
+            Assert.AreEqual(1, proteins[0].SequenceVariations.First().OneBasedModifications.Count);
+            var variant = proteins[0].GetVariantProteins()[0];
+            Assert.AreEqual(1, variant.OneBasedPossibleLocalizedModifications.Count);
+
+            ProteinDbWriter.WriteXmlDatabase(null, proteins, Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "oblm2rewrite.xml"));
+            proteins = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "oblm2rewrite.xml"), true,
+                DecoyType.None, null, false, null, out unknownModifications);
+            Assert.AreEqual(0, proteins[0].OneBasedPossibleLocalizedModifications.Count);
+            Assert.AreEqual(1, proteins[0].SequenceVariations.Count());
+            Assert.AreEqual(1, proteins[0].SequenceVariations.First().OneBasedModifications.Count);
+            variant = proteins[0].GetVariantProteins()[0];
+            Assert.AreEqual(1, variant.OneBasedPossibleLocalizedModifications.Count);
+        }
+
         [Test]
         public void VariantLongDeletionXml()
         {

--- a/Test/DatabaseTests/oblm.xml
+++ b/Test/DatabaseTests/oblm.xml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<mzLibProteinDb>
+  <modification>ID   acetyl on K
+MT   type
+TG   K
+PP   Anywhere.
+MM   42
+
+//</modification>
+  <entry>
+    <accession>accession1</accession>
+    <gene />
+    <feature type="modified residue" description="acetyl on K">
+      <location>
+        <position position="3" />
+      </location>
+    </feature>
+    <feature type="sequence variant" description="1\t50000000\t.\tA\tG\t.\tPASS\tANN=\tGT:AD:DP\t1/1:30,30:30">
+      <original>P</original>
+      <variation>K</variation>
+      <location>
+        <position position="3" />
+      </location>
+    </feature>
+    <sequence length="6">PEPTID</sequence>
+  </entry>
+</mzLibProteinDb>

--- a/Test/DatabaseTests/oblm2.xml
+++ b/Test/DatabaseTests/oblm2.xml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<mzLibProteinDb>
+  <modification>ID   acetyl on K
+MT   type
+TG   K
+PP   Anywhere.
+MM   42
+
+//</modification>
+  <entry>
+    <accession>accession1</accession>
+    <gene />
+    <feature type="sequence variant" description="1\t50000000\t.\tA\tG\t.\tPASS\tANN=\tGT:AD:DP\t1/1:30,30:30">
+      <original>P</original>
+      <variation>K</variation>
+      <location>
+        <position position="3" />
+      </location>
+      <subfeature type="modified residue" description="acetyl on K">
+      <location>
+        <position position="3" />
+      </location>
+      </subfeature>
+    </feature>
+    <sequence length="6">PEPTID</sequence>
+  </entry>
+</mzLibProteinDb>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -160,6 +160,12 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="DatabaseTests\oblm.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="DatabaseTests\oblm2.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="DatabaseTests\sampleModFileFail_missingChemicalFormulaAndMonoisotopicMass.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/UsefulProteomicsDatabases/DecoyProteinGenerator.cs
+++ b/UsefulProteomicsDatabases/DecoyProteinGenerator.cs
@@ -90,6 +90,7 @@ namespace UsefulProteomicsDatabases
                 List<SequenceVariation> decoyVariations = new List<SequenceVariation>();
                 foreach (SequenceVariation sv in protein.SequenceVariations)
                 {
+                    // reverse sequence variation
                     char[] originalArray = sv.OriginalSequence.ToArray();
                     char[] variationArray = sv.VariantSequence.ToArray();
                     if (sv.OneBasedBeginPosition == 1)
@@ -107,7 +108,23 @@ namespace UsefulProteomicsDatabases
                     int decoyBegin = decoyEnd - originalArray.Length + 1;
                     Array.Reverse(originalArray);
                     Array.Reverse(variationArray);
-                    decoyVariations.Add(new SequenceVariation(decoyBegin, decoyEnd, new string(originalArray), new string(variationArray), "DECOY VARIANT: " + sv.Description));
+
+                    // place reversed modifications (referencing variant sequence location)
+                    Dictionary<int, List<Modification>> decoyVariantModifications = new Dictionary<int, List<Modification>>(sv.OneBasedModifications.Count);
+                    int variantSeqLength = protein.BaseSequence.Length + sv.VariantSequence.Length - sv.OriginalSequence.Length;
+                    foreach (var kvp in sv.OneBasedModifications)
+                    {
+                        if (kvp.Key > 1)
+                        {
+                            decoyVariantModifications.Add(variantSeqLength - kvp.Key + 2, kvp.Value);
+                        }
+                        else if (kvp.Key == 1)
+                        {
+                            decoyVariantModifications.Add(1, kvp.Value);
+                        }
+                    }
+
+                    decoyVariations.Add(new SequenceVariation(decoyBegin, decoyEnd, new string(originalArray), new string(variationArray), "DECOY VARIANT: " + sv.Description, decoyVariantModifications));
                 }
                 var decoyProtein = new Protein(reversed_sequence, "DECOY_" + protein.Accession, protein.Organism, protein.GeneNames.ToList(), decoyModifications, decoyPP,
                     protein.Name, protein.FullName, true, protein.IsContaminant, null, decoyVariations, decoyDisulfides, protein.DatabaseFilePath);

--- a/UsefulProteomicsDatabases/DecoyProteinGenerator.cs
+++ b/UsefulProteomicsDatabases/DecoyProteinGenerator.cs
@@ -28,7 +28,7 @@ namespace UsefulProteomicsDatabases
             }
             else if (decoyType == DecoyType.Slide)
             {
-                return GenerateSlideDecoys(proteins , maxThreads);
+                return GenerateSlideDecoys(proteins, maxThreads);
             }
             else
             {

--- a/UsefulProteomicsDatabases/ProteinDbLoader.cs
+++ b/UsefulProteomicsDatabases/ProteinDbLoader.cs
@@ -49,7 +49,7 @@ namespace UsefulProteomicsDatabases
             List<Modification> prespecified = GetPtmListFromProteinXml(proteinDbLocation);
             allKnownModifications = allKnownModifications ?? new List<Modification>();
             modTypesToExclude = modTypesToExclude ?? new List<string>();
-            
+
             //Dictionary<string, IList<Modification>> modsDictionary = new Dictionary<string, IList<Modification>>();
             if (prespecified.Count > 0 || allKnownModifications.Count() > 0)
             {
@@ -128,7 +128,7 @@ namespace UsefulProteomicsDatabases
                                 }
                                 else if (xml.Name == "entry")
                                 {
-                                    //if we are up to entry fields in the protein database, then there no more prespecified modifications to read and we 
+                                    //if we are up to entry fields in the protein database, then there no more prespecified modifications to read and we
                                     //can begin processing all the lines we have read.
                                     //This block of code does not process information in any of the entries.
                                     protein_xml_modlist_general = storedKnownModificationsBuilder.Length <= 0 ?

--- a/UsefulProteomicsDatabases/ProteinDbWriter.cs
+++ b/UsefulProteomicsDatabases/ProteinDbWriter.cs
@@ -38,7 +38,7 @@ namespace UsefulProteomicsDatabases
                 List<Modification> myModificationList = new List<Modification>();
                 foreach (Protein p in proteinList)
                 {
-                    foreach (KeyValuePair<int,List<Modification>> entry in p.OneBasedPossibleLocalizedModifications)
+                    foreach (KeyValuePair<int, List<Modification>> entry in p.OneBasedPossibleLocalizedModifications)
                     {
                         myModificationList.AddRange(entry.Value);
                     }


### PR DESCRIPTION
- Adds a subfeature for modifications that are found on sequence variations. Since traditional "modified residue" entries refer to the original base sequence, this prevents confusing mismatches.
- Removing the `ModFits` check in reading the database, since this is done in constructing the protein entry. This was redundant and prevented the database from being read completely. These modifications are stored in OriginalModifications. Added a test for this.