### PR TITLE
nterminal protease bug fix

### DIFF
--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -561,15 +561,22 @@ namespace Proteomics.ProteolyticDigestion
                             //get the AA that follows the peptide sequence fromt he variant protein (AKA the first AA of the varaint)
                             PeptideWithSetModifications nextAA_Variant = new PeptideWithSetModifications(Protein, DigestionParams, OneBasedEndResidueInProtein + 1, OneBasedEndResidueInProtein + 1, CleavageSpecificity.Full, "full", 0, AllModsOneIsNterminus, NumFixedMods);
 
-                            // get the AA that follows the peptide sequence in the original protein (without any applied variants)
-                            PeptideWithSetModifications nextAA_Original = new PeptideWithSetModifications(Protein.NonVariantProtein, DigestionParams, (OneBasedEndResidueInProtein + 1) - totalLengthDifference, (OneBasedEndResidueInProtein + 1) - totalLengthDifference, CleavageSpecificity.Full, "full", 0, AllModsOneIsNterminus, NumFixedMods);
-                            bool newSite = nTerminalResidue.Contains(nextAA_Variant.BaseSequence);
-                            bool oldSite = nTerminalResidue.Contains(nextAA_Original.BaseSequence);
-                            // if the new AA causes a cleavage event, and that cleavage event would not have occurred without the variant then it is identified
-                            if (newSite == true && oldSite == false)
+                            // checks to make sure the original protein has an amino acid following the peptide (an issue with stop loss variants or variatns that add AA after the previous stop residue)
+                            // no else statement because if the peptide end residue was the previous protein stop site, there is no way to truly identify the variant. 
+                            // if the peptide were to extend into the stop loss region then the peptide would intesect the variant and this code block would not be triggered.
+                            if (Protein.NonVariantProtein.Length >= OneBasedEndResidueInProtein + 1)
                             {
-                                identifies = true;
+                                // get the AA that follows the peptide sequence in the original protein (without any applied variants)
+                                PeptideWithSetModifications nextAA_Original = new PeptideWithSetModifications(Protein.NonVariantProtein, DigestionParams, (OneBasedEndResidueInProtein + 1) - totalLengthDifference, (OneBasedEndResidueInProtein + 1) - totalLengthDifference, CleavageSpecificity.Full, "full", 0, AllModsOneIsNterminus, NumFixedMods);
+                                bool newSite = nTerminalResidue.Contains(nextAA_Variant.BaseSequence);
+                                bool oldSite = nTerminalResidue.Contains(nextAA_Original.BaseSequence);
+                                // if the new AA causes a cleavage event, and that cleavage event would not have occurred without the variant then it is identified
+                                if (newSite == true && oldSite == false)
+                                {
+                                    identifies = true;
+                                }
                             }
+
                         }
                         //for stop gain varations that cause peptide
                         else

--- a/Test/TestPeptideWithSetMods.cs
+++ b/Test/TestPeptideWithSetMods.cs
@@ -647,10 +647,13 @@ namespace Test
                 new Protein("MPEPTIDE", "protein11", sequenceVariations: new List<SequenceVariation> { new SequenceVariation(5, 5, "T", "*", @"1\t50000000\t.\tA\tG\t.\tPASS\tANN=G||||||||||||||||\tGT:AD:DP\t1/1:30,30:30", null) }), //stop-gain (can identify)
                 new Protein("MPEKTIDE", "protein12", sequenceVariations: new List<SequenceVariation> { new SequenceVariation(5, 5, "T", "*", @"1\t50000000\t.\tA\tG\t.\tPASS\tANN=G||||||||||||||||\tGT:AD:DP\t1/1:30,30:30", null) }), //stop-gain (can't identify)
                 new Protein("MPEPTIPEPEPTIPE", "protein13", sequenceVariations: new List<SequenceVariation> { new SequenceVariation(7, 7, "P", "D", @"1\t50000000\t.\tA\tG\t.\tPASS\tANN=G||||||||||||||||\tGT:AD:DP\t1/1:30,30:30", null) }),
+                new Protein("MPEPTIDE", "protein14", sequenceVariations: new List<SequenceVariation> { new SequenceVariation(8, 9, "E", "EK", @"1\t50000000\t.\tA\tG\t.\tPASS\tANN=G||||||||||||||||\tGT:AD:DP\t1/1:30,30:30", null) }), //peptide becomes longer, and cleavage site is created but cannot be identified
+                new Protein("MPEPTIDE", "protein15", sequenceVariations: new List<SequenceVariation> { new SequenceVariation(9, 13, "*", "KMPEP", @"1\t50000000\t.\tA\tG\t.\tPASS\tANN=G||||||||||||||||\tGT:AD:DP\t1/1:30,30:30", null) }), // stop loss at end of original protein that cannot be identified
             };
 
             DigestionParams dp = new DigestionParams(minPeptideLength: 2);
             DigestionParams dp2 = new DigestionParams(protease: "Asp-N", minPeptideLength: 2);
+            DigestionParams dp3 = new DigestionParams(protease: "Lys-N", minPeptideLength: 2);
 
             var protein0_variant = proteins.ElementAt(0).GetVariantProteins().ElementAt(0);
             var protein1_variant = proteins.ElementAt(1).GetVariantProteins().ElementAt(0);
@@ -666,6 +669,8 @@ namespace Test
             var protein11_variant = proteins.ElementAt(11).GetVariantProteins().ElementAt(0);
             var protein12_variant = proteins.ElementAt(12).GetVariantProteins().ElementAt(0);
             var protein13_variant = proteins.ElementAt(13).GetVariantProteins().ElementAt(0);
+            var protein14_variant = proteins.ElementAt(14).GetVariantProteins().ElementAt(0);
+            var protein15_variant = proteins.ElementAt(15).GetVariantProteins().ElementAt(0);
 
             List<Modification> digestMods = new List<Modification>();
 
@@ -685,6 +690,8 @@ namespace Test
             var protein11_peptide2 = protein11_variant.Digest(dp, digestMods, digestMods).ElementAt(0);
             var protein12_peptide = protein12_variant.Digest(dp, digestMods, digestMods).ElementAt(0);
             var protein13_peptide = protein13_variant.Digest(dp2, digestMods, digestMods).ElementAt(0);
+            var protein14_peptide = protein14_variant.Digest(dp3, digestMods, digestMods).ElementAt(0);
+            var protein15_peptide = protein15_variant.Digest(dp3, digestMods, digestMods).ElementAt(0);
 
             Assert.AreEqual((true, true), protein0_peptide.IntersectsAndIdentifiesVariation(protein0_variant.AppliedSequenceVariations.ElementAt(0)));
             Assert.AreEqual((true, true), protein0_peptide2.IntersectsAndIdentifiesVariation(protein0_variant.AppliedSequenceVariations.ElementAt(0)));
@@ -702,6 +709,8 @@ namespace Test
             Assert.AreEqual((false, true), protein11_peptide2.IntersectsAndIdentifiesVariation(protein11_variant.AppliedSequenceVariations.ElementAt(0)));
             Assert.AreEqual((false, false), protein12_peptide.IntersectsAndIdentifiesVariation(protein12_variant.AppliedSequenceVariations.ElementAt(0)));
             Assert.AreEqual((false, true), protein13_peptide.IntersectsAndIdentifiesVariation(protein13_variant.AppliedSequenceVariations.ElementAt(0)));
+            Assert.AreEqual((true, false), protein14_peptide.IntersectsAndIdentifiesVariation(protein14_variant.AppliedSequenceVariations.ElementAt(0)));// the peptide crosses the variant but the newly genrated cleavage site makes the same peptide as without the variant
+            Assert.AreEqual((false, false), protein15_peptide.IntersectsAndIdentifiesVariation(protein15_variant.AppliedSequenceVariations.ElementAt(0)));// the peptide does not cross the variant, and the stop loss adds addition amino acids, but it creates the same peptide as without the variant
 
             Assert.AreEqual("P4V", protein0_peptide.SequenceVariantString(protein0_variant.AppliedSequenceVariations.ElementAt(0), true));
             Assert.AreEqual("P4V", protein0_peptide2.SequenceVariantString(protein0_variant.AppliedSequenceVariations.ElementAt(0), true));


### PR DESCRIPTION
if the variant occurs at the previous end of the protein, and the variant adds on additional amino acids that cause N terminal cleavage. The original protein will be shorter than peptide +1. These peptides cannot be identified as variant because there is no way to tell if the protein ends  therefore causing the peptide or if the variant exists causing the same peptide sequence.