### PR TITLE
fix RawFileReader precursor scan problem

### DIFF
--- a/ThermoRawFileReader/ThermoRawFileReaderData.cs
+++ b/ThermoRawFileReader/ThermoRawFileReaderData.cs
@@ -231,7 +231,7 @@ namespace ThermoRawFileReader
                 if (labels[i].StartsWith("Master Scan Number", StringComparison.Ordinal)
                     || labels[i].StartsWith("Master Index", StringComparison.Ordinal))
                 {
-                    precursorScanNumber = int.Parse(values[i], CultureInfo.InvariantCulture) <= 0 ?
+                    precursorScanNumber = int.Parse(values[i], CultureInfo.InvariantCulture) <= 1 ?
                         (int?)null :
                         int.Parse(values[i], CultureInfo.InvariantCulture);
                 }


### PR DESCRIPTION
Many Thermo MS2 scans have a precursor scan incorrectly listed as "1". MSFileReader corrects this problem by looping back through the spectra file to find the previous MS1 scan. RawFileReader doesn't do this, so we need to do it ourselves. Got this info from Jim Shofstahl at Thermo.