### PR TITLE
set culture as invariant culture by default on reference to loaders

### DIFF
--- a/Test/FixtureSetUp.cs
+++ b/Test/FixtureSetUp.cs
@@ -17,7 +17,9 @@
 
 using NUnit.Framework;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
+using System.Threading;
 using UsefulProteomicsDatabases;
 
 namespace Test
@@ -30,6 +32,9 @@ namespace Test
         public void Setup()
         {
             Loaders.LoadElements();
+
+            Assert.That(Thread.CurrentThread.CurrentCulture == CultureInfo.InvariantCulture);
+            Assert.That(Thread.CurrentThread.CurrentUICulture == CultureInfo.InvariantCulture);
         }
     }
 }

--- a/UsefulProteomicsDatabases/Loaders.cs
+++ b/UsefulProteomicsDatabases/Loaders.cs
@@ -19,11 +19,13 @@ using Chemistry;
 using Proteomics;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Xml.Serialization;
 using UsefulProteomicsDatabases.Generated;
 
@@ -34,6 +36,15 @@ namespace UsefulProteomicsDatabases
         static Loaders()
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+            SetCultureAsInvariantCulture();
+        }
+
+        public static void SetCultureAsInvariantCulture()
+        {
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
         }
 
         public static void UpdateUniprot(string uniprotLocation)


### PR DESCRIPTION
this PR will set current and future threads' culture as the invariant culture, upon the Loaders project being referenced for the first time (e.g., when the periodic table is loaded). this should generally fix the recurring bug reported in https://github.com/smith-chem-wisc/MetaMorpheus/issues/1561 .