### PR TITLE
repair within calculation

### DIFF
--- a/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
+++ b/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
@@ -14,7 +14,7 @@ namespace MassSpectrometry.MzSpectra
             primaryXArray = primary.XArray;
             secondaryYarray = Normalize(secondary.YArray, scheme);
             secondaryXArray = secondary.XArray;
-            localTolerance = toleranceInPpm / 1000000.0;
+            ppmTolerance = toleranceInPpm;
             _intensityPairs = IntensityPairs(allPeaks);
         }
 
@@ -24,7 +24,7 @@ namespace MassSpectrometry.MzSpectra
             primaryXArray = primary.XArray;
             secondaryYarray = Normalize(secondaryY, scheme);
             secondaryXArray = secondaryX;
-            localTolerance = toleranceInPpm / 1000000.0;
+            ppmTolerance = toleranceInPpm;
             _intensityPairs = IntensityPairs(allPeaks);
         }
 
@@ -32,7 +32,7 @@ namespace MassSpectrometry.MzSpectra
         public double[] primaryXArray { get; private set; }
         public double[] secondaryYarray { get; private set; }
         public double[] secondaryXArray { get; private set; }
-        private double localTolerance;
+        private double ppmTolerance;
         private List<(double, double)> _intensityPairs = new List<(double, double)>();
         
         public List<(double, double)> intensityPairs
@@ -236,7 +236,7 @@ namespace MassSpectrometry.MzSpectra
 
         private bool Within(double mz1, double mz2)
         {
-            return (Math.Abs(mz1 - mz2) < localTolerance);
+            return (Math.Abs(mz1 - mz2)/mz1*1000000.0 < ppmTolerance);
         }
 
         public enum SpectrumNormalizationScheme

--- a/Test/TestSpectralSimilarity.cs
+++ b/Test/TestSpectralSimilarity.cs
@@ -117,10 +117,10 @@ namespace Test
 
             //explore bounds of binary search
             primary = new MzSpectrum(new double[] { 1, 2, 3, 4 }, new double[] { 1, 2, 3, 4 }, false);
-            secondary = new MzSpectrum(new double[] { 1.000009, 1.99999, 3.00004, 3.99995 }, new double[] { 1, 2, 3, 4 }, false);
+            secondary = new MzSpectrum(new double[] { 1.000011, 1.99997, 3.000031, 3.99995 }, new double[] { 1, 2, 3, 4 }, false);
 
             s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.spectrumSum, ppmTolerance, true);
-            Assert.AreEqual(7, s.intensityPairs.Count);
+            Assert.AreEqual(8, s.intensityPairs.Count);
 
             //Test alternate constructor
             primary = new MzSpectrum(new double[] { 1, 2, 3 }, new double[] { 2, 4, 6 }, false);


### PR DESCRIPTION
the method I used in the prior commit to tell if two mz peaks were close enough was incorrect. this pr fixes that error.