### PR TITLE
Fix Variant Psm Crash

### DIFF
--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -622,7 +622,7 @@ namespace Proteomics.ProteolyticDigestion
                     .Where(kv => kv.Key == 1 && applied.OneBasedBeginPosition == 1 || applied.OneBasedBeginPosition <= kv.Key - 2 + OneBasedStartResidueInProtein && kv.Key - 2 + OneBasedStartResidueInProtein <= applied.OneBasedEndPosition)
                     .ToDictionary(kv => kv.Key - applied.OneBasedBeginPosition + (modResidueScale), kv => kv.Value);
                 PeptideWithSetModifications variantWithAnyMods = new PeptideWithSetModifications(Protein, DigestionParams, applied.OneBasedBeginPosition == 1 ? applied.OneBasedBeginPosition : applied.OneBasedBeginPosition - 1, applied.OneBasedEndPosition, CleavageSpecificityForFdrCategory, PeptideDescription, MissedCleavages, modsOnVariantOneIsNTerm, NumFixedMods);
-                return $"{applied.OriginalSequence}{applied.OneBasedBeginPosition}{variantWithAnyMods.FullSequence.Substring(startAtNTerm ? 0 : 1)}";
+                return $"{applied.OriginalSequence}{applied.OneBasedBeginPosition}{variantWithAnyMods.FullSequence.Substring(applied.OneBasedBeginPosition == 1 ? 0 : 1)}";
             }
             //if the variant caused a cleavage site leading the the peptide sequence (variant does not intersect but is identified)
             else

--- a/Test/TestPeptideWithSetMods.cs
+++ b/Test/TestPeptideWithSetMods.cs
@@ -607,6 +607,13 @@ namespace Test
             PeptideWithSetModifications pepe3 = new PeptideWithSetModifications(protein, new DigestionParams(), 2, 9, CleavageSpecificity.Unknown, "", 0, new Dictionary<int, Modification>(), 0);
             SequenceVariation svvvv = new SequenceVariation(7, 10, "GHM", "GHIK", ""); // insertion
             Assert.AreEqual("GHM7GHIK", pepe3.SequenceVariantString(svvvv, true));
+
+            Protein protein2 = new Protein("WACDEFGHIK", "test");
+
+            //variant starts at protein start but peptide does not
+            PeptideWithSetModifications pepe4 = new PeptideWithSetModifications(protein2, new DigestionParams(), 4, 8, CleavageSpecificity.Unknown, "", 0, new Dictionary<int, Modification>(), 0);
+            SequenceVariation variant = new SequenceVariation(1, 10, "MABCDEFGHIJKLMNOP", "WACDEFGHIK", ""); // frameshift
+            Assert.AreEqual("MABCDEFGHIJKLMNOP1WACDEFGHIK", pepe4.SequenceVariantString(variant, true));
         }
 
         [Test]


### PR DESCRIPTION
Variants that started at 1 residue of protein, but the peptide containing the variant did not start at the N-terminal residue was causing a crash. This is now fixed and is tested. (specific case causing the original crash was a frameshift variant)