### PR TITLE
changeHyprLinkForPsiModOboXmlToLocalSmithForkTemporarily

### DIFF
--- a/UsefulProteomicsDatabases/Loaders.cs
+++ b/UsefulProteomicsDatabases/Loaders.cs
@@ -174,7 +174,7 @@ namespace UsefulProteomicsDatabases
         {
             using (WebClient Client = new WebClient())
             {
-                Client.DownloadFile(@"https://raw.githubusercontent.com/HUPO-PSI/psi-mod-CV/master/PSI-MOD.obo.xml", psimodLocation + ".temp");
+                Client.DownloadFile(@"https://github.com/smith-chem-wisc/psi-mod-CV/blob/master/PSI-MOD.obo.xml?raw=true", psimodLocation + ".temp");
             }
         }
 


### PR DESCRIPTION
the fine folks at https://github.com/HUPO-PSI/psi-mod-CV decided to depracate the obo.xml file that mzlib uses. This broke several unit tests related to database reading. A temporary fix for this was to fork the version of their repol that contained the need xml file in the smith-chem-wisc. I did that and now mzlib referes to that file. 

However, if we want to maintain the ability to use psi-mod, then we'll need to read their new version in "OWL/RDF" format.