### PR TITLE
digestion methods

### DIFF
--- a/Proteomics/Modifications/ModificationLocalization.cs
+++ b/Proteomics/Modifications/ModificationLocalization.cs
@@ -26,15 +26,15 @@ namespace Proteomics
             {
                 return false;
             }
-            if (attemptToLocalize.LocationRestriction == "Peptide N-terminal." && peptideOneBasedIndex > 1)
+            else if (attemptToLocalize.LocationRestriction == "Peptide N-terminal." && peptideOneBasedIndex > 1)
             {
                 return false;
             }
-            if (attemptToLocalize.LocationRestriction == "C-terminal." && proteinOneBasedIndex < proteinSequence.Length)
+            else if (attemptToLocalize.LocationRestriction == "C-terminal." && proteinOneBasedIndex < proteinSequence.Length)
             {
                 return false;
             }
-            if (attemptToLocalize.LocationRestriction == "Peptide C-terminal." && peptideOneBasedIndex < peptideLength)
+            else if (attemptToLocalize.LocationRestriction == "Peptide C-terminal." && peptideOneBasedIndex < peptideLength)
             {
                 return false;
             }

--- a/Proteomics/Modifications/ModificationLocalization.cs
+++ b/Proteomics/Modifications/ModificationLocalization.cs
@@ -7,16 +7,16 @@ namespace Proteomics
         public static bool ModFits(Modification attemptToLocalize, string proteinSequence, int peptideOneBasedIndex, int peptideLength, int proteinOneBasedIndex)
         {
             // First find the capital letter...
-            var motif = attemptToLocalize.Target;
-            var motifStartLocation = motif.ToString().IndexOf(motif.ToString().First(b => char.IsUpper(b)));
+            var motif = attemptToLocalize.Target.ToString();
+            var motifStartLocation = motif.IndexOf(motif.First(b => char.IsUpper(b)));
 
             // Look up starting at and including the capital letter
             var proteinToMotifOffset = proteinOneBasedIndex - motifStartLocation - 1;
             var indexUp = 0;
-            while (indexUp < motif.ToString().Length)
+            while (indexUp < motif.Length)
             {
                 if (indexUp + proteinToMotifOffset < 0 || indexUp + proteinToMotifOffset >= proteinSequence.Length
-                    || !MotifMatches(motif.ToString()[indexUp], proteinSequence[indexUp + proteinToMotifOffset]))
+                    || !MotifMatches(motif[indexUp], proteinSequence[indexUp + proteinToMotifOffset]))
                 {
                     return false;
                 }


### PR DESCRIPTION
digestion methods are faster now but can still be improved.

main edits:
- new algorithm to generate different modification patterns for a peptide

benchmark test using yeast.fasta database and arg-c: managed to reduce time from **114s to 69s**