### PR TITLE
[WIP] baseline imputation implemented in flashlfq

### DIFF
--- a/FlashLFQ/DetectionType.cs
+++ b/FlashLFQ/DetectionType.cs
@@ -4,9 +4,9 @@
     {
         MSMS,
         MBR,
+        Imputed,
         NotDetected,
         MSMSAmbiguousPeakfinding,
-        MSMSIdentifiedButNotQuantified,
-        Imputed
+        MSMSIdentifiedButNotQuantified
     }
 }

--- a/FlashLFQ/ImputationEngine.cs
+++ b/FlashLFQ/ImputationEngine.cs
@@ -1,0 +1,114 @@
+﻿using BayesianEstimation;
+using Chemistry;
+using MassSpectrometry;
+using MathNet.Numerics.Distributions;
+using MathNet.Numerics.Statistics;
+using MzLibUtil;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlashLFQ
+{
+    /// <summary>
+    /// TODO: 
+    /// 
+    /// only impute to fill out 3 mmts per protein? or impute all missing?
+    /// FWHM for imputing from distribution?
+    /// when to use for bayesian? maybe same as regular protein quant?
+    /// skip protein quant if only 1 MBR mmt?
+    /// 
+    /// </summary>
+
+    public class ImputationEngine
+    {
+        private Dictionary<(SpectraFileInfo, int rt, DoubleRange mzWindow), List<(double hdiStart, double hdiEnd)>> FileAndScanMzRangeToNoise;
+
+        public ImputationEngine()
+        {
+            FileAndScanMzRangeToNoise = new Dictionary<(SpectraFileInfo, int rt, DoubleRange mzWindow), List<(double hdiStart, double hdiEnd)>>();
+        }
+
+        public void CalculateIntensityBaselines(SpectraFileInfo file, MsDataScan[] fileData)
+        {
+            foreach (MsDataScan scan in fileData.Where(p => p != null))
+            {
+                List<(double mz, double intensity)> peaks = new List<(double mz, double intensity)>();
+
+                for (double minMz = 0; minMz < scan.ScanWindowRange.Maximum; minMz += 100)
+                {
+                    peaks.Clear();
+                    double maxMz = minMz + 100;
+
+                    int index = scan.MassSpectrum.GetClosestPeakIndex(minMz);
+
+                    for (int i = index; i < scan.MassSpectrum.XArray.Length; i++)
+                    {
+                        double mz = scan.MassSpectrum.XArray[i];
+                        double intensity = scan.MassSpectrum.YArray[i];
+
+                        if (mz > maxMz)
+                        {
+                            break;
+                        }
+                        if (mz < minMz || intensity <= 0)
+                        {
+                            continue;
+                        }
+
+                        peaks.Add((mz, intensity));
+                    }
+
+                    if (peaks.Count < 20)
+                    {
+                        continue;
+                    }
+
+                    var peakIntensities = peaks.Select(p => p.intensity).ToArray();
+                    var hdi = Util.GetHighestDensityInterval(peakIntensities, 0.1);
+
+                    var mzRange = new DoubleRange((int)minMz, (int)maxMz);
+                    int roundedRt = (int)scan.RetentionTime;
+
+                    FileAndScanMzRangeToNoise.TryAdd((file, roundedRt, mzRange), new List<(double hdiStart, double hdiEnd)>());
+
+                    FileAndScanMzRangeToNoise[(file, roundedRt, mzRange)].Add(hdi);
+                }
+            }
+        }
+
+        public ChromatographicPeak ImputePeak(SpectraFileInfo file, Identification id, double rt, List<(double mass, double abundance)> theoreticalIsotopeAbundances, int seed)
+        {
+            var rand = new Random(seed);
+            double mz = id.PeakfindingMass.ToMz(id.PrecursorChargeState);
+
+            double mzRangeStart = (int)(mz - (mz % 100));
+            double mzRangeEnd = mzRangeStart + 100;
+
+            if (!FileAndScanMzRangeToNoise.TryGetValue((file, (int)rt, new DoubleRange(mzRangeStart, mzRangeEnd)), out var hdiList))
+            {
+                return null;
+            }
+
+            var hdi = hdiList[rand.Next(0, hdiList.Count)];
+
+            double imputedPeakIntensity = rand.Next((int)hdi.hdiStart, (int)hdi.hdiEnd);
+            double imputedEnvelopeIntensity = 0;
+
+            // impute isotope peak intensities for the envelope
+            for (int i = 0; i < theoreticalIsotopeAbundances.Count; i++)
+            {
+                imputedEnvelopeIntensity += theoreticalIsotopeAbundances[i].abundance * imputedPeakIntensity;
+            }
+
+            var peak = new ChromatographicPeak(id, PeakType.Imputed, file);
+
+            peak.IsotopicEnvelopes.Add(new IsotopicEnvelope(new IndexedMassSpectralPeak(mz, imputedPeakIntensity, 0, rt), id.PrecursorChargeState, imputedEnvelopeIntensity));
+            peak.CalculateIntensityForThisFeature(false);
+
+            return peak;
+        }
+    }
+}

--- a/FlashLFQ/ImputationEngine.cs
+++ b/FlashLFQ/ImputationEngine.cs
@@ -12,16 +12,6 @@ using System.Threading.Tasks;
 
 namespace FlashLFQ
 {
-    /// <summary>
-    /// TODO: 
-    /// 
-    /// only impute to fill out 3 mmts per protein? or impute all missing?
-    /// FWHM for imputing from distribution?
-    /// when to use for bayesian? maybe same as regular protein quant?
-    /// skip protein quant if only 1 MBR mmt?
-    /// 
-    /// </summary>
-
     public class ImputationEngine
     {
         private Dictionary<(SpectraFileInfo, int rt, DoubleRange mzWindow), List<(double hdiStart, double hdiEnd)>> FileAndScanMzRangeToNoise;

--- a/FlashLFQ/PeakIndexingEngine.cs
+++ b/FlashLFQ/PeakIndexingEngine.cs
@@ -27,7 +27,7 @@ namespace FlashLFQ
             _serializer = new Serializer(messageTypes);
         }
 
-        public bool IndexMassSpectralPeaks(SpectraFileInfo fileInfo, bool silent, Dictionary<SpectraFileInfo, Ms1ScanInfo[]> _ms1Scans)
+        public bool IndexMassSpectralPeaks(SpectraFileInfo fileInfo, bool silent, Dictionary<SpectraFileInfo, Ms1ScanInfo[]> _ms1Scans, ImputationEngine imputationEngine)
         {
             if (!silent)
             {
@@ -186,6 +186,12 @@ namespace FlashLFQ
                 }
 
                 return false;
+            }
+
+            // calculate scan baselines for imputation
+            if (imputationEngine != null)
+            {
+                imputationEngine.CalculateIntensityBaselines(fileInfo, msDataScans);
             }
 
             return true;

--- a/FlashLFQ/ProteinGroup.cs
+++ b/FlashLFQ/ProteinGroup.cs
@@ -11,6 +11,7 @@ namespace FlashLFQ
         public readonly string Organism;
         private Dictionary<SpectraFileInfo, double> Intensities;
         public Dictionary<string, ProteinQuantificationEngineResult> ConditionToQuantificationResults;
+        public int NumQuantifiedPeptides;
 
         public ProteinGroup(string proteinGroupName, string geneName, string organism)
         {
@@ -51,15 +52,16 @@ namespace FlashLFQ
             sb.Append("Protein Groups" + "\t");
             sb.Append("Gene Name" + "\t");
             sb.Append("Organism" + "\t");
+            sb.Append("Number Quantified Peptides" + "\t");
 
             bool unfractionated = spectraFiles.Select(p => p.Fraction).Distinct().Count() == 1;
-            bool conditionsDefined = spectraFiles.All(p => p.Condition == "Default") || spectraFiles.All(p => string.IsNullOrWhiteSpace(p.Condition));
+            bool conditionsUndefined = spectraFiles.All(p => p.Condition == "Default") || spectraFiles.All(p => string.IsNullOrWhiteSpace(p.Condition));
 
             foreach (var sampleGroup in spectraFiles.GroupBy(p => p.Condition))
             {
                 foreach (var sample in sampleGroup.GroupBy(p => p.BiologicalReplicate).OrderBy(p => p.Key))
                 {
-                    if (!conditionsDefined && unfractionated)
+                    if (conditionsUndefined && unfractionated)
                     {
                         sb.Append("Intensity_" + sample.First().FilenameWithoutExtension + "\t");
                     }
@@ -79,6 +81,7 @@ namespace FlashLFQ
             sb.Append(ProteinGroupName + "\t");
             sb.Append(GeneName + "\t");
             sb.Append(Organism + "\t");
+            sb.Append(NumQuantifiedPeptides + "\t");
 
             bool unfractionated = spectraFiles.Select(p => p.Fraction).Distinct().Count() == 1;
             bool conditionsDefined = spectraFiles.All(p => p.Condition == "Default") || spectraFiles.All(p => string.IsNullOrWhiteSpace(p.Condition));

--- a/FlashLFQ/SpectraFileInfo.cs
+++ b/FlashLFQ/SpectraFileInfo.cs
@@ -8,6 +8,7 @@
         public readonly int BiologicalReplicate;
         public readonly int Fraction;
         public readonly int TechnicalReplicate;
+        public double NormalizationFactor;
 
         public SpectraFileInfo(string fullFilePathWithExtension, string condition, int biorep, int techrep, int fraction)
         {
@@ -17,6 +18,7 @@
             this.BiologicalReplicate = biorep;
             this.TechnicalReplicate = techrep;
             this.Fraction = fraction;
+            NormalizationFactor = 1;
         }
 
         // files are considered the same if the absolute file path is the same

--- a/MzLibUtil/DoubleRange.cs
+++ b/MzLibUtil/DoubleRange.cs
@@ -127,5 +127,22 @@ namespace MzLibUtil
         {
             return CompareTo(item).Equals(0);
         }
+
+        public override int GetHashCode()
+        {
+            return Minimum.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            var other = (DoubleRange)obj;
+
+            if(other.Minimum == this.Minimum && other.Maximum == this.Maximum)
+            {
+                return true;
+            }    
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
- added option to impute missing peptide values from baseline estimation
- made the median polish intensity scaling more stable (issue reported by @blfrey )
- protein quant output reports number of peptides used to quantify that protein