### PR TITLE
non-static thermo dynamic connection

### DIFF
--- a/FlashLFQ/PeakIndexingEngine.cs
+++ b/FlashLFQ/PeakIndexingEngine.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using ThermoRawFileReader;
 
 namespace FlashLFQ
 {
@@ -75,18 +76,18 @@ namespace FlashLFQ
             else if (ext == ".RAW")
             {
                 var tempList = new List<MsDataScan>();
+                ThermoDynamicData dynamicConnection = null;
 
                 try
                 {
-                    ThermoRawFileReader.ThermoRawFileReaderData.InitiateDynamicConnection(fileInfo.FullFilePathWithExtension);
-                    
+                    dynamicConnection = new ThermoDynamicData(fileInfo.FullFilePathWithExtension);
+
                     // use thermo dynamic connection to get the ms1 scans and then dispose of the connection
-                    int[] msOrders = ThermoRawFileReader.ThermoRawFileReaderData.GetMsOrdersByScanInDynamicConnection();
-                    for (int i = 0; i < msOrders.Length; i++)
+                    for (int i = 0; i < dynamicConnection.MsOrdersByScan.Length; i++)
                     {
-                        if (msOrders[i] == 1)
+                        if (dynamicConnection.MsOrdersByScan[i] == 1)
                         {
-                            tempList.Add(ThermoRawFileReader.ThermoRawFileReaderData.GetOneBasedScanFromDynamicConnection(i + 1));
+                            tempList.Add(dynamicConnection.GetOneBasedScanFromDynamicConnection(i + 1));
                         }
                         else
                         {
@@ -94,11 +95,14 @@ namespace FlashLFQ
                         }
                     }
 
-                    ThermoRawFileReader.ThermoRawFileReaderData.CloseDynamicConnection();
+                    dynamicConnection.CloseDynamicConnection();
                 }
                 catch (FileNotFoundException)
                 {
-                    ThermoRawFileReader.ThermoRawFileReaderData.CloseDynamicConnection();
+                    if (dynamicConnection != null)
+                    {
+                        dynamicConnection.CloseDynamicConnection();
+                    }
 
                     if (!silent)
                     {
@@ -109,7 +113,10 @@ namespace FlashLFQ
                 }
                 catch (Exception e)
                 {
-                    ThermoRawFileReader.ThermoRawFileReaderData.CloseDynamicConnection();
+                    if (dynamicConnection != null)
+                    {
+                        dynamicConnection.CloseDynamicConnection();
+                    }
 
                     if (!silent)
                     {

--- a/MassSpectrometry/MsDataScan.cs
+++ b/MassSpectrometry/MsDataScan.cs
@@ -57,7 +57,7 @@ namespace MassSpectrometry
         /// </summary>
         public MzSpectrum MassSpectrum { get; protected set; }
 
-        public int OneBasedScanNumber { get; }
+        public int OneBasedScanNumber { get; private set; }
         public int MsnOrder { get; }
         public double RetentionTime { get; }
         public Polarity Polarity { get; }
@@ -190,6 +190,11 @@ namespace MassSpectrometry
         public void SetOneBasedPrecursorScanNumber(int value)
         {
             this.OneBasedPrecursorScanNumber = value;
+        }
+
+        public void SetOneBasedScanNumber(int value)
+        {
+            this.OneBasedScanNumber = value;
         }
 
         private IEnumerable<double> GetNoiseDataMass(double[,] noiseData)

--- a/Test/TestRawFileReader.cs
+++ b/Test/TestRawFileReader.cs
@@ -43,20 +43,28 @@ namespace Test
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "DataFiles", "small.raw");
+            var path1 = Path.Combine(TestContext.CurrentContext.TestDirectory, "DataFiles", "small.raw");
+            var dynamicConnection1 = new ThermoDynamicData(path1);
 
-            var dynamicConnection = new ThermoDynamicData(path);
+            var path2 = Path.Combine(TestContext.CurrentContext.TestDirectory, "DataFiles", "testFileWMS2.raw");
+            var dynamicConnection2 = new ThermoDynamicData(path2);
 
-            var msOrders = dynamicConnection.MsOrdersByScan;
+            var msOrders = dynamicConnection1.MsOrdersByScan;
             Assert.That(msOrders != null && msOrders.Length > 0);
 
-            var a = dynamicConnection.GetOneBasedScanFromDynamicConnection(1);
+            var a = dynamicConnection1.GetOneBasedScanFromDynamicConnection(1);
             Assert.That(a != null);
 
-            a = dynamicConnection.GetOneBasedScanFromDynamicConnection(10000);
+            a = dynamicConnection1.GetOneBasedScanFromDynamicConnection(10000);
             Assert.That(a == null);
 
-            dynamicConnection.CloseDynamicConnection();
+            var b = dynamicConnection2.GetOneBasedScanFromDynamicConnection(1);
+            Assert.That(b != null);
+
+            Assert.That(a.MassSpectrum.XArray.Length != b.MassSpectrum.XArray.Length);
+
+            dynamicConnection1.CloseDynamicConnection();
+            dynamicConnection2.CloseDynamicConnection();
             
             Console.WriteLine($"Analysis time for TestDynamicConnectionRawFileReader: {stopwatch.Elapsed.Hours}h {stopwatch.Elapsed.Minutes}m {stopwatch.Elapsed.Seconds}s");
         }

--- a/Test/TestRawFileReader.cs
+++ b/Test/TestRawFileReader.cs
@@ -54,14 +54,14 @@ namespace Test
 
             var a = dynamicConnection1.GetOneBasedScanFromDynamicConnection(1);
             Assert.That(a != null);
-
-            a = dynamicConnection1.GetOneBasedScanFromDynamicConnection(10000);
-            Assert.That(a == null);
-
+            
             var b = dynamicConnection2.GetOneBasedScanFromDynamicConnection(1);
             Assert.That(b != null);
 
             Assert.That(a.MassSpectrum.XArray.Length != b.MassSpectrum.XArray.Length);
+
+            a = dynamicConnection1.GetOneBasedScanFromDynamicConnection(10000);
+            Assert.That(a == null);
 
             dynamicConnection1.CloseDynamicConnection();
             dynamicConnection2.CloseDynamicConnection();

--- a/Test/TestRawFileReader.cs
+++ b/Test/TestRawFileReader.cs
@@ -45,18 +45,18 @@ namespace Test
 
             var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "DataFiles", "small.raw");
 
-            ThermoRawFileReaderData.InitiateDynamicConnection(path);
+            var dynamicConnection = new ThermoDynamicData(path);
 
-            var msOrders = ThermoRawFileReaderData.GetMsOrdersByScanInDynamicConnection();
+            var msOrders = dynamicConnection.MsOrdersByScan;
             Assert.That(msOrders != null && msOrders.Length > 0);
 
-            var a = ThermoRawFileReaderData.GetOneBasedScanFromDynamicConnection(1);
+            var a = dynamicConnection.GetOneBasedScanFromDynamicConnection(1);
             Assert.That(a != null);
 
-            a = ThermoRawFileReaderData.GetOneBasedScanFromDynamicConnection(10000);
+            a = dynamicConnection.GetOneBasedScanFromDynamicConnection(10000);
             Assert.That(a == null);
-            
-            ThermoRawFileReaderData.CloseDynamicConnection();
+
+            dynamicConnection.CloseDynamicConnection();
             
             Console.WriteLine($"Analysis time for TestDynamicConnectionRawFileReader: {stopwatch.Elapsed.Hours}h {stopwatch.Elapsed.Minutes}m {stopwatch.Elapsed.Seconds}s");
         }

--- a/ThermoRawFileReader/ThermoDynamicData.cs
+++ b/ThermoRawFileReader/ThermoDynamicData.cs
@@ -1,0 +1,112 @@
+﻿using MassSpectrometry;
+using MzLibUtil;
+using System.IO;
+using System.Linq;
+using ThermoFisher.CommonCore.Data.Business;
+using ThermoFisher.CommonCore.Data.Interfaces;
+using ThermoFisher.CommonCore.RawFileReader;
+using UsefulProteomicsDatabases;
+
+namespace ThermoRawFileReader
+{
+    public class ThermoDynamicData
+    {
+        private IRawDataPlus dynamicConnection;
+        public readonly int[] MsOrdersByScan;
+
+        public ThermoDynamicData(string filePath)
+        {
+            InitiateDynamicConnection(filePath);
+            MsOrdersByScan = GetMsOrdersByScanInDynamicConnection();
+        }
+
+        /// <summary>
+        /// Gets all the MS orders of all scans in a dynamic connection. This is useful if you want to open all MS1 scans
+        /// without loading all of the other MSn scans.
+        /// </summary>
+        private int[] GetMsOrdersByScanInDynamicConnection()
+        {
+            if (dynamicConnection != null)
+            {
+                int lastSpectrum = dynamicConnection.RunHeaderEx.LastSpectrum;
+                var scanEvents = dynamicConnection.GetScanEvents(1, lastSpectrum);
+
+                int[] msorders = scanEvents.Select(p => (int)p.MSOrder).ToArray();
+
+                return msorders;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Initiates a dynamic connection with a Thermo .raw file. Data can be "streamed" instead of loaded all at once. Use 
+        /// GetOneBasedScanFromDynamicConnection to get data from a particular scan. Use CloseDynamicConnection to close the 
+        /// dynamic connection after all desired data has been retrieved from the dynamic connection.
+        /// </summary>
+        private void InitiateDynamicConnection(string filePath)
+        {
+            Loaders.LoadElements();
+
+            if (dynamicConnection != null)
+            {
+                dynamicConnection.Dispose();
+            }
+
+            dynamicConnection = RawFileReaderAdapter.FileFactory(filePath);
+
+            if (!File.Exists(filePath))
+            {
+                throw new FileNotFoundException();
+            }
+
+            if (!dynamicConnection.IsOpen)
+            {
+                throw new MzLibException("Unable to access RAW file!");
+            }
+
+            if (dynamicConnection.IsError)
+            {
+                throw new MzLibException("Error opening RAW file!");
+            }
+
+            if (dynamicConnection.InAcquisition)
+            {
+                throw new MzLibException("RAW file still being acquired!");
+            }
+
+            dynamicConnection.SelectInstrument(Device.MS, 1);
+            GetMsOrdersByScanInDynamicConnection();
+        }
+
+        /// <summary>
+        /// Allows access to a .raw file one scan at a time via an open dynamic connection. Returns null if the raw file does not contain the 
+        /// scan number specified. Use InitiateDynamicConnection to open a dynamic connection before using this method.
+        /// </summary>
+        public MsDataScan GetOneBasedScanFromDynamicConnection(int oneBasedScanNumber, IFilteringParams filterParams = null)
+        {
+            if (dynamicConnection == null)
+            {
+                throw new MzLibException("The dynamic connection has not been created yet!");
+            }
+
+            if (oneBasedScanNumber > dynamicConnection.RunHeaderEx.LastSpectrum || oneBasedScanNumber < dynamicConnection.RunHeaderEx.FirstSpectrum)
+            {
+                return null;
+            }
+
+            return ThermoRawFileReaderData.GetOneBasedScan(dynamicConnection, filterParams, oneBasedScanNumber);
+        }
+
+        /// <summary>
+        /// Disposes of the dynamic connection, if one is open.
+        /// </summary>
+        public void CloseDynamicConnection()
+        {
+            if (dynamicConnection != null)
+            {
+                dynamicConnection.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
the old code I wrote had static methods to access Thermo data dynamically. This meant that you could only have one dynamic connection open at a time. This code removes the static stuff. So you can have dynamic connections to multiple Thermo files open at once