### PR TITLE
Allow Silac Label Mixtures

### DIFF
--- a/Proteomics/Modifications/SilacLabel.cs
+++ b/Proteomics/Modifications/SilacLabel.cs
@@ -39,6 +39,22 @@ namespace Proteomics
             }
         }
 
+        /// <summary>
+        /// This method exists for conversion of Silac labels, which take double inputs
+        /// Although a double object could be saved, it clutters tomls
+        /// </summary>
+        /// <returns></returns>
+        public double ConvertMassDifferenceToDouble()
+        {
+            string substring = MassDifference.Substring(1);
+            double value = Convert.ToDouble(substring);
+            if (MassDifference[0] == '-')
+            {
+                value *= -1;
+            }
+            return value;
+        }
+
         /// this parameterless constructor needs to exist to read the toml.
         /// if you can figure out a way to get rid of it, feel free...
         /// this is also encountered in MetaMorpheus's "CommonParameters.cs" if you find a solution.

--- a/Proteomics/Protein/Protein.cs
+++ b/Proteomics/Protein/Protein.cs
@@ -224,7 +224,7 @@ namespace Proteomics
         /// Gets peptides for digestion of a protein
         /// </summary>
         public IEnumerable<PeptideWithSetModifications> Digest(DigestionParams digestionParams, IEnumerable<Modification> allKnownFixedModifications,
-            List<Modification> variableModifications, List<SilacLabel> silacLabels = null)
+            List<Modification> variableModifications, List<SilacLabel> silacLabels = null, (SilacLabel startLabel, SilacLabel endLabel)? turnoverLabels = null)
         {
             //can't be null
             allKnownFixedModifications = allKnownFixedModifications ?? new List<Modification>();
@@ -250,7 +250,7 @@ namespace Proteomics
             //add silac labels (if needed)
             if (silacLabels != null)
             {
-                return GetSilacPeptides(modifiedPeptides, silacLabels, digestionParams.GeneratehUnlabeledProteinsForSilac);
+                return GetSilacPeptides(modifiedPeptides, silacLabels, digestionParams.GeneratehUnlabeledProteinsForSilac, turnoverLabels);
             }
 
             return modifiedPeptides;
@@ -276,38 +276,174 @@ namespace Proteomics
         /// <summary>
         /// Add additional peptides with SILAC amino acids
         /// </summary>
-        internal IEnumerable<PeptideWithSetModifications> GetSilacPeptides(IEnumerable<PeptideWithSetModifications> originalPeptides, List<SilacLabel> silacLabels, bool generateUnlabeledProteins)
+        internal IEnumerable<PeptideWithSetModifications> GetSilacPeptides(IEnumerable<PeptideWithSetModifications> originalPeptides, List<SilacLabel> silacLabels, bool generateUnlabeledProteins, (SilacLabel startLabel, SilacLabel endLabel)? turnoverLabels)
         {
-            //unlabeled peptides
-            if (generateUnlabeledProteins)
+            //if this is a multiplex experiment (pooling multiple samples, not a turnover), then only create the fully unlabeled/labeled peptides
+            if (turnoverLabels == null)
             {
+                //unlabeled peptides
+                if (generateUnlabeledProteins)
+                {
+                    foreach (PeptideWithSetModifications pwsm in originalPeptides)
+                    {
+                        yield return pwsm;
+                    }
+                }
+
+                //fully labeled peptides
+                foreach (SilacLabel label in silacLabels)
+                {
+                    Protein silacProtein = GenerateFullyLabeledSilacProtein(label);
+                    foreach (PeptideWithSetModifications pwsm in originalPeptides)
+                    {
+                        //duplicate the peptides with the updated protein sequence that contains only silac labels
+                        yield return new PeptideWithSetModifications(silacProtein, pwsm.DigestionParams, pwsm.OneBasedStartResidueInProtein, pwsm.OneBasedEndResidueInProtein, pwsm.CleavageSpecificityForFdrCategory, pwsm.PeptideDescription, pwsm.MissedCleavages, pwsm.AllModsOneIsNterminus, pwsm.NumFixedMods);
+                    }
+                }
+            }
+            else //if this is a turnover experiment, we want to be able to look for peptides containing mixtures of heavy and light amino acids (typically occurs for missed cleavages)
+            {
+                (SilacLabel startLabel, SilacLabel endLabel) turnoverLabelsValue = turnoverLabels.Value;
+                SilacLabel startLabel = turnoverLabelsValue.startLabel;
+                SilacLabel endLabel = turnoverLabelsValue.endLabel;
+
+                //This allows you to move from one label to another (rather than unlabeled->labeled or labeled->unlabeled). Useful for when your lab is swimming in cash and you have stock in a SILAC company
+                if (startLabel != null && endLabel != null) //if neither the start nor end conditions are unlabeled, then generate fully labeled proteins using the "startLabel" (otherwise maintain the unlabeled)
+                {
+                    Protein silacStartProtein = GenerateFullyLabeledSilacProtein(startLabel);
+                    PeptideWithSetModifications[] originalPeptideArray = originalPeptides.ToArray();
+                    for (int i = 0; i < originalPeptideArray.Length; i++)
+                    {
+                        PeptideWithSetModifications pwsm = originalPeptideArray[i];
+                        //duplicate the peptides with the updated protein sequence that contains only silac labels
+                        originalPeptideArray[i] = new PeptideWithSetModifications(silacStartProtein, pwsm.DigestionParams, pwsm.OneBasedStartResidueInProtein, pwsm.OneBasedEndResidueInProtein, pwsm.CleavageSpecificityForFdrCategory, pwsm.PeptideDescription, pwsm.MissedCleavages, pwsm.AllModsOneIsNterminus, pwsm.NumFixedMods);
+                    }
+                    originalPeptides = originalPeptideArray;
+                }
+
+                //add all unlabeled (or if no unlabeled, then the startLabeled) peptides
                 foreach (PeptideWithSetModifications pwsm in originalPeptides)
                 {
                     yield return pwsm;
                 }
-            }
 
-            //labeled peptides
-            foreach (SilacLabel label in silacLabels)
-            {
-                string updatedBaseSequence = BaseSequence.Replace(label.OriginalAminoAcid, label.AminoAcidLabel);
-                string updatedAccession = Accession + label.MassDifference;
-                if (label.AdditionalLabels != null) //if there is more than one label per replicate (i.e both R and K were labeled in a sample before pooling)
+                //the order (below) matters when neither labels are null, because the fully labeled "start" has already been created above, so we want to use the end label here if it's not unlabeled (null)
+                SilacLabel label = endLabel ?? startLabel; //pick the labeled (not the unlabeled). If no unlabeled, take the endLabel
+
+                Protein silacEndProtein = GenerateFullyLabeledSilacProtein(label);
+
+                //add all peptides containing any label (may also contain unlabeled) 
+                if (label.AdditionalLabels == null) //if there's only one (which is common)
                 {
-                    foreach (SilacLabel additionalLabel in label.AdditionalLabels)
+                    //get the residues to change
+                    char originalResidue = label.OriginalAminoAcid;
+                    char labeledResidue = label.AminoAcidLabel;
+
+                    //label peptides
+                    foreach (PeptideWithSetModifications pwsm in originalPeptides)
                     {
-                        updatedBaseSequence = updatedBaseSequence.Replace(additionalLabel.OriginalAminoAcid, additionalLabel.AminoAcidLabel);
-                        updatedAccession += additionalLabel.MassDifference;
+                        //find the indexes in the base sequence for labeling
+                        char[] baseSequenceArray = pwsm.BaseSequence.ToArray();
+                        List<int> indexesOfResiduesToBeLabeled = new List<int>();
+                        for (int c = 0; c < baseSequenceArray.Length; c++)
+                        {
+                            if (baseSequenceArray[c] == originalResidue)
+                            {
+                                indexesOfResiduesToBeLabeled.Add(c);
+                            }
+                        }
+                        //if there's something to label
+                        if (indexesOfResiduesToBeLabeled.Count != 0)
+                        {
+                            List<PeptideWithSetModifications> pwsmsForCombinatorics = new List<PeptideWithSetModifications> { pwsm };
+                            for (int a = 0; a < indexesOfResiduesToBeLabeled.Count; a++)
+                            {
+                                foreach (PeptideWithSetModifications pwsmCombination in pwsmsForCombinatorics)
+                                {
+                                    char[] combinatoricBaseSequenceArray = pwsmCombination.BaseSequence.ToArray();
+                                    combinatoricBaseSequenceArray[indexesOfResiduesToBeLabeled[a]] = labeledResidue;
+                                    string updatedBaseSequence = string.Concat(combinatoricBaseSequenceArray);
+
+                                    PeptideWithSetModifications labeledPwsm = new PeptideWithSetModifications(silacEndProtein, pwsm.DigestionParams,
+                                        pwsm.OneBasedStartResidueInProtein, pwsm.OneBasedEndResidueInProtein, pwsm.CleavageSpecificityForFdrCategory,
+                                        pwsm.PeptideDescription, pwsm.MissedCleavages, pwsm.AllModsOneIsNterminus, pwsm.NumFixedMods, updatedBaseSequence);
+                                    yield return labeledPwsm; //return
+                                    pwsmsForCombinatorics.Add(labeledPwsm); //add so it can be used again
+                                }
+                            }
+                        }
                     }
                 }
-                Protein silacProtein = new Protein(this, updatedBaseSequence, updatedAccession);
-
-                foreach (PeptideWithSetModifications pwsm in originalPeptides)
+                else //if there are more than one (i.e. K and R are labeled)
                 {
-                    //duplicate the peptides with the updated protein sequence that contains only silac labels
-                    yield return new PeptideWithSetModifications(silacProtein, pwsm.DigestionParams, pwsm.OneBasedStartResidueInProtein, pwsm.OneBasedEndResidueInProtein, pwsm.CleavageSpecificityForFdrCategory, pwsm.PeptideDescription, pwsm.MissedCleavages, pwsm.AllModsOneIsNterminus, pwsm.NumFixedMods);
+                    //get the residues to change
+                    char[] originalResidues = new char[label.AdditionalLabels.Count + 1];
+                    char[] labeledResidues = new char[label.AdditionalLabels.Count + 1];
+                    originalResidues[0] = label.OriginalAminoAcid;
+                    labeledResidues[0] = label.AminoAcidLabel;
+                    for (int i = 0; i < label.AdditionalLabels.Count; i++)
+                    {
+                        originalResidues[i + 1] = label.AdditionalLabels[i].OriginalAminoAcid;
+                        labeledResidues[i + 1] = label.AdditionalLabels[i].AminoAcidLabel;
+                    }
+
+                    //label peptides
+                    foreach (PeptideWithSetModifications pwsm in originalPeptides)
+                    {
+                        //find the indexes in the base sequence for labeling
+                        char[] baseSequenceArray = pwsm.BaseSequence.ToArray();
+                        Dictionary<int, char> indexesOfResiduesToBeLabeled = new Dictionary<int, char>();
+                        for (int peptideResidueIndex = 0; peptideResidueIndex < baseSequenceArray.Length; peptideResidueIndex++)
+                        {
+                            for (int silacResidue = 0; silacResidue < originalResidues.Length; silacResidue++)
+                            {
+                                if (baseSequenceArray[peptideResidueIndex] == originalResidues[silacResidue])
+                                {
+                                    indexesOfResiduesToBeLabeled.Add(peptideResidueIndex, labeledResidues[silacResidue]);
+                                }
+                            }
+                        }
+                        //if there's something to label
+                        if (indexesOfResiduesToBeLabeled.Count != 0)
+                        {
+                            List<PeptideWithSetModifications> pwsmsForCombinatorics = new List<PeptideWithSetModifications> { pwsm };
+                            foreach (KeyValuePair<int, char> kvp in indexesOfResiduesToBeLabeled)
+                            {
+                                foreach (PeptideWithSetModifications pwsmCombination in pwsmsForCombinatorics)
+                                {
+                                    char[] combinatoricBaseSequenceArray = pwsmCombination.BaseSequence.ToArray();
+                                    combinatoricBaseSequenceArray[kvp.Key] = kvp.Value;
+                                    string updatedBaseSequence = string.Concat(combinatoricBaseSequenceArray);
+
+                                    PeptideWithSetModifications labeledPwsm = new PeptideWithSetModifications(silacEndProtein, pwsm.DigestionParams,
+                                        pwsm.OneBasedStartResidueInProtein, pwsm.OneBasedEndResidueInProtein, pwsm.CleavageSpecificityForFdrCategory,
+                                        pwsm.PeptideDescription, pwsm.MissedCleavages, pwsm.AllModsOneIsNterminus, pwsm.NumFixedMods, updatedBaseSequence);
+                                    yield return labeledPwsm; //return
+                                    pwsmsForCombinatorics.Add(labeledPwsm); //add so it can be used again
+                                }
+                            }
+                        }
+                    }
                 }
             }
+        }
+
+        /// <summary>
+        /// Generates a protein that is fully labeled with the specified silac label
+        /// </summary>
+        private Protein GenerateFullyLabeledSilacProtein(SilacLabel label)
+        {
+            string updatedBaseSequence = BaseSequence.Replace(label.OriginalAminoAcid, label.AminoAcidLabel);
+            string updatedAccession = Accession + label.MassDifference;
+            if (label.AdditionalLabels != null) //if there is more than one label per replicate (i.e both R and K were labeled in a sample before pooling)
+            {
+                foreach (SilacLabel additionalLabel in label.AdditionalLabels)
+                {
+                    updatedBaseSequence = updatedBaseSequence.Replace(additionalLabel.OriginalAminoAcid, additionalLabel.AminoAcidLabel);
+                    updatedAccession += additionalLabel.MassDifference;
+                }
+            }
+            return new Protein(this, updatedBaseSequence, updatedAccession);
         }
 
         /// <summary>

--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -34,8 +34,8 @@ namespace Proteomics.ProteolyticDigestion
         /// </summary>
         public PeptideWithSetModifications(Protein protein, DigestionParams digestionParams, int oneBasedStartResidueInProtein,
             int oneBasedEndResidueInProtein, CleavageSpecificity cleavageSpecificity, string peptideDescription, int missedCleavages,
-           Dictionary<int, Modification> allModsOneIsNterminus, int numFixedMods)
-           : base(protein, oneBasedStartResidueInProtein, oneBasedEndResidueInProtein, missedCleavages, cleavageSpecificity, peptideDescription)
+           Dictionary<int, Modification> allModsOneIsNterminus, int numFixedMods, string baseSequence = null)
+           : base(protein, oneBasedStartResidueInProtein, oneBasedEndResidueInProtein, missedCleavages, cleavageSpecificity, peptideDescription, baseSequence)
         {
             _allModsOneIsNterminus = allModsOneIsNterminus;
             NumFixedMods = numFixedMods;

--- a/Proteomics/ProteolyticDigestion/ProteolyticPeptide.cs
+++ b/Proteomics/ProteolyticDigestion/ProteolyticPeptide.cs
@@ -13,7 +13,7 @@ namespace Proteomics.ProteolyticDigestion
     {
         protected string _baseSequence;
 
-        internal ProteolyticPeptide(Protein protein, int oneBasedStartResidueInProtein, int oneBasedEndResidueInProtein, int missedCleavages, CleavageSpecificity cleavageSpecificityForFdrCategory, string peptideDescription = null)
+        internal ProteolyticPeptide(Protein protein, int oneBasedStartResidueInProtein, int oneBasedEndResidueInProtein, int missedCleavages, CleavageSpecificity cleavageSpecificityForFdrCategory, string peptideDescription = null, string baseSequence = null)
         {
             _protein = protein;
             OneBasedStartResidueInProtein = oneBasedStartResidueInProtein;
@@ -21,6 +21,7 @@ namespace Proteomics.ProteolyticDigestion
             MissedCleavages = missedCleavages;
             CleavageSpecificityForFdrCategory = cleavageSpecificityForFdrCategory;
             PeptideDescription = peptideDescription;
+            _baseSequence = baseSequence;
         }
 
         [NonSerialized] private Protein _protein; // protein that this peptide is a digestion product of

--- a/Test/TestModifications.cs
+++ b/Test/TestModifications.cs
@@ -129,11 +129,14 @@ namespace Test
         {
             Protein originalProtein = new Protein("ACDEFGHIKAKAK", "TEST");
             List<PeptideWithSetModifications> originalDigest = originalProtein.Digest(new DigestionParams(), new List<Modification>(), new List<Modification>()).ToList();
+
             //Multiple SILAC labels
             Residue lysine = Residue.GetResidue('K');
+            Residue arginine = Residue.GetResidue('R');
             Residue heavyLabel = new Residue("heavy", 'a', "aaa", ChemicalFormula.ParseFormula("C{13}6H12N2O"), ModificationSites.All); //Lysine +6
             Residue heavierLabel = new Residue("heavier", 'b', "bbb", ChemicalFormula.ParseFormula("C{13}6H12N{15}2O"), ModificationSites.All); //Lysine +8
-            List<Residue> residuesToAdd = new List<Residue> { heavyLabel, heavierLabel };
+            Residue heavyArginine = new Residue("heavyR", 'c', "ccc", ChemicalFormula.ParseFormula("C{13}6H5N{15}4O"), ModificationSites.All); //Arginine +10
+            List<Residue> residuesToAdd = new List<Residue> { heavyLabel, heavierLabel, heavyArginine };
             Residue.AddNewResiduesToDictionary(residuesToAdd);
             List<SilacLabel> silacLabels = new List<SilacLabel>
             {
@@ -166,7 +169,41 @@ namespace Test
             Assert.IsTrue(silacLabels[0].AdditionalLabels.Count == 2);
             silacDigest = originalProtein.Digest(new DigestionParams(), new List<Modification>(), new List<Modification>(), silacLabels).ToList();
             Assert.IsTrue(silacDigest.Count == 9);
+
+            //Turnover
+            silacLabels = new List<SilacLabel>
+            {
+                new SilacLabel('K','b', heavierLabel.ThisChemicalFormula.Formula, heavierLabel.MonoisotopicMass - lysine.MonoisotopicMass)
+            };
+            silacDigest = originalProtein.Digest(new DigestionParams(), new List<Modification>(), new List<Modification>(), silacLabels, (null, silacLabels[0])).ToList();
+            Assert.IsTrue(silacDigest.Count == 14);
+            silacDigest = originalProtein.Digest(new DigestionParams(), new List<Modification>(), new List<Modification>(), silacLabels, (silacLabels[0], null)).ToList();
+            Assert.IsTrue(silacDigest.Count == 14);
+
+            silacLabels = new List<SilacLabel>
+            {
+                new SilacLabel('K','a', heavyLabel.ThisChemicalFormula.Formula, heavyLabel.MonoisotopicMass - lysine.MonoisotopicMass),
+                new SilacLabel('K','b', heavierLabel.ThisChemicalFormula.Formula, heavierLabel.MonoisotopicMass - lysine.MonoisotopicMass)
+            };
+            silacDigest = originalProtein.Digest(new DigestionParams(generateUnlabeledProteinsForSilac: false), new List<Modification>(), new List<Modification>(), silacLabels, (silacLabels[1], silacLabels[0])).ToList();
+            Assert.IsTrue(silacDigest.Count == 14);
+
+            originalProtein = new Protein("ACDEFGHIKARAK", "TEST");
+            silacLabels[1].AddAdditionalSilacLabel(new SilacLabel('R', 'c', heavyArginine.ThisChemicalFormula.Formula, heavyArginine.MonoisotopicMass - arginine.MonoisotopicMass));
+            silacDigest = originalProtein.Digest(new DigestionParams(generateUnlabeledProteinsForSilac: false), new List<Modification>(), new List<Modification>(), silacLabels, (silacLabels[1], silacLabels[0])).ToList();
+            Assert.IsTrue(silacDigest.Count == 14);
+
+            silacLabels = new List<SilacLabel>
+            {
+                new SilacLabel('K','a', heavyLabel.ThisChemicalFormula.Formula, heavyLabel.MonoisotopicMass - lysine.MonoisotopicMass),
+                new SilacLabel('K','b', heavierLabel.ThisChemicalFormula.Formula, heavierLabel.MonoisotopicMass - lysine.MonoisotopicMass)
+            };
+            silacLabels[0].AddAdditionalSilacLabel(new SilacLabel('R', 'c', heavyArginine.ThisChemicalFormula.Formula, heavyArginine.MonoisotopicMass - arginine.MonoisotopicMass));
+            silacDigest = originalProtein.Digest(new DigestionParams(generateUnlabeledProteinsForSilac: false), new List<Modification>(), new List<Modification>(), silacLabels, (silacLabels[1], silacLabels[0])).ToList();
+            Assert.IsTrue(silacDigest.Count == 14);
         }
+
+
 
         [Test]
         public void ModificationCollectionTest()


### PR DESCRIPTION
Needed for turnover experiments because of amino acid recycling: https://www.hindawi.com/journals/ijcb/2015/798936/