### PR TITLE
Edits to dissociation type

### DIFF
--- a/MassSpectrometry/Enums/DissociationType.cs
+++ b/MassSpectrometry/Enums/DissociationType.cs
@@ -20,12 +20,15 @@ namespace MassSpectrometry
 {
     public enum DissociationType
     {
+        // see https://github.com/HUPO-PSI/psi-ms-CV/blob/master/psi-ms.obo for PSI-MS list of dissociation types
+        // search for "is_a: MS:1000044 ! dissociation method"
+
         Unknown = -1,
 
         // The values below are identical to thermo names
         CID = 0, // MS:1000133 collision-induced dissociation
 
-        IRMPD = 1, // MS:1000435 photodissociation
+        IRMPD = 1, // MS:1000262 infrared multiphoton dissociation
         ECD = 2, // MS:1000250 electron capture dissociation
         PQD = 3, // MS:1000599 pulsed q dissociation
         ETD = 4, // MS:1000598 electron transfer dissociation
@@ -42,5 +45,10 @@ namespace MassSpectrometry
         // The values above are identical to thermo names
 
         //ISCID = 11
+        MPD = 12, // MS:1000435 photodissociation
+
+        // this is used to indicate that the dissociation type in the scan header should be used
+        // in MetaMorpheus instead of having a fixed dissociation type
+        Autodetect = 13
     }
 }

--- a/MassSpectrometry/Enums/DissociationType.cs
+++ b/MassSpectrometry/Enums/DissociationType.cs
@@ -18,37 +18,105 @@
 
 namespace MassSpectrometry
 {
+    /// <summary>
+    /// See https://github.com/HUPO-PSI/psi-ms-CV/blob/master/psi-ms.obo for PSI-MS list of dissociation types.
+    /// search for "is_a: MS:1000044 ! dissociation method" and "is_a: MS:1000422 ! beam-type collision-induced dissociation"
+    /// </summary>
     public enum DissociationType
     {
-        // see https://github.com/HUPO-PSI/psi-ms-CV/blob/master/psi-ms.obo for PSI-MS list of dissociation types
-        // search for "is_a: MS:1000044 ! dissociation method"
+        /// <summary>
+        /// id: MS:1000133 collision-induced dissociation
+        /// </summary>
+        CID,
 
-        Unknown = -1,
+        /// <summary>
+        /// id: MS:1000134 plasma desorption
+        /// </summary>
+        PD,
 
-        // The values below are identical to thermo names
-        CID = 0, // MS:1000133 collision-induced dissociation
+        /// <summary>
+        /// id: MS:1000135 post-source decay
+        /// </summary>
+        PSD,
 
-        IRMPD = 1, // MS:1000262 infrared multiphoton dissociation
-        ECD = 2, // MS:1000250 electron capture dissociation
-        PQD = 3, // MS:1000599 pulsed q dissociation
-        ETD = 4, // MS:1000598 electron transfer dissociation
-        HCD = 5, // MS:1002481 higher energy beam-type collision-induced dissociation
+        /// <summary>
+        /// id: MS:1000136 surface-induced dissociation
+        /// </summary>
+        SID,
 
-        AnyActivationType = 6,
+        /// <summary>
+        /// id: MS:1000242 blackbody infrared radiative dissociation
+        /// </summary>
+        BIRD,
 
-        EThcD = 7, // MS:1002631 Electron-Transfer/Higher-Energy Collision Dissociation (EThcD)
-        Custom = 8,
+        /// <summary>
+        /// MS:1000250 electron capture dissociation
+        /// </summary>
+        ECD,
 
-        ISCID = 9,
-        LowCID = 10,
-        //NPTR = 10,
-        // The values above are identical to thermo names
+        /// <summary>
+        /// MS:1000262 infrared multiphoton dissociation
+        /// </summary>
+        IRMPD,
 
-        //ISCID = 11
-        MPD = 12, // MS:1000435 photodissociation
+        /// <summary>
+        /// id: MS:1000282 sustained off-resonance irradiation
+        /// </summary>
+        SORI,
 
-        // this is used to indicate that the dissociation type in the scan header should be used
-        // in MetaMorpheus instead of having a fixed dissociation type
-        Autodetect = 13
+        /// <summary>
+        /// MS:1000435 photodissociation
+        /// </summary>
+        MPD,
+
+        /// <summary>
+        /// MS:1000598 electron transfer dissociation
+        /// </summary>
+        ETD,
+
+        /// <summary>
+        /// MS:1000599 pulsed q dissociation
+        /// </summary>
+        PQD,
+
+        /// <summary>
+        /// id: MS:1001880 in-source collision-induced dissociation
+        /// </summary>
+        ISCID,
+
+        /// <summary>
+        /// MS:1000422 beam-type collision-induced dissociation
+        /// </summary>
+        HCD,
+
+        /// <summary>
+        /// MS:1002631 Electron-Transfer/Higher-Energy Collision Dissociation (EThcD)
+        /// </summary>
+        EThcD,
+
+        /// <summary>
+        /// ultraviolet photodissociation
+        /// </summary>
+        UVPD,
+
+        /// <summary>
+        /// negative-mode electron transfer dissociation
+        /// </summary>
+        NETD,
+
+        /// <summary>
+        /// low-resolution (ion-trap) CID
+        /// </summary>
+        LowCID,
+
+        Unknown,
+        AnyActivationType,
+        Custom,
+        
+        /// <summary>
+        /// Placeholder used to communicate to MetaMorpheus that the dissociation type 
+        /// should be taken from the scan header instead of using a fixed, constant dissociation type
+        /// </summary>
+        Autodetect
     }
 }

--- a/MzML/Mzml.cs
+++ b/MzML/Mzml.cs
@@ -57,33 +57,60 @@ namespace IO.MzML
         private const string _intensityArray = "MS:1000515";
         private static readonly Regex MZAnalyzerTypeRegex = new Regex(@"^[a-zA-Z]*", RegexOptions.Compiled);
 
-        private static readonly Dictionary<string, Polarity> polarityDictionary = new Dictionary<string, Polarity>
+        public static readonly Dictionary<string, Polarity> PolarityDictionary = new Dictionary<string, Polarity>
         {
-            {"MS:1000129",Polarity.Negative},
-            {"MS:1000130",Polarity.Positive}
+            {"MS:1000129", Polarity.Negative},
+            {"MS:1000130", Polarity.Positive}
         };
 
-        private static readonly Dictionary<string, MZAnalyzerType> analyzerDictionary = new Dictionary<string, MZAnalyzerType>
+        public static readonly Dictionary<string, MZAnalyzerType> AnalyzerDictionary = new Dictionary<string, MZAnalyzerType>
         {
             { "MS:1000443", MZAnalyzerType.Unknown},
-            { "MS:1000081",MZAnalyzerType.Quadrupole},
-            { "MS:1000291",MZAnalyzerType.IonTrap2D},
-            { "MS:1000082",MZAnalyzerType.IonTrap3D},
-            { "MS:1000484",MZAnalyzerType.Orbitrap},
-            { "MS:1000084",MZAnalyzerType.TOF},
-            { "MS:1000079",MZAnalyzerType.FTICR},
-            { "MS:1000080",MZAnalyzerType.Sector}
+            { "MS:1000081", MZAnalyzerType.Quadrupole},
+            { "MS:1000291", MZAnalyzerType.IonTrap2D},
+            { "MS:1000082", MZAnalyzerType.IonTrap3D},
+            { "MS:1000484", MZAnalyzerType.Orbitrap},
+            { "MS:1000084", MZAnalyzerType.TOF},
+            { "MS:1000079", MZAnalyzerType.FTICR},
+            { "MS:1000080", MZAnalyzerType.Sector}
         };
 
-        private static readonly Dictionary<string, DissociationType> dissociationDictionary = new Dictionary<string, DissociationType>
+        public static readonly Dictionary<string, DissociationType> DissociationDictionary = new Dictionary<string, DissociationType>
         {
-            { "MS:1000133",DissociationType.CID},
-            { "MS:1001880",DissociationType.ISCID},
-            { "MS:1000422",DissociationType.HCD},
-            { "MS:1000598",DissociationType.ETD},
-            { "MS:1000435",DissociationType.IRMPD},
-            { "MS:1000599",DissociationType.PQD},
-            { "MS:1000044",DissociationType.Unknown}
+            { "MS:1000133", DissociationType.CID},
+            { "MS:1000134", DissociationType.PD},
+            { "MS:1000135", DissociationType.PSD},
+            { "MS:1000136", DissociationType.SID},
+            { "MS:1000242", DissociationType.BIRD},
+            { "MS:1000250", DissociationType.ECD},
+            { "MS:1000262", DissociationType.IRMPD},
+            { "MS:1000282", DissociationType.SORI},
+            { "MS:1000435", DissociationType.MPD},
+            { "MS:1000598", DissociationType.ETD},
+            { "MS:1000599", DissociationType.PQD},
+            { "MS:1001880", DissociationType.ISCID},
+            { "MS:1000422", DissociationType.HCD},
+            { "MS:1002631", DissociationType.EThcD},
+            { "MS:1000044", DissociationType.Unknown},
+        };
+
+        public static readonly Dictionary<string, DissociationType> DissociationTypeNames = new Dictionary<string, DissociationType>
+        {
+            { "collision-induced dissociation", DissociationType.CID},
+            { "plasma desorption", DissociationType.PD},
+            { "post-source decay", DissociationType.PSD},
+            { "surface-induced dissociation", DissociationType.SID},
+            { "blackbody infrared radiative dissociation", DissociationType.BIRD},
+            { "electron capture dissociation", DissociationType.ECD},
+            { "infrared multiphoton dissociation", DissociationType.IRMPD},
+            { "sustained off-resonance irradiation", DissociationType.SORI},
+            { "photodissociation", DissociationType.MPD},
+            { "electron transfer dissociation", DissociationType.ETD},
+            { "pulsed q dissociation", DissociationType.PQD},
+            { "in-source collision-induced dissociation", DissociationType.ISCID},
+            { "higher energy beam-type collision-induced dissociation", DissociationType.HCD},
+            { "Electron-Transfer/Higher-Energy Collision Dissociation (EThcD)", DissociationType.EThcD},
+            { "unknown dissociation type", DissociationType.Unknown},
         };
 
         private Mzml(MsDataScan[] scans, SourceFile sourceFile) : base(scans, sourceFile)
@@ -276,7 +303,7 @@ namespace IO.MzML
                 {
                     analyzer = default(MZAnalyzerType);
                 }
-                else if (analyzerDictionary.TryGetValue(configs[0].componentList.analyzer[0].cvParam[0].accession, out MZAnalyzerType returnVal))
+                else if (AnalyzerDictionary.TryGetValue(configs[0].componentList.analyzer[0].cvParam[0].accession, out MZAnalyzerType returnVal))
                 {
                     analyzer = returnVal;
                 }
@@ -288,7 +315,7 @@ namespace IO.MzML
                 {
                     if (configs[i].id.Equals(scanSpecificInsturmentConfig))
                     {
-                        analyzerDictionary.TryGetValue(configs[i].componentList.analyzer[0].cvParam[0].accession, out MZAnalyzerType returnVal);
+                        AnalyzerDictionary.TryGetValue(configs[i].componentList.analyzer[0].cvParam[0].accession, out MZAnalyzerType returnVal);
                         analyzer = returnVal;
                     }
                 }
@@ -321,7 +348,7 @@ namespace IO.MzML
                 }
                 if (polarity.Equals(Polarity.Unknown))
                 {
-                    polarityDictionary.TryGetValue(cv.accession, out polarity);
+                    PolarityDictionary.TryGetValue(cv.accession, out polarity);
                 }
             }
 
@@ -486,7 +513,7 @@ namespace IO.MzML
 
                 foreach (Generated.CVParamType cv in _mzMLConnection.run.spectrumList.spectrum[oneBasedIndex - 1].precursorList.precursor[0].activation.cvParam)
                 {
-                    if (dissociationDictionary.TryGetValue(cv.accession, out var scanDissociationType))
+                    if (DissociationDictionary.TryGetValue(cv.accession, out var scanDissociationType))
                     {
                         scanDissociationTypes.Add(scanDissociationType);
                     }

--- a/MzML/MzmlDynamicData.cs
+++ b/MzML/MzmlDynamicData.cs
@@ -117,7 +117,27 @@ namespace IO.MzML
                         {
                             // controlled vocabulary parameter
                             case "CVPARAM":
-                                switch (xmlReader["accession"])
+                                string cvParamAccession = xmlReader["accession"];
+
+                                if (Mzml.DissociationDictionary.ContainsKey(cvParamAccession))
+                                {
+                                    dissociationType = Mzml.DissociationDictionary[cvParamAccession];
+                                    break;
+                                }
+
+                                if (Mzml.PolarityDictionary.ContainsKey(cvParamAccession))
+                                {
+                                    polarity = Mzml.PolarityDictionary[cvParamAccession];
+                                    break;
+                                }
+
+                                if (Mzml.AnalyzerDictionary.ContainsKey(cvParamAccession))
+                                {
+                                    mzAnalyzerType = Mzml.AnalyzerDictionary[cvParamAccession];
+                                    break;
+                                }
+
+                                switch (cvParamAccession)
                                 {
                                     // MS order
                                     case "MS:1000511":
@@ -133,16 +153,6 @@ namespace IO.MzML
                                     case "MS:1000128":
                                         isCentroid = false;
                                         throw new MzLibException("Reading profile mode mzmls not supported");
-                                        break;
-
-                                    // positive scan mode
-                                    case "MS:1000130":
-                                        polarity = Polarity.Positive;
-                                        break;
-
-                                    // negative scan mode
-                                    case "MS:1000129":
-                                        polarity = Polarity.Negative;
                                         break;
 
                                     // total ion current
@@ -203,60 +213,6 @@ namespace IO.MzML
                                     // selected intensity
                                     case "MS:1000042":
                                         selectedIonIntensity = double.Parse(xmlReader["value"]);
-                                        break;
-
-                                    // activation types
-                                    case "MS:1000133":
-                                        dissociationType = DissociationType.CID;
-                                        break;
-
-                                    case "MS:1001880":
-                                        dissociationType = DissociationType.ISCID;
-                                        break;
-
-                                    case "MS:1000422":
-                                        dissociationType = DissociationType.HCD;
-                                        break;
-
-                                    case "MS:1000598":
-                                        dissociationType = DissociationType.ETD;
-                                        break;
-
-                                    case "MS:1000435":
-                                        dissociationType = DissociationType.IRMPD;
-                                        break;
-
-                                    case "MS:1000599":
-                                        dissociationType = DissociationType.PQD;
-                                        break;
-
-                                    // mass analyzer types
-                                    case "MS:1000081":
-                                        mzAnalyzerType = MZAnalyzerType.Quadrupole;
-                                        break;
-
-                                    case "MS:1000291":
-                                        mzAnalyzerType = MZAnalyzerType.IonTrap2D;
-                                        break;
-
-                                    case "MS:1000082":
-                                        mzAnalyzerType = MZAnalyzerType.IonTrap3D;
-                                        break;
-
-                                    case "MS:1000484":
-                                        mzAnalyzerType = MZAnalyzerType.Orbitrap;
-                                        break;
-
-                                    case "MS:1000084":
-                                        mzAnalyzerType = MZAnalyzerType.TOF;
-                                        break;
-
-                                    case "MS:1000079":
-                                        mzAnalyzerType = MZAnalyzerType.FTICR;
-                                        break;
-
-                                    case "MS:1000080":
-                                        mzAnalyzerType = MZAnalyzerType.Sector;
                                         break;
 
                                     case "MS:1000523":

--- a/MzML/MzmlDynamicData.cs
+++ b/MzML/MzmlDynamicData.cs
@@ -131,12 +131,6 @@ namespace IO.MzML
                                     break;
                                 }
 
-                                if (Mzml.AnalyzerDictionary.ContainsKey(cvParamAccession))
-                                {
-                                    mzAnalyzerType = Mzml.AnalyzerDictionary[cvParamAccession];
-                                    break;
-                                }
-
                                 switch (cvParamAccession)
                                 {
                                     // MS order
@@ -213,6 +207,35 @@ namespace IO.MzML
                                     // selected intensity
                                     case "MS:1000042":
                                         selectedIonIntensity = double.Parse(xmlReader["value"]);
+                                        break;
+
+                                    // mass analyzer types
+                                    case "MS:1000081":
+                                        mzAnalyzerType = MZAnalyzerType.Quadrupole;
+                                        break;
+
+                                    case "MS:1000291":
+                                        mzAnalyzerType = MZAnalyzerType.IonTrap2D;
+                                        break;
+
+                                    case "MS:1000082":
+                                        mzAnalyzerType = MZAnalyzerType.IonTrap3D;
+                                        break;
+
+                                    case "MS:1000484":
+                                        mzAnalyzerType = MZAnalyzerType.Orbitrap;
+                                        break;
+
+                                    case "MS:1000084":
+                                        mzAnalyzerType = MZAnalyzerType.TOF;
+                                        break;
+
+                                    case "MS:1000079":
+                                        mzAnalyzerType = MZAnalyzerType.FTICR;
+                                        break;
+
+                                    case "MS:1000080":
+                                        mzAnalyzerType = MZAnalyzerType.Sector;
                                         break;
 
                                     case "MS:1000523":

--- a/MzML/MzmlMethods.cs
+++ b/MzML/MzmlMethods.cs
@@ -18,39 +18,11 @@ namespace IO.MzML
         internal static readonly XmlSerializer mzmlSerializer = new XmlSerializer(typeof(Generated.mzMLType));
         private static readonly string NewLine = "\n";
 
-        private static readonly Dictionary<DissociationType, string> DissociationTypeAccessions = new Dictionary<DissociationType, string>
-        {
-            {DissociationType.CID, "MS:1000133"},
-            {DissociationType.ISCID, "MS:1001880"},
-            {DissociationType.HCD, "MS:1000422" },
-            {DissociationType.ETD, "MS:1000598"},
-            {DissociationType.IRMPD, "MS:1000435"},
-            {DissociationType.PQD, "MS:1000599"},
-            {DissociationType.Unknown, "MS:1000044"}
-        };
+        private static readonly Dictionary<DissociationType, string> DissociationTypeAccessions = Mzml.DissociationDictionary.ToDictionary(p => p.Value, p => p.Key);
 
-        private static readonly Dictionary<DissociationType, string> DissociationTypeNames = new Dictionary<DissociationType, string>
-        {
-            {DissociationType.CID, "collision-induced dissociation"},
-            {DissociationType.ISCID, "in-source collision-induced dissociation"},
-            {DissociationType.HCD, "beam-type collision-induced dissociation"},
-            {DissociationType.ETD, "electron transfer dissociation"},
-            {DissociationType.IRMPD, "photodissociation"},
-            {DissociationType.PQD, "pulsed q dissociation"},
-            {DissociationType.Unknown, "dissociation method"}
-        };
+        private static readonly Dictionary<DissociationType, string> DissociationTypeNames = Mzml.DissociationTypeNames.ToDictionary(p => p.Value, p => p.Key);
 
-        private static readonly Dictionary<MZAnalyzerType, string> analyzerDictionary = new Dictionary<MZAnalyzerType, string>
-        {
-            {MZAnalyzerType.Unknown, "MS:1000443"},
-            {MZAnalyzerType.Quadrupole, "MS:1000081"},
-            {MZAnalyzerType.IonTrap2D, "MS:1000291"},
-            {MZAnalyzerType.IonTrap3D,"MS:1000082"},
-            {MZAnalyzerType.Orbitrap,"MS:1000484"},
-            {MZAnalyzerType.TOF,"MS:1000084"},
-            {MZAnalyzerType.FTICR ,"MS:1000079"},
-            {MZAnalyzerType.Sector,"MS:1000080"}
-        };
+        private static readonly Dictionary<MZAnalyzerType, string> analyzerDictionary = Mzml.AnalyzerDictionary.ToDictionary(p => p.Value, p => p.Key);
 
         private static readonly Dictionary<string, string> nativeIdFormatAccessions = new Dictionary<string, string>
         {
@@ -83,13 +55,10 @@ namespace IO.MzML
             {false, "profile spectrum"}
         };
 
-        private static readonly Dictionary<Polarity, string> PolarityAccessions = new Dictionary<Polarity, string>
-        {
-            {Polarity.Negative, "MS:1000129"},
-            {Polarity.Positive, "MS:1000130"}
-        };
+        private static readonly Dictionary<Polarity, string> PolarityAccessions = Mzml.PolarityDictionary.ToDictionary(p => p.Value, p => p.Key);
 
-        private static readonly Dictionary<Polarity, string> PolarityNames = new Dictionary<Polarity, string>
+        private static readonly Dictionary<Polarity, string> PolarityNames 
+            = new Dictionary<Polarity, string>
         {
             {Polarity.Negative, "negative scan"},
             {Polarity.Positive, "positive scan"}

--- a/MzML/MzmlMethods.cs
+++ b/MzML/MzmlMethods.cs
@@ -57,8 +57,7 @@ namespace IO.MzML
 
         private static readonly Dictionary<Polarity, string> PolarityAccessions = Mzml.PolarityDictionary.ToDictionary(p => p.Value, p => p.Key);
 
-        private static readonly Dictionary<Polarity, string> PolarityNames 
-            = new Dictionary<Polarity, string>
+        private static readonly Dictionary<Polarity, string> PolarityNames = new Dictionary<Polarity, string>
         {
             {Polarity.Negative, "negative scan"},
             {Polarity.Positive, "positive scan"}

--- a/ThermoRawFileReader/ThermoRawFileReader.cs
+++ b/ThermoRawFileReader/ThermoRawFileReader.cs
@@ -366,6 +366,10 @@ namespace IO.ThermoRawFileReader
                 case ActivationType.ElectronTransferDissociation: return DissociationType.ETD;
                 case ActivationType.HigherEnergyCollisionalDissociation: return DissociationType.HCD;
                 case ActivationType.ElectronCaptureDissociation: return DissociationType.ECD;
+                case ActivationType.MultiPhotonDissociation: return DissociationType.MPD;
+                case ActivationType.PQD: return DissociationType.PQD;
+                case ActivationType.UltraVioletPhotoDissociation: return DissociationType.UVPD;
+                case ActivationType.NegativeElectronTransferDissociation: return DissociationType.NETD;
 
                 default: return DissociationType.Unknown;
             }


### PR DESCRIPTION
- Added the "Autodetect" dissociation type, for use in MetaMorpheus, when the dissociation type should be detected from the scan header instead of fixed prior to search
- Corrected the CVParam term for photodissociation
- Added more dissociation types, and matched to their Thermo equivalents when reading .raw files
- Removed code duplication