### PR TITLE
Implement SILAC in digestion by allowing modification of the residue dictionary

### DIFF
--- a/Chemistry/ChemicalFormula.cs
+++ b/Chemistry/ChemicalFormula.cs
@@ -173,7 +173,8 @@ namespace Chemistry
 
         /// <summary>
         /// Parses a string representation of chemical formula and adds the elements
-        /// to this chemical formula
+        /// to this chemical formula.
+        /// Use brackets for isotopes (C6H12N2O -> C{13}6H12N2O)
         /// </summary>
         /// <param name="formula">the Chemical Formula to parse</param>
         public static ChemicalFormula ParseFormula(string formula)

--- a/Proteomics/AminoAcidPolymer/Residue.cs
+++ b/Proteomics/AminoAcidPolymer/Residue.cs
@@ -18,13 +18,12 @@
 
 using Chemistry;
 using System.Collections.Generic;
-using MzLibUtil;
 
 namespace Proteomics.AminoAcidPolymer
 {
     public class Residue : IHasChemicalFormula
     {
-        public static double[] ResidueMonoisotopicMass { get; private set; }
+        public static readonly double[] ResidueMonoisotopicMass;
 
         private static readonly Dictionary<string, Residue> ResiduesDictionary;
         private static readonly Residue[] ResiduesByLetter;
@@ -133,7 +132,7 @@ namespace Proteomics.AminoAcidPolymer
         }
 
         /// <summary>
-        /// Adds a list of new residues to the dictionary using arbitrary lowercase letters as indexes.
+        /// Adds a list of new residues to the dictionary at their specified index.
         /// </summary>
         /// <param name="residuesToAdd"></param>
         /// <returns></returns>

--- a/Proteomics/AminoAcidPolymer/Residue.cs
+++ b/Proteomics/AminoAcidPolymer/Residue.cs
@@ -18,12 +18,13 @@
 
 using Chemistry;
 using System.Collections.Generic;
+using MzLibUtil;
 
 namespace Proteomics.AminoAcidPolymer
 {
     public class Residue : IHasChemicalFormula
     {
-        public static readonly double[] ResidueMonoisotopicMass;
+        public static double[] ResidueMonoisotopicMass { get; private set; }
 
         private static readonly Dictionary<string, Residue> ResiduesDictionary;
         private static readonly Residue[] ResiduesByLetter;
@@ -57,12 +58,12 @@ namespace Proteomics.AminoAcidPolymer
 
             ResiduesByLetter = new Residue[]
         {
-            null,null,null,null,null,null,null,null,null,null,null,null,null,
-            null,null,null,null,null,null,null,null,null,null,null,null,null,
-            null,null,null,null,null,null,null,null,null,null,null,null,null,
-            null,null,null,null,null,null,null,null,null,null,null,null,null,
-            null,null,null,null,null,null,null,null,null,null,null,null,null,
-            ResiduesDictionary["Alanine"],
+            null,null,null,null,null,null,null,null,null,null,null,null,null, //12
+            null,null,null,null,null,null,null,null,null,null,null,null,null, //25
+            null,null,null,null,null,null,null,null,null,null,null,null,null, //38
+            null,null,null,null,null,null,null,null,null,null,null,null,null, //51
+            null,null,null,null,null,null,null,null,null,null,null,null,null, //64
+            ResiduesDictionary["Alanine"], //65
             null, // B
             ResiduesDictionary["Cysteine"],
             ResiduesDictionary["Aspartic Acid"],
@@ -87,10 +88,10 @@ namespace Proteomics.AminoAcidPolymer
             ResiduesDictionary["Tryptophan"],
             null, // X
             ResiduesDictionary["Tyrosine"],
-            null, // Z
-            null,null,null,null,null,null,null,null,null,null,null,null,null,
-            null,null,null,null,null,null,null,null,null,null,null,null,null,
-            null,null,null,null,null,null
+            null, // Z  //90
+            null,null,null,null,null,null,null,null,null,null,null,null,null, //103
+            null,null,null,null,null,null,null,null,null,null,null,null,null, //116
+            null,null,null,null,null,null //122
         };
             ResidueMonoisotopicMass = new double[]
         {
@@ -131,7 +132,23 @@ namespace Proteomics.AminoAcidPolymer
         };
         }
 
-        internal Residue(string name, char oneLetterAbbreviation, string threeLetterAbbreviation, ChemicalFormula chemicalFormula, ModificationSites site)
+        /// <summary>
+        /// Adds a list of new residues to the dictionary using arbitrary lowercase letters as indexes.
+        /// </summary>
+        /// <param name="residuesToAdd"></param>
+        /// <returns></returns>
+        public static void AddNewResiduesToDictionary(List<Residue> residuesToAdd)
+        {
+            foreach (Residue residue in residuesToAdd)
+            {
+                ResiduesDictionary[residue.Name] = residue;
+                ResiduesByLetter[residue.Letter] = residue;
+                ResidueMonoisotopicMass[residue.Letter] = residue.MonoisotopicMass;
+            }
+        }
+
+
+        public Residue(string name, char oneLetterAbbreviation, string threeLetterAbbreviation, ChemicalFormula chemicalFormula, ModificationSites site)
         {
             Name = name;
             Letter = oneLetterAbbreviation;

--- a/Proteomics/Modifications/SilacLabel.cs
+++ b/Proteomics/Modifications/SilacLabel.cs
@@ -15,6 +15,10 @@ namespace Proteomics
             OriginalAminoAcid = originalAminoAcid;
             AminoAcidLabel = aminoAcidLabel;
             MassDifference = Math.Round(massDifference, 3).ToString();
+            if (MassDifference[0] != '-')//if not negative, add a plus
+            {
+                MassDifference = "+" + MassDifference;
+            }
         }
     }
 }

--- a/Proteomics/Modifications/SilacLabel.cs
+++ b/Proteomics/Modifications/SilacLabel.cs
@@ -15,7 +15,7 @@ namespace Proteomics
             OriginalAminoAcid = originalAminoAcid;
             AminoAcidLabel = aminoAcidLabel;
             MassDifference = Math.Round(massDifference, 3).ToString();
-            if (MassDifference[0] != '-')//if not negative, add a plus
+            if (massDifference > 0)//if not negative, add a plus
             {
                 MassDifference = "+" + MassDifference;
             }

--- a/Proteomics/Modifications/SilacLabel.cs
+++ b/Proteomics/Modifications/SilacLabel.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Proteomics
+{
+    public class SilacLabel
+    {
+        public char OriginalAminoAcid { get; private set; }
+        public char AminoAcidLabel { get; private set; }
+        public string MassDifference { get; private set; }
+
+        public SilacLabel(char originalAminoAcid, char aminoAcidLabel, double massDifference)
+        {
+            OriginalAminoAcid = originalAminoAcid;
+            AminoAcidLabel = aminoAcidLabel;
+            MassDifference = Math.Round(massDifference, 3).ToString();
+        }
+    }
+}

--- a/Proteomics/Protein/Protein.cs
+++ b/Proteomics/Protein/Protein.cs
@@ -66,29 +66,29 @@ namespace Proteomics
         /// Protein construction that clones a protein but assigns a different base sequence
         /// For use in SILAC experiments
         /// </summary>
-        /// <param name="silacSequence"></param>
         /// <param name="originalProtein"></param>
-        public Protein(string silacSequence, Protein p)
+        /// <param name="silacSequence"></param>
+        public Protein(Protein originalProtein, string silacSequence)
         {
             BaseSequence = silacSequence;
             NonVariantProtein = this;
-            Accession = p.Accession;
-            Name = p.Name;
-            Organism = p.Organism;
-            FullName = p.FullName;
-            IsDecoy = p.IsDecoy;
-            IsContaminant = p.IsContaminant;
-            DatabaseFilePath = p.DatabaseFilePath;
-            SampleNameForVariants = p.SampleNameForVariants;
-            GeneNames = p.GeneNames;
-            ProteolysisProducts = p.ProteolysisProducts;
-            SequenceVariations = p.SequenceVariations;
-            AppliedSequenceVariations = p.AppliedSequenceVariations;
-            OriginalNonVariantModifications = p.OriginalNonVariantModifications;
-            OneBasedPossibleLocalizedModifications = p.OneBasedPossibleLocalizedModifications;
-            DatabaseReferences = p.DatabaseReferences;
-            DisulfideBonds = p.DisulfideBonds;
-            SpliceSites = p.SpliceSites;
+            Accession = originalProtein.Accession;
+            Name = originalProtein.Name;
+            Organism = originalProtein.Organism;
+            FullName = originalProtein.FullName;
+            IsDecoy = originalProtein.IsDecoy;
+            IsContaminant = originalProtein.IsContaminant;
+            DatabaseFilePath = originalProtein.DatabaseFilePath;
+            SampleNameForVariants = originalProtein.SampleNameForVariants;
+            GeneNames = originalProtein.GeneNames;
+            ProteolysisProducts = originalProtein.ProteolysisProducts;
+            SequenceVariations = originalProtein.SequenceVariations;
+            AppliedSequenceVariations = originalProtein.AppliedSequenceVariations;
+            OriginalNonVariantModifications = originalProtein.OriginalNonVariantModifications;
+            OneBasedPossibleLocalizedModifications = originalProtein.OneBasedPossibleLocalizedModifications;
+            DatabaseReferences = originalProtein.DatabaseReferences;
+            DisulfideBonds = originalProtein.DisulfideBonds;
+            SpliceSites = originalProtein.SpliceSites;
         }
 
         /// <summary>
@@ -268,7 +268,7 @@ namespace Proteomics
             }
             foreach (SilacLabel label in silacLabels)
             {
-                Protein silacProtein = new Protein(BaseSequence.Replace(label.OriginalAminoAcid, label.AminoAcidLabel), this);
+                Protein silacProtein = new Protein(this, BaseSequence.Replace(label.OriginalAminoAcid, label.AminoAcidLabel));
                 foreach (PeptideWithSetModifications pwsm in originalPeptides)
                 {
                     //duplicate the peptides with the updated protein sequence that contains only silac labels

--- a/Proteomics/Protein/Protein.cs
+++ b/Proteomics/Protein/Protein.cs
@@ -244,9 +244,9 @@ namespace Proteomics
             List<Modification> variableModifications, List<SilacLabel> silacLabels = null)
         {
             ProteinDigestion digestion = new ProteinDigestion(digestionParams, allKnownFixedModifications, variableModifications);
-            IEnumerable<ProteolyticPeptide> unmodifiedPeptides = 
-                digestionParams.SearchModeType == CleavageSpecificity.Semi ? 
-                digestion.SpeedySemiSpecificDigestion(this) : 
+            IEnumerable<ProteolyticPeptide> unmodifiedPeptides =
+                digestionParams.SearchModeType == CleavageSpecificity.Semi ?
+                digestion.SpeedySemiSpecificDigestion(this) :
                 digestion.Digestion(this);
             IEnumerable<PeptideWithSetModifications> modifiedPeptides = unmodifiedPeptides.SelectMany(peptide => peptide.GetModifiedPeptides(allKnownFixedModifications, digestionParams, variableModifications));
 
@@ -262,14 +262,14 @@ namespace Proteomics
         /// </summary>
         internal IEnumerable<PeptideWithSetModifications> GetSilacPeptides(IEnumerable<PeptideWithSetModifications> originalPeptides, List<SilacLabel> silacLabels)
         {
-            foreach(PeptideWithSetModifications pwsm in originalPeptides)
+            foreach (PeptideWithSetModifications pwsm in originalPeptides)
             {
                 yield return pwsm;
             }
-            foreach(SilacLabel label in silacLabels)
+            foreach (SilacLabel label in silacLabels)
             {
                 Protein silacProtein = new Protein(BaseSequence.Replace(label.OriginalAminoAcid, label.AminoAcidLabel), this);
-                foreach(PeptideWithSetModifications pwsm in originalPeptides)
+                foreach (PeptideWithSetModifications pwsm in originalPeptides)
                 {
                     //duplicate the peptides with the updated protein sequence that contains only silac labels
                     yield return new PeptideWithSetModifications(silacProtein, pwsm.DigestionParams, pwsm.OneBasedStartResidueInProtein, pwsm.OneBasedEndResidueInProtein, pwsm.CleavageSpecificityForFdrCategory, pwsm.PeptideDescription, pwsm.MissedCleavages, pwsm.AllModsOneIsNterminus, pwsm.NumFixedMods);

--- a/Proteomics/Protein/Protein.cs
+++ b/Proteomics/Protein/Protein.cs
@@ -243,11 +243,16 @@ namespace Proteomics
         public IEnumerable<PeptideWithSetModifications> Digest(DigestionParams digestionParams, IEnumerable<Modification> allKnownFixedModifications,
             List<Modification> variableModifications, List<SilacLabel> silacLabels = null)
         {
+            //can't be null
+            allKnownFixedModifications = allKnownFixedModifications ?? new List<Modification>();
+            variableModifications = variableModifications ?? new List<Modification>();
+
             ProteinDigestion digestion = new ProteinDigestion(digestionParams, allKnownFixedModifications, variableModifications);
             IEnumerable<ProteolyticPeptide> unmodifiedPeptides =
                 digestionParams.SearchModeType == CleavageSpecificity.Semi ?
                 digestion.SpeedySemiSpecificDigestion(this) :
                 digestion.Digestion(this);
+
             IEnumerable<PeptideWithSetModifications> modifiedPeptides = unmodifiedPeptides.SelectMany(peptide => peptide.GetModifiedPeptides(allKnownFixedModifications, digestionParams, variableModifications));
 
             if (silacLabels != null)

--- a/Proteomics/ProteolyticDigestion/ProteinDigestion.cs
+++ b/Proteomics/ProteolyticDigestion/ProteinDigestion.cs
@@ -41,7 +41,7 @@ namespace Proteomics.ProteolyticDigestion
         /// </summary>
         /// <param name="protein"></param>
         /// <returns></returns>
-        public IEnumerable<PeptideWithSetModifications> SpeedySemiSpecificDigestion(Protein protein) //We are only getting fully specific peptides of the maximum cleaved residues here
+        public IEnumerable<ProteolyticPeptide> SpeedySemiSpecificDigestion(Protein protein) //We are only getting fully specific peptides of the maximum cleaved residues here
         {
             List<ProteolyticPeptide> peptides = new List<ProteolyticPeptide>();
             List<int> oneBasedIndicesToCleaveAfter = Protease.GetDigestionSiteIndices(protein.BaseSequence); //get peptide bonds to cleave SPECIFICALLY (termini included)
@@ -144,7 +144,7 @@ namespace Proteomics.ProteolyticDigestion
                     .Select(proteolysisProduct => new ProteolyticPeptide(protein, proteolysisProduct.OneBasedBeginPosition.Value, proteolysisProduct.OneBasedEndPosition.Value,
                         0, CleavageSpecificity.Full, proteolysisProduct.Type + " start")));
 
-            return peptides.SelectMany(peptide => peptide.GetModifiedPeptides(AllKnownFixedModifications, DigestionParams, VariableModifications));
+            return peptides;
         }
 
         /// <summary>
@@ -152,10 +152,9 @@ namespace Proteomics.ProteolyticDigestion
         /// </summary>
         /// <param name="protein"></param>
         /// <returns></returns>
-        public IEnumerable<PeptideWithSetModifications> Digestion(Protein protein)
+        public IEnumerable<ProteolyticPeptide> Digestion(Protein protein)
         {
-            var unmodifiedPeptides = Protease.GetUnmodifiedPeptides(protein, MaximumMissedCleavages, InitiatorMethionineBehavior, MinPeptideLength, MaxPeptideLength);
-            return unmodifiedPeptides.SelectMany(peptide => peptide.GetModifiedPeptides(AllKnownFixedModifications, DigestionParams, VariableModifications));
+            return Protease.GetUnmodifiedPeptides(protein, MaximumMissedCleavages, InitiatorMethionineBehavior, MinPeptideLength, MaxPeptideLength);
         }
     }
 }

--- a/Proteomics/ProteolyticDigestion/ProteinDigestion.cs
+++ b/Proteomics/ProteolyticDigestion/ProteinDigestion.cs
@@ -20,8 +20,8 @@ namespace Proteomics.ProteolyticDigestion
             InitiatorMethionineBehavior = digestionParams.InitiatorMethionineBehavior;
             MinPeptideLength = digestionParams.MinPeptideLength;
             MaxPeptideLength = digestionParams.MaxPeptideLength;
-            AllKnownFixedModifications = allKnownFixedModifications ?? new List<Modification>();
-            VariableModifications = variableModifications ?? new List<Modification>();
+            AllKnownFixedModifications = allKnownFixedModifications;
+            VariableModifications = variableModifications;
         }
 
         public Protease Protease { get; set; }

--- a/Test/TestModifications.cs
+++ b/Test/TestModifications.cs
@@ -141,13 +141,17 @@ namespace Test
                 new SilacLabel('K','b', heavierLabel.MonoisotopicMass-lysine.MonoisotopicMass)
             };
             List<PeptideWithSetModifications> silacDigest = originalProtein.Digest(new DigestionParams(), new List<Modification>(), new List<Modification>(), silacLabels).ToList();
-            Assert.IsTrue(originalDigest.Count*3 == silacDigest.Count); //check that each peptide now has a heavy and heavier compliment
+            Assert.IsTrue(originalDigest.Count * 3 == silacDigest.Count); //check that each peptide now has a light, heavy, and heavier compliment
 
+            double silacPeptideLightMonoisotopicMass = silacDigest.Where(x => x.BaseSequence.Contains("K")).First().MonoisotopicMass;
             double silacPeptideHeavyMonoisotopicMass = silacDigest.Where(x => x.BaseSequence.Contains("a")).First().MonoisotopicMass;
             double silacPeptideHeavierMonoisotopicMass = silacDigest.Where(x => x.BaseSequence.Contains("b")).First().MonoisotopicMass;
-            Assert.IsTrue(silacPeptideHeavyMonoisotopicMass != double.NaN); //if both NaN, then the bottom statement will always be true, because NaN + double = NaN
-            Assert.IsTrue(silacPeptideHeavierMonoisotopicMass != double.NaN); //if both NaN, then the bottom statement will always be true, because NaN + double = NaN
-            Assert.IsTrue(Math.Round(silacPeptideHeavyMonoisotopicMass + heavierLabel.MonoisotopicMass,5).Equals(Math.Round(silacPeptideHeavierMonoisotopicMass + heavyLabel.MonoisotopicMass,5))); //check that the residue masses were succesfully added
+            Assert.IsTrue(silacPeptideLightMonoisotopicMass != double.NaN); //if both NaN, then the mass comparison statements will always be true, because NaN + double = NaN
+            Assert.IsTrue(silacPeptideHeavyMonoisotopicMass != double.NaN); //if both NaN, then the mass comparison statements will always be true, because NaN + double = NaN
+            Assert.IsTrue(silacPeptideHeavierMonoisotopicMass != double.NaN); //if both NaN, then the mass comparison statements will always be true, because NaN + double = NaN
+
+            Assert.IsTrue(Math.Round(silacPeptideLightMonoisotopicMass + heavyLabel.MonoisotopicMass, 5).Equals(Math.Round(silacPeptideHeavyMonoisotopicMass + lysine.MonoisotopicMass, 5))); //check that the residue masses were succesfully added
+            Assert.IsTrue(Math.Round(silacPeptideHeavyMonoisotopicMass + heavierLabel.MonoisotopicMass, 5).Equals(Math.Round(silacPeptideHeavierMonoisotopicMass + heavyLabel.MonoisotopicMass, 5))); //check that the residue masses were succesfully added
         }
 
         [Test]

--- a/Test/TestModifications.cs
+++ b/Test/TestModifications.cs
@@ -125,6 +125,32 @@ namespace Test
         }
 
         [Test]
+        public void SilacLabelTest()
+        {
+            Protein originalProtein = new Protein("ACDEFGHIKAKAK", "TEST");
+            List<PeptideWithSetModifications> originalDigest = originalProtein.Digest(new DigestionParams(), new List<Modification>(), new List<Modification>()).ToList();
+            //Multiple SILAC labels
+            Residue lysine = Residue.GetResidue('K');
+            Residue heavyLabel = new Residue("heavy", 'a', "aaa", ChemicalFormula.ParseFormula("C{13}6H12N2O"), ModificationSites.All); //Lysine +6
+            Residue heavierLabel = new Residue("heavier", 'b', "bbb", ChemicalFormula.ParseFormula("C{13}6H12N{15}2O"), ModificationSites.All); //Lysine +8
+            List<Residue> residuesToAdd = new List<Residue> { heavyLabel, heavierLabel };
+            Residue.AddNewResiduesToDictionary(residuesToAdd);
+            List<SilacLabel> silacLabels = new List<SilacLabel>
+            {
+                new SilacLabel('K','a', heavyLabel.MonoisotopicMass-lysine.MonoisotopicMass),
+                new SilacLabel('K','b', heavierLabel.MonoisotopicMass-lysine.MonoisotopicMass)
+            };
+            List<PeptideWithSetModifications> silacDigest = originalProtein.Digest(new DigestionParams(), new List<Modification>(), new List<Modification>(), silacLabels).ToList();
+            Assert.IsTrue(originalDigest.Count*3 == silacDigest.Count); //check that each peptide now has a heavy and heavier compliment
+
+            double silacPeptideHeavyMonoisotopicMass = silacDigest.Where(x => x.BaseSequence.Contains("a")).First().MonoisotopicMass;
+            double silacPeptideHeavierMonoisotopicMass = silacDigest.Where(x => x.BaseSequence.Contains("b")).First().MonoisotopicMass;
+            Assert.IsTrue(silacPeptideHeavyMonoisotopicMass != double.NaN); //if both NaN, then the bottom statement will always be true, because NaN + double = NaN
+            Assert.IsTrue(silacPeptideHeavierMonoisotopicMass != double.NaN); //if both NaN, then the bottom statement will always be true, because NaN + double = NaN
+            Assert.IsTrue(Math.Round(silacPeptideHeavyMonoisotopicMass + heavierLabel.MonoisotopicMass,5).Equals(Math.Round(silacPeptideHeavierMonoisotopicMass + heavyLabel.MonoisotopicMass,5))); //check that the residue masses were succesfully added
+        }
+
+        [Test]
         public void ModificationCollectionTest()
         {
             ModificationCollection a = new ModificationCollection(new OldSchoolModification(1, "Mod1"), new OldSchoolModification(2, "Mod2"));


### PR DESCRIPTION
Major
-Allow any character of the residue dictionary to be modified using the "AddNewResiduesToDictionary" method

Minor
-Create new SILAC proteins for digested peptides in Digest()
-Have modifications assigned in Digest() instead of Digestion() and SpeedySemiSpecificDigestion()