### PR TITLE
Increase buffer so write mzML doesn't crash on files with line length…

### DIFF
--- a/MzML/MzmlMethods.cs
+++ b/MzML/MzmlMethods.cs
@@ -1155,7 +1155,7 @@ namespace IO.MzML
                 using (StreamReader reader = new StreamReader(stream, bufferSize: 4096))
                 {
                     string line;
-                    byte[] buffer = new byte[1000000];
+                    byte[] buffer = new byte[2000000];
                     bool foundChecksumField = false;
 
                     while (reader.Peek() > 0 && !foundChecksumField)

--- a/MzML/MzmlMethods.cs
+++ b/MzML/MzmlMethods.cs
@@ -1155,7 +1155,7 @@ namespace IO.MzML
                 using (StreamReader reader = new StreamReader(stream, bufferSize: 4096))
                 {
                     string line;
-                    byte[] buffer = new byte[2000000];
+                    byte[] buffer = new byte[10000000]; //write mzML method will crash is line.Length exceeds this value.
                     bool foundChecksumField = false;
 
                     while (reader.Peek() > 0 && !foundChecksumField)


### PR DESCRIPTION
… exceed 1000000