### PR TITLE
Update proteases.tsv to match the same file in MetaMorpheus

### DIFF
--- a/Proteomics/ProteolyticDigestion/proteases.tsv
+++ b/Proteomics/ProteolyticDigestion/proteases.tsv
@@ -4,6 +4,7 @@ Asp-N	|D			full	MS:1001304	Asp-N	(?=[BD])
 chymotrypsin (don't cleave before proline)	"F[P]|,W[P]|,Y[P]|"			full	MS:1001306	Chymotrypsin	(?<=[FYWL])(?!P)	
 chymotrypsin (cleave before proline)	"F|,W|,Y|"			full	MS:1001306	Chymotrypsin	(?<=[FYWL])	
 CNBr	M|			full	MS:1001307	CNBr	(?<=M)	
+elastase	A|,V|,S|,G|,L|,I|			full		Elastase	(?<=[AVSGLI])	
 Glu-C	E|			full				
 Glu-C (with asp)	"E|,D|"			full				
 Lys-C (don't cleave before proline)	K[P]|			full	MS:1001309	Lys-C	(?<=K)(?!P)	
@@ -16,4 +17,6 @@ non-specific	X|			full	MS:1001956	unspecific cleavage
 top-down				none	MS:1001955	no cleavage		
 singleN				SingleN	MS:1001957	single cleavage		
 singleC				SingleC	MS:1001958	single cleavage		
+peptidomics				none		no cleavage		
 collagenase	GPX|GPX			full				
+StcE-trypsin	TX|T,TX|S,SX|T,SX|S,K|,R|			full		StcE/Trpsin		


### PR DESCRIPTION
Discovered today that the mzlib file was missing elastase, peptidomics and StcE-trypsin. I added those three proteases from the MetaMorpheus file to maintain consistency. 