### PR TITLE
added zDot ion type and corrected etd/ecd/ethcd fragmentation to zDot…

### DIFF
--- a/Chemistry/Constants.cs
+++ b/Chemistry/Constants.cs
@@ -39,6 +39,12 @@ namespace Chemistry
         public const double ElectronMass = 5.48579909070e-4;
 
         /// <summary>
+        /// The difference between the carbon 13 isotope and carbon 12 isotope in
+        /// atomic units (u)
+        /// </summary>
+        public const double C13MinusC12 = 1.00335483810;
+
+        /// <summary>
         /// The largest number of elements to consider
         /// </summary>
         internal const int MaximumNumberOfElementsAllowed = 128;

--- a/Proteomics/Fragmentation/DissociationTypeCollection.cs
+++ b/Proteomics/Fragmentation/DissociationTypeCollection.cs
@@ -11,12 +11,12 @@ namespace Proteomics.Fragmentation
             { DissociationType.Unknown, new List<ProductType>() },
             { DissociationType.CID, new List<ProductType>{ ProductType.b, ProductType.y } },
             { DissociationType.IRMPD, new List<ProductType>{ ProductType.b, ProductType.y } },
-            { DissociationType.ECD, new List<ProductType>{ ProductType.c, ProductType.y, ProductType.zPlusOne } },
+            { DissociationType.ECD, new List<ProductType>{ ProductType.c, ProductType.y, ProductType.zDot } },
             { DissociationType.PQD, new List<ProductType>() },
-            { DissociationType.ETD, new List<ProductType>{ ProductType.c, ProductType.y, ProductType.zPlusOne } },
+            { DissociationType.ETD, new List<ProductType>{ ProductType.c, ProductType.y, ProductType.zDot } },
             { DissociationType.HCD, new List<ProductType>{ ProductType.b, ProductType.y } },//HCD often creates a-, aStar, and aDegree-ions and we should examine what other prominent algoroithms do to see if that would benefit our search results
             { DissociationType.AnyActivationType, new List<ProductType>{ ProductType.b, ProductType.y } },
-            { DissociationType.EThcD, new List<ProductType>{ ProductType.b, ProductType.y, ProductType.c, ProductType.zPlusOne } },
+            { DissociationType.EThcD, new List<ProductType>{ ProductType.b, ProductType.y, ProductType.c, ProductType.zDot } },
             { DissociationType.Custom, new List<ProductType>() },
             { DissociationType.ISCID, new List<ProductType>() }
         };
@@ -34,6 +34,7 @@ namespace Proteomics.Fragmentation
             { ProductType.y, null},//+O +H2
             { ProductType.yStar, null},//+O -H -N
             { ProductType.yDegree, null},//no change
+            { ProductType.zDot, null },// +O -NH + e- + p+
             { ProductType.zPlusOne, null},//+O +H -N: A Zdot ion is also known as z+1. It is not a z-ion in the Biemann nomenclature. It differs from a y-ion by N-1 H-1;
             { ProductType.M, null},// neutral Molecular product can be used with neutral loss as fragment
             { ProductType.D, null},// diagnostic ions are not shifted but added sumarily
@@ -59,6 +60,7 @@ namespace Proteomics.Fragmentation
                         case ProductType.y: NeutralMassShiftFromProductType[productType] = ChemicalFormula.ParseFormula("H2O1").MonoisotopicMass; break;// 18.01056468403, +O +H2
                         case ProductType.yStar: NeutralMassShiftFromProductType[productType] = ChemicalFormula.ParseFormula("O1H-1N-1").MonoisotopicMass; break;// 0.98401558291000057, +O -H -N
                         case ProductType.yDegree: NeutralMassShiftFromProductType[productType] = 0; break;// 0, no change
+                        case ProductType.zDot: NeutralMassShiftFromProductType[productType] = ChemicalFormula.ParseFormula("O1N-1H-1").MonoisotopicMass + Constants.ElectronMass + Constants.ProtonMass; break; //1.991840552567, +O -NH + e- + p+
                         case ProductType.zPlusOne: NeutralMassShiftFromProductType[productType] = ChemicalFormula.ParseFormula("O1H1N-1").MonoisotopicMass; break;//; 2.9996656473699996, +O +H -N:
                         case ProductType.M: NeutralMassShiftFromProductType[productType] = 0; break;// no change
                         case ProductType.D: NeutralMassShiftFromProductType[productType] = 0; break;// no change

--- a/Proteomics/Fragmentation/ProductType.cs
+++ b/Proteomics/Fragmentation/ProductType.cs
@@ -34,6 +34,7 @@ namespace Proteomics.Fragmentation
         yStar,
         yDegree,
         zPlusOne,//This is zDot plus H
+        zDot,
         M, //this is the molecular ion
         D //this is a diagnostic ion
     }

--- a/Proteomics/Fragmentation/TerminusSpecificProductTypes.cs
+++ b/Proteomics/Fragmentation/TerminusSpecificProductTypes.cs
@@ -9,8 +9,8 @@ namespace Proteomics.Fragmentation
         public static Dictionary<FragmentationTerminus, List<ProductType>> ProductIonTypesFromSpecifiedTerminus = new Dictionary<FragmentationTerminus, List<ProductType>>
         {
             {FragmentationTerminus.N, new List<ProductType>{ ProductType.a, ProductType.aDegree, ProductType.aStar, ProductType.b, ProductType.bDegree, ProductType.bStar, ProductType.c } }, //all ion types that include the N-terminus
-            {FragmentationTerminus.C, new List<ProductType>{ ProductType.x, ProductType.y, ProductType.yDegree, ProductType.yStar, ProductType.zPlusOne } }, //all ion types that include the C-terminus
-            {FragmentationTerminus.Both, new List<ProductType>{ ProductType.a, ProductType.aDegree, ProductType.aStar, ProductType.b, ProductType.bDegree, ProductType.bStar, ProductType.c, ProductType.x, ProductType.y, ProductType.yDegree, ProductType.yStar, ProductType.zPlusOne} },
+            {FragmentationTerminus.C, new List<ProductType>{ ProductType.x, ProductType.y, ProductType.yDegree, ProductType.yStar, ProductType.zDot, ProductType.zPlusOne } }, //all ion types that include the C-terminus
+            {FragmentationTerminus.Both, new List<ProductType>{ ProductType.a, ProductType.aDegree, ProductType.aStar, ProductType.b, ProductType.bDegree, ProductType.bStar, ProductType.c, ProductType.x, ProductType.y, ProductType.yDegree, ProductType.yStar, ProductType.zDot, ProductType.zPlusOne} },
             {FragmentationTerminus.None, new List<ProductType>() }
         };
 
@@ -27,6 +27,7 @@ namespace Proteomics.Fragmentation
             { ProductType.y, FragmentationTerminus.C },
             { ProductType.yDegree, FragmentationTerminus.C },
             { ProductType.yStar, FragmentationTerminus.C },
+            { ProductType.zDot, FragmentationTerminus.C },
             { ProductType.zPlusOne, FragmentationTerminus.C },
         };
 

--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -185,7 +185,7 @@ namespace Proteomics.ProteolyticDigestion
             var productCollection = TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[fragmentationTerminus].Intersect(DissociationTypeCollection.ProductsFromDissociationType[dissociationType]);
 
             List<(ProductType, int)> skippers = new List<(ProductType, int)>();
-            foreach (var product in productCollection.Where(f => f != ProductType.zPlusOne))
+            foreach (var product in productCollection.Where(f => f != ProductType.zDot))
             {
                 skippers.Add((product, BaseSequence.Length));
             }
@@ -325,7 +325,7 @@ namespace Proteomics.ProteolyticDigestion
         {
             for (int i = BaseSequence.IndexOf('P'); i > -1; i = BaseSequence.IndexOf('P', i + 1))
             {
-                yield return (ProductType.zPlusOne, BaseSequence.Length - i);
+                yield return (ProductType.zDot, BaseSequence.Length - i);
             }
         }
 

--- a/Proteomics/ProteolyticDigestion/ProductTypeMethods.cs
+++ b/Proteomics/ProteolyticDigestion/ProductTypeMethods.cs
@@ -9,11 +9,13 @@ namespace Proteomics.ProteolyticDigestion
         public static FragmentationTerminus IdentifyTerminusType(List<ProductType> productTypes)
         {
             if ((productTypes.Contains(ProductType.b) || productTypes.Contains(ProductType.c) || productTypes.Contains(ProductType.aDegree))
-                && (productTypes.Contains(ProductType.y) || productTypes.Contains(ProductType.zPlusOne) || productTypes.Contains(ProductType.x)))
+                && (productTypes.Contains(ProductType.y) || productTypes.Contains(ProductType.zDot) || productTypes.Contains(ProductType.zPlusOne) 
+                || productTypes.Contains(ProductType.x)))
             {
                 return FragmentationTerminus.Both;
             }
-            else if (productTypes.Contains(ProductType.y) || productTypes.Contains(ProductType.zPlusOne) || productTypes.Contains(ProductType.x))
+            else if (productTypes.Contains(ProductType.y) || productTypes.Contains(ProductType.zDot) 
+                || productTypes.Contains(ProductType.zPlusOne) || productTypes.Contains(ProductType.x))
             {
                 return FragmentationTerminus.C;
             }

--- a/Test/MyPeptideTest.cs
+++ b/Test/MyPeptideTest.cs
@@ -209,13 +209,13 @@ namespace Test
         {
             var prot = new Protein("MNNNKQQQQMNNNKQQQQ", null);
 
-            DigestionParams digestionParams = new DigestionParams("Custom Protease7", maxMissedCleavages: 0, minPeptideLength: 1, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            DigestionParams digestionParams = new DigestionParams("trypsin", maxMissedCleavages: 0, minPeptideLength: 1, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
             var ye = prot.Digest(digestionParams, new List<Modification>(), new List<Modification>()).ToList();
-            digestionParams = new DigestionParams("Custom Protease7", maxMissedCleavages: 0, minPeptideLength: 5, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            digestionParams = new DigestionParams("trypsin", maxMissedCleavages: 0, minPeptideLength: 5, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
             var ye1 = prot.Digest(digestionParams, new List<Modification>(), new List<Modification>()).ToList();
-            digestionParams = new DigestionParams("Custom Protease7", maxMissedCleavages: 0, minPeptideLength: 1, maxPeptideLength: 5, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            digestionParams = new DigestionParams("trypsin", maxMissedCleavages: 0, minPeptideLength: 1, maxPeptideLength: 5, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
             var ye2 = prot.Digest(digestionParams, new List<Modification>(), new List<Modification>()).ToList();
-            digestionParams = new DigestionParams("Custom Protease7", maxMissedCleavages: 0, minPeptideLength: 5, maxPeptideLength: 8, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            digestionParams = new DigestionParams("trypsin", maxMissedCleavages: 0, minPeptideLength: 5, maxPeptideLength: 8, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
             var ye3 = prot.Digest(digestionParams, new List<Modification>(), new List<Modification>()).ToList();
             Assert.AreEqual(3, ye.Count);
             Assert.AreEqual(2, ye1.Count);

--- a/Test/TestDissociation.cs
+++ b/Test/TestDissociation.cs
@@ -23,7 +23,7 @@ namespace Test
             List<ProductType> d = DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ECD];
             Assert.IsTrue(d.Contains(ProductType.c));
             Assert.IsTrue(d.Contains(ProductType.y));
-            Assert.IsTrue(d.Contains(ProductType.zPlusOne));
+            Assert.IsTrue(d.Contains(ProductType.zDot));
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace Test
             List<ProductType> d = DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ETD];
             Assert.IsTrue(d.Contains(ProductType.c));
             Assert.IsTrue(d.Contains(ProductType.y));
-            Assert.IsTrue(d.Contains(ProductType.zPlusOne));
+            Assert.IsTrue(d.Contains(ProductType.zDot));
         }
 
         [Test]

--- a/Test/TestFragments.cs
+++ b/Test/TestFragments.cs
@@ -620,6 +620,10 @@ namespace Test
                     case ProductType.zPlusOne:
                         Assert.AreEqual(Chemistry.ClassExtensions.RoundedDouble(ChemicalFormula.ParseFormula("O1H1N-1").MonoisotopicMass).Value, mass);
                         break;
+
+                    case ProductType.zDot:
+                        Assert.AreEqual(Chemistry.ClassExtensions.RoundedDouble(ChemicalFormula.ParseFormula("O1N-1H-1").MonoisotopicMass + Constants.ProtonMass + Constants.ElectronMass).Value, mass);
+                        break;
                 }
             }
         }
@@ -654,9 +658,9 @@ namespace Test
             Assert.AreEqual(new List<ProductType> { ProductType.y }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.C].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.HCD]));
             Assert.AreEqual(new List<ProductType> { }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.None].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.HCD]));
 
-            Assert.AreEqual(new List<ProductType> { ProductType.c, ProductType.y, ProductType.zPlusOne }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.Both].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ETD]));
+            Assert.AreEqual(new List<ProductType> { ProductType.c, ProductType.y, ProductType.zDot }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.Both].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ETD]));
             Assert.AreEqual(new List<ProductType> { ProductType.c }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.N].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ETD]));
-            Assert.AreEqual(new List<ProductType> { ProductType.y, ProductType.zPlusOne }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.C].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ETD]));
+            Assert.AreEqual(new List<ProductType> { ProductType.y, ProductType.zDot }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.C].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ETD]));
             Assert.AreEqual(new List<ProductType> { }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.None].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ETD]));
 
             Assert.AreEqual(new List<ProductType> { ProductType.b, ProductType.y }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.Both].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.CID]));
@@ -676,9 +680,9 @@ namespace Test
             Assert.AreEqual(new List<ProductType> { ProductType.y }, p.Fragment(DissociationType.HCD, FragmentationTerminus.C).Select(b => b.ProductType).Distinct().ToList());
             Assert.AreEqual(new List<ProductType> { }, p.Fragment(DissociationType.HCD, FragmentationTerminus.None).Select(b => b.ProductType).Distinct().ToList());
 
-            Assert.AreEqual(new List<ProductType> { ProductType.c, ProductType.y, ProductType.zPlusOne }, p.Fragment(DissociationType.ETD, FragmentationTerminus.Both).Select(b => b.ProductType).Distinct().ToList());
+            Assert.AreEqual(new List<ProductType> { ProductType.c, ProductType.y, ProductType.zDot }, p.Fragment(DissociationType.ETD, FragmentationTerminus.Both).Select(b => b.ProductType).Distinct().ToList());
             Assert.AreEqual(new List<ProductType> { ProductType.c }, p.Fragment(DissociationType.ETD, FragmentationTerminus.N).Select(b => b.ProductType).Distinct().ToList());
-            Assert.AreEqual(new List<ProductType> { ProductType.y, ProductType.zPlusOne }, p.Fragment(DissociationType.ETD, FragmentationTerminus.C).Select(b => b.ProductType).Distinct().ToList());
+            Assert.AreEqual(new List<ProductType> { ProductType.y, ProductType.zDot }, p.Fragment(DissociationType.ETD, FragmentationTerminus.C).Select(b => b.ProductType).Distinct().ToList());
             Assert.AreEqual(new List<ProductType> { }, p.Fragment(DissociationType.ETD, FragmentationTerminus.None).Select(b => b.ProductType).Distinct().ToList());
 
             Assert.AreEqual(new List<ProductType> { ProductType.b, ProductType.y }, p.Fragment(DissociationType.CID, FragmentationTerminus.Both).Select(b => b.ProductType).Distinct().ToList());
@@ -763,7 +767,7 @@ namespace Test
             PeptideWithSetModifications p = new PeptideWithSetModifications("MPEPTIDE", new Dictionary<string, Modification>());
             var fragments = p.Fragment(DissociationType.ETD, FragmentationTerminus.Both);
 
-            var z = fragments.Where(f => f.ProductType == ProductType.zPlusOne).ToList();
+            var z = fragments.Where(f => f.ProductType == ProductType.zDot).ToList();
 
             var ionNums = z.Select(f => f.TerminusFragment.FragmentNumber).ToArray();
             var expected = new[] { 1, 2, 3, 4, 6, 8 };
@@ -777,7 +781,7 @@ namespace Test
             PeptideWithSetModifications p = new PeptideWithSetModifications("MTETTIDE", new Dictionary<string, Modification>());
             var fragments = p.Fragment(DissociationType.ETD, FragmentationTerminus.Both);
 
-            var z = fragments.Where(f => f.ProductType == ProductType.zPlusOne).ToList();
+            var z = fragments.Where(f => f.ProductType == ProductType.zDot).ToList();
 
             var ionNums = z.Select(f => f.TerminusFragment.FragmentNumber).ToArray();
             var expected = new[] { 1, 2, 3, 4, 5, 6, 7, 8 };
@@ -791,7 +795,7 @@ namespace Test
             PeptideWithSetModifications p = new PeptideWithSetModifications("METPIPEEEE", new Dictionary<string, Modification>());
             var fragments = p.Fragment(DissociationType.ETD, FragmentationTerminus.Both);
 
-            var z = fragments.Where(f => f.ProductType == ProductType.zPlusOne).ToList();
+            var z = fragments.Where(f => f.ProductType == ProductType.zDot).ToList();
 
             var ionNums = z.Select(f => f.TerminusFragment.FragmentNumber).ToArray();
             var expected = new[] { 1, 2, 3, 4, 6, 8, 9, 10 };
@@ -807,7 +811,7 @@ namespace Test
             PeptideWithSetModifications p = new PeptideWithSetModifications("METP[OK:TEST]IPEEEE", new Dictionary<string, Modification> { { "TEST", m } });
             var fragments = p.Fragment(DissociationType.ETD, FragmentationTerminus.Both);
 
-            var z = fragments.Where(f => f.ProductType == ProductType.zPlusOne).ToList();
+            var z = fragments.Where(f => f.ProductType == ProductType.zDot).ToList();
 
             var ionNums = z.Select(f => f.TerminusFragment.FragmentNumber).ToArray();
             var expected = new[] { 1, 2, 3, 4, 6, 8, 9, 10 };

--- a/Test/TestProductMassesMightHaveDuplicates.cs
+++ b/Test/TestProductMassesMightHaveDuplicates.cs
@@ -32,13 +32,13 @@ namespace Test
             Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { 98, 227, 120, 249 }));
             
             allFragmentIonMzs = new HashSet<int>(aPeptideWithSetModifications.Fragment(DissociationType.ECD, FragmentationTerminus.Both).Select(i => (int)Math.Round(i.NeutralMass.ToMz(1))));
-            Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { 115, 244, 120, 249, 105, 234 }));
+            Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { 115, 244, 120, 249, 104, 233 }));
 
             allFragmentIonMzs = new HashSet<int>(aPeptideWithSetModifications.Fragment(DissociationType.PQD, FragmentationTerminus.Both).Select(i => (int)Math.Round(i.NeutralMass.ToMz(1))));
             Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { }));
 
             allFragmentIonMzs = new HashSet<int>(aPeptideWithSetModifications.Fragment(DissociationType.ETD, FragmentationTerminus.Both).Select(i => (int)Math.Round(i.NeutralMass.ToMz(1))));
-            Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { 115, 244, 120, 249, 105, 234 }));
+            Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { 115, 244, 120, 249, 104, 233 }));
 
             allFragmentIonMzs = new HashSet<int>(aPeptideWithSetModifications.Fragment(DissociationType.HCD, FragmentationTerminus.Both).Select(i => (int)Math.Round(i.NeutralMass.ToMz(1))));
             Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { 98, 227, 120, 249 }));
@@ -47,7 +47,7 @@ namespace Test
             Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { 98, 227, 120, 249 }));
 
             allFragmentIonMzs = new HashSet<int>(aPeptideWithSetModifications.Fragment(DissociationType.EThcD, FragmentationTerminus.Both).Select(i => (int)Math.Round(i.NeutralMass.ToMz(1))));
-            Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { 98, 227, 115, 244, 120, 249, 105, 234 }));
+            Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { 98, 227, 115, 244, 120, 249, 104, 233 }));
 
             DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom] = new List<ProductType> { };
             allFragmentIonMzs = new HashSet<int>(aPeptideWithSetModifications.Fragment(DissociationType.Custom, FragmentationTerminus.Both).Select(i => (int)Math.Round(i.NeutralMass.ToMz(1))));


### PR DESCRIPTION
… from zPlusOne

see: https://github.com/cwenger/Morpheus/blob/master/Morpheus/Morpheus/product_caps.tsv

http://www.pnas.org/content/101/26/9528

http://prospector.ucsf.edu/prospector/html/misc/faq.htm "The Biemann nomenclature gives a mass difference of 17 Da between y and z ions. Why is Protein Prospector giving me a 16Da difference.?"