### PR TITLE
Flash lfq for percolator

### DIFF
--- a/FlashLFQ/Identification.cs
+++ b/FlashLFQ/Identification.cs
@@ -33,6 +33,25 @@ namespace FlashLFQ
             UseForProteinQuant = useForProteinQuant;
             PosteriorErrorProbability = posteriorErrorProbability;
         }
+        /// <summary>
+        /// This Identification object was created for instances when the modified sequence isn't parsable into a formula
+        /// for calcuation of the peptide/proteoform mass. 
+        /// </summary>
+        public Identification(SpectraFileInfo fileInfo, string ModifiedSequence, double monoisotopicMass, 
+            double ms2RetentionTimeInMinutes, int chargeState, List<ProteinGroup> proteinGroups, 
+            bool useForProteinQuant = true, double posteriorErrorProbability = 0)
+        {
+            this.FileInfo = fileInfo;
+            this.BaseSequence = null;
+            this.ModifiedSequence = ModifiedSequence;
+            this.MonoisotopicMass = monoisotopicMass;
+            this.Ms2RetentionTimeInMinutes = ms2RetentionTimeInMinutes;
+            this.PrecursorChargeState = chargeState;
+            this.ProteinGroups = new HashSet<ProteinGroup>(proteinGroups);
+            this.OptionalChemicalFormula = null;
+            UseForProteinQuant = useForProteinQuant;
+            PosteriorErrorProbability = posteriorErrorProbability;
+        }
 
         public override string ToString()
         {

--- a/FlashLFQ/Identification.cs
+++ b/FlashLFQ/Identification.cs
@@ -33,25 +33,6 @@ namespace FlashLFQ
             UseForProteinQuant = useForProteinQuant;
             PosteriorErrorProbability = posteriorErrorProbability;
         }
-        /// <summary>
-        /// This Identification object was created for instances when the modified sequence isn't parsable into a formula
-        /// for calcuation of the peptide/proteoform mass. 
-        /// </summary>
-        public Identification(SpectraFileInfo fileInfo, string ModifiedSequence, double monoisotopicMass, 
-            double ms2RetentionTimeInMinutes, int chargeState, List<ProteinGroup> proteinGroups, 
-            bool useForProteinQuant = true, double posteriorErrorProbability = 0)
-        {
-            this.FileInfo = fileInfo;
-            this.BaseSequence = null;
-            this.ModifiedSequence = ModifiedSequence;
-            this.MonoisotopicMass = monoisotopicMass;
-            this.Ms2RetentionTimeInMinutes = ms2RetentionTimeInMinutes;
-            this.PrecursorChargeState = chargeState;
-            this.ProteinGroups = new HashSet<ProteinGroup>(proteinGroups);
-            this.OptionalChemicalFormula = null;
-            UseForProteinQuant = useForProteinQuant;
-            PosteriorErrorProbability = posteriorErrorProbability;
-        }
 
         public override string ToString()
         {

--- a/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
+++ b/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
@@ -8,31 +8,31 @@ namespace MassSpectrometry.MzSpectra
 {
     public class SpectralSimilarity
     {
-        public SpectralSimilarity(MzSpectrum primary, MzSpectrum secondary, SpectrumNormalizationScheme scheme, double toleranceInPpm, bool allPeaks)
+        public SpectralSimilarity(MzSpectrum experimentalSpectrum, MzSpectrum theoreticalSpectrum, SpectrumNormalizationScheme scheme, double toleranceInPpm, bool allPeaks)
         {
-            primaryYArray = Normalize(primary.YArray, scheme);
-            primaryXArray = primary.XArray;
-            secondaryYarray = Normalize(secondary.YArray, scheme);
-            secondaryXArray = secondary.XArray;
-            ppmTolerance = toleranceInPpm;
+            experimentalYArray = Normalize(experimentalSpectrum.YArray, scheme);
+            experimentalXArray = experimentalSpectrum.XArray;
+            theoreticalYArray = Normalize(theoreticalSpectrum.YArray, scheme);
+            theoreticalXArray = theoreticalSpectrum.XArray;
+            localPpmTolerance = toleranceInPpm;
             _intensityPairs = IntensityPairs(allPeaks);
         }
 
-        public SpectralSimilarity(MzSpectrum primary, double[] secondaryX, double[] secondaryY, SpectrumNormalizationScheme scheme, double toleranceInPpm, bool allPeaks)
+        public SpectralSimilarity(MzSpectrum experimentalSpectrum, double[] theoreticalX, double[] theoreticalY, SpectrumNormalizationScheme scheme, double toleranceInPpm, bool allPeaks)
         {
-            primaryYArray = Normalize(primary.YArray, scheme);
-            primaryXArray = primary.XArray;
-            secondaryYarray = Normalize(secondaryY, scheme);
-            secondaryXArray = secondaryX;
-            ppmTolerance = toleranceInPpm;
+            experimentalYArray = Normalize(experimentalSpectrum.YArray, scheme);
+            experimentalXArray = experimentalSpectrum.XArray;
+            theoreticalYArray = Normalize(theoreticalY, scheme);
+            theoreticalXArray = theoreticalX;
+            localPpmTolerance = toleranceInPpm;
             _intensityPairs = IntensityPairs(allPeaks);
         }
 
-        public double[] primaryYArray { get; private set; }
-        public double[] primaryXArray { get; private set; }
-        public double[] secondaryYarray { get; private set; }
-        public double[] secondaryXArray { get; private set; }
-        private double ppmTolerance;
+        public double[] experimentalYArray { get; private set; }
+        public double[] experimentalXArray { get; private set; }
+        public double[] theoreticalYArray { get; private set; }
+        public double[] theoreticalXArray { get; private set; }
+        private double localPpmTolerance;
         private List<(double, double)> _intensityPairs = new List<(double, double)>();
         
         public List<(double, double)> intensityPairs
@@ -75,29 +75,29 @@ namespace MassSpectrometry.MzSpectra
         private List<(double, double)> IntensityPairs(bool allPeaks)
         {
             List<(double, double)> intensityPairs = new List<(double, double)>();
-            List<(double, double)> primary = new List<(double, double)>();
-            List<(double, double)> secondary = new List<(double, double)>();
+            List<(double, double)> experimental = new List<(double, double)>();
+            List<(double, double)> theoretical = new List<(double, double)>();
 
-            for (int i = 0; i < primaryXArray.Length; i++)
+            for (int i = 0; i < experimentalXArray.Length; i++)
             {
-                primary.Add((primaryXArray[i], primaryYArray[i]));
+                experimental.Add((experimentalXArray[i], experimentalYArray[i]));
             }
-            for (int i = 0; i < secondaryXArray.Length; i++)
+            for (int i = 0; i < theoreticalXArray.Length; i++)
             {
-                secondary.Add((secondaryXArray[i], secondaryYarray[i]));
+                theoretical.Add((theoreticalXArray[i], theoreticalYArray[i]));
             }
-            primary = primary.OrderByDescending(i => i.Item2).ToList();
-            secondary = secondary.OrderByDescending(i => i.Item2).ToList();
+            experimental = experimental.OrderByDescending(i => i.Item2).ToList();
+            theoretical = theoretical.OrderByDescending(i => i.Item2).ToList();
 
-            foreach ((double,double) xyPair in secondary)
+            foreach ((double,double) xyPair in theoretical)
             {
                 int index = 0;
-                while(primary.Count >0 && index < primary.Count)
+                while(experimental.Count >0 && index < experimental.Count)
                 {
-                    if (Within(primary[index].Item1, xyPair.Item1))
+                    if (Within(experimental[index].Item1, xyPair.Item1))
                     {
-                        intensityPairs.Add((primary[index].Item2, xyPair.Item2));
-                        primary.RemoveAt(index);
+                        intensityPairs.Add((experimental[index].Item2, xyPair.Item2));
+                        experimental.RemoveAt(index);
                         index = -1;
                         break;
                     }
@@ -105,13 +105,15 @@ namespace MassSpectrometry.MzSpectra
                 }
                 if(index > 0)
                 {
-                    //didn't find a primary mz in range
+                    //didn't find a experimental mz in range
                     intensityPairs.Add((0, xyPair.Item2));
                 }
             }
-            if(primary.Count > 0 && allPeaks)
+
+            //If we're keeping all experimental and theoretical peaks, then we add intensity pairs for all unpaired experimental peaks here.
+            if(experimental.Count > 0 && allPeaks)
             {
-                foreach ((double, double) xyPair in primary)
+                foreach ((double, double) xyPair in experimental)
                 {
                     intensityPairs.Add((xyPair.Item2, 0));
                 }
@@ -158,6 +160,7 @@ namespace MassSpectrometry.MzSpectra
 
         #region similarityMethods
 
+        //The cosine similarity returns values between 1 and -1 with 1 being closes and -1 being opposite and 0 being orthoganal
         public double CosineSimilarity()
         {
             double numerator = 0;
@@ -170,12 +173,20 @@ namespace MassSpectrometry.MzSpectra
                 denominatorValue2 += Math.Pow(pair.Item2, 2);
             }
             double denominatorProduct = denominatorValue1 * denominatorValue2;
+            
+            //because we keep all secondary spectrum peaks, denominatorValue1 can equal zero
+            if(denominatorProduct == 0)
+            {
+                return 0;
+            }
             return numerator / Math.Sqrt(denominatorProduct);
         }
 
+        //Spectral contrast angle should expect values between 1 and -1;
         public double SpectralContrastAngle()
         {
-            return (1.0 - ((2 * Math.Acos(CosineSimilarity())) / Math.PI));
+            return (1 - 2 * Math.Acos(CosineSimilarity()) / Math.PI);
+
         }
 
         public double EuclideanDistance()
@@ -234,9 +245,10 @@ namespace MassSpectrometry.MzSpectra
 
         #endregion similarityMethods
 
+        //use Math.Max() in the denominator for consistancy
         private bool Within(double mz1, double mz2)
         {
-            return (Math.Abs(mz1 - mz2)/mz1*1000000.0 < ppmTolerance);
+            return ((Math.Abs(mz1 - mz2) / Math.Max(mz1,mz2) * 1000000.0) < localPpmTolerance);
         }
 
         public enum SpectrumNormalizationScheme

--- a/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
+++ b/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
@@ -28,11 +28,13 @@ namespace MassSpectrometry.MzSpectra
             _intensityPairs = IntensityPairs(allPeaks);
         }
 
+
         public double[] experimentalYArray { get; private set; }
         public double[] experimentalXArray { get; private set; }
         public double[] theoreticalYArray { get; private set; }
         public double[] theoreticalXArray { get; private set; }
         private double localPpmTolerance;
+
         private List<(double, double)> _intensityPairs = new List<(double, double)>();
         
         public List<(double, double)> intensityPairs
@@ -248,6 +250,7 @@ namespace MassSpectrometry.MzSpectra
         //use Math.Max() in the denominator for consistancy
         private bool Within(double mz1, double mz2)
         {
+
             return ((Math.Abs(mz1 - mz2) / Math.Max(mz1,mz2) * 1000000.0) < localPpmTolerance);
         }
 

--- a/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
+++ b/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
@@ -28,11 +28,11 @@ namespace MassSpectrometry.MzSpectra
             _intensityPairs = IntensityPairs(allPeaks);
         }
 
-
         public double[] experimentalYArray { get; private set; }
         public double[] experimentalXArray { get; private set; }
         public double[] theoreticalYArray { get; private set; }
         public double[] theoreticalXArray { get; private set; }
+
         private double localPpmTolerance;
 
         private List<(double, double)> _intensityPairs = new List<(double, double)>();
@@ -250,7 +250,6 @@ namespace MassSpectrometry.MzSpectra
         //use Math.Max() in the denominator for consistancy
         private bool Within(double mz1, double mz2)
         {
-
             return ((Math.Abs(mz1 - mz2) / Math.Max(mz1,mz2) * 1000000.0) < localPpmTolerance);
         }
 

--- a/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
+++ b/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
@@ -1,0 +1,250 @@
+﻿using MzLibUtil;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace MassSpectrometry.MzSpectra
+{
+    public class SpectralSimilarity
+    {
+        public SpectralSimilarity(MzSpectrum primary, MzSpectrum secondary, SpectrumNormalizationScheme scheme, double toleranceInPpm, bool allPeaks)
+        {
+            primaryYArray = Normalize(primary.YArray, scheme);
+            primaryXArray = primary.XArray;
+            secondaryYarray = Normalize(secondary.YArray, scheme);
+            secondaryXArray = secondary.XArray;
+            localTolerance = toleranceInPpm / 1000000.0;
+            _intensityPairs = IntensityPairs(allPeaks);
+        }
+
+        public SpectralSimilarity(MzSpectrum primary, double[] secondaryX, double[] secondaryY, SpectrumNormalizationScheme scheme, double toleranceInPpm, bool allPeaks)
+        {
+            primaryYArray = Normalize(primary.YArray, scheme);
+            primaryXArray = primary.XArray;
+            secondaryYarray = Normalize(secondaryY, scheme);
+            secondaryXArray = secondaryX;
+            localTolerance = toleranceInPpm / 1000000.0;
+            _intensityPairs = IntensityPairs(allPeaks);
+        }
+
+        public double[] primaryYArray { get; private set; }
+        public double[] primaryXArray { get; private set; }
+        public double[] secondaryYarray { get; private set; }
+        public double[] secondaryXArray { get; private set; }
+        private double localTolerance;
+        private List<(double, double)> _intensityPairs = new List<(double, double)>();
+        
+        public List<(double, double)> intensityPairs
+        { get { return _intensityPairs; } }
+
+        /// <summary>
+        /// Every spectrum gets normalized when the SpectralSimilarity object gets created. This methods sends the spectra to the appropriate normalization.
+        /// </summary>
+        /// <param name="spectrum"></param>
+        /// <param name="scheme"></param>
+        /// <returns></returns>
+        private double[] Normalize(double[] spectrum, SpectrumNormalizationScheme scheme)
+        {
+            if (spectrum.Length == 0)
+            {
+                throw new MzLibException(string.Format(CultureInfo.InvariantCulture, "Empty YArray in spectrum."));
+            }
+            if (spectrum.Sum() == 0)
+            {
+                throw new MzLibException(string.Format(CultureInfo.InvariantCulture, "Spectrum has no intensity."));
+            }
+            return scheme switch
+            {
+                SpectrumNormalizationScheme.mostAbundantPeak => NormalizeMostAbundantPeak(spectrum),
+                SpectrumNormalizationScheme.spectrumSum => NormalizeSpectrumSum(spectrum),
+                SpectrumNormalizationScheme.squareRootSpectrumSum => NormalizeSquareRootSpectrumSum(spectrum),
+                _ => spectrum,
+            };
+        }
+
+        /// <summary>
+        /// Intensity Pairs a computed immediately upon creation of the SpectralSimilarity object. That way they can be used in all the methods without being recomputed.
+        /// We loop throught the secondaryXArray under the assumption that it is the shorter of the two arrays (i.e. typically the theoretical spectrum).
+        /// Experimental spectrum defaults to 200 peaks and is therefore usually longer.
+        /// We sort intensities in descending order so that when we make peak pairs, we're choosing pairs with the highest intensity so long as they are with mz range. 
+        /// Sometimes you could have two peaks in mz range and I don't think you want to pair the lesser intensity peak first just because it is closer in mass.
+        /// </summary>
+        /// <returns></returns>
+
+        private List<(double, double)> IntensityPairs(bool allPeaks)
+        {
+            List<(double, double)> intensityPairs = new List<(double, double)>();
+            List<(double, double)> primary = new List<(double, double)>();
+            List<(double, double)> secondary = new List<(double, double)>();
+
+            for (int i = 0; i < primaryXArray.Length; i++)
+            {
+                primary.Add((primaryXArray[i], primaryYArray[i]));
+            }
+            for (int i = 0; i < secondaryXArray.Length; i++)
+            {
+                secondary.Add((secondaryXArray[i], secondaryYarray[i]));
+            }
+            primary = primary.OrderByDescending(i => i.Item2).ToList();
+            secondary = secondary.OrderByDescending(i => i.Item2).ToList();
+
+            foreach ((double,double) xyPair in secondary)
+            {
+                int index = 0;
+                while(primary.Count >0 && index < primary.Count)
+                {
+                    if (Within(primary[index].Item1, xyPair.Item1))
+                    {
+                        intensityPairs.Add((primary[index].Item2, xyPair.Item2));
+                        primary.RemoveAt(index);
+                        index = -1;
+                        break;
+                    }
+                    index++;
+                }
+                if(index > 0)
+                {
+                    //didn't find a primary mz in range
+                    intensityPairs.Add((0, xyPair.Item2));
+                }
+            }
+            if(primary.Count > 0 && allPeaks)
+            {
+                foreach ((double, double) xyPair in primary)
+                {
+                    intensityPairs.Add((xyPair.Item2, 0));
+                }
+            }
+            return intensityPairs;
+        }
+
+        #region normalization
+
+        private double[] NormalizeSquareRootSpectrumSum(double[] spectrum)
+        {
+            double sqrtSum = spectrum.Select(y => Math.Sqrt(y)).Sum();
+
+            for (int i = 0; i < spectrum.Length; i++)
+            {
+                spectrum[i] = Math.Sqrt(spectrum[i]) / sqrtSum;
+            }
+            return spectrum;
+        }
+
+        private double[] NormalizeMostAbundantPeak(double[] spectrum)
+        {
+            double max = spectrum.Max();
+
+            for (int i = 0; i < spectrum.Length; i++)
+            {
+                spectrum[i] = spectrum[i] / max;
+            }
+            return spectrum;
+        }
+
+        private double[] NormalizeSpectrumSum(double[] spectrum)
+        {
+            double sum = spectrum.Sum();
+
+            for (int i = 0; i < spectrum.Length; i++)
+            {
+                spectrum[i] = spectrum[i] / sum;
+            }
+            return spectrum;
+        }
+
+        #endregion normalization
+
+        #region similarityMethods
+
+        public double CosineSimilarity()
+        {
+            double numerator = 0;
+            double denominatorValue1 = 0;
+            double denominatorValue2 = 0;
+            foreach ((double, double) pair in _intensityPairs)
+            {
+                numerator += pair.Item1 * pair.Item2;
+                denominatorValue1 += Math.Pow(pair.Item1, 2);
+                denominatorValue2 += Math.Pow(pair.Item2, 2);
+            }
+            double denominatorProduct = denominatorValue1 * denominatorValue2;
+            return numerator / Math.Sqrt(denominatorProduct);
+        }
+
+        public double SpectralContrastAngle()
+        {
+            return (1.0 - ((2 * Math.Acos(CosineSimilarity())) / Math.PI));
+        }
+
+        public double EuclideanDistance()
+        {
+            double sum = 0;
+            foreach ((double, double) pair in _intensityPairs)
+            {
+                sum += Math.Pow(pair.Item1 - pair.Item2, 2);
+            }
+            return 1 - Math.Sqrt(sum);
+        }
+
+        public double BrayCurtis()
+        {
+            double numerator = 0;
+            double denominator = 0;
+            foreach ((double, double) pair in _intensityPairs)
+            {
+                numerator += Math.Abs(pair.Item1 - pair.Item2);
+                denominator += pair.Item1 + pair.Item2;
+            }
+            return (1 - numerator / denominator);
+        }
+
+        public double PearsonsCorrelation()
+        {
+            double numerator = 0;
+            double denominator = 0;
+            double denominator1 = 0;
+            double denominator2 = 0;
+            double averagePrimaryIntensity = intensityPairs.Select(a => a.Item1).Sum() / intensityPairs.Count;
+            double averageSecondaryIntensity = intensityPairs.Select(a => a.Item2).Sum() / intensityPairs.Count;
+            foreach ((double, double) pair in _intensityPairs)
+            {
+                numerator += (pair.Item1 - averagePrimaryIntensity) * (pair.Item2 - averageSecondaryIntensity);
+                denominator1 += Math.Pow((pair.Item1 - averagePrimaryIntensity), 2);
+                denominator2 += Math.Pow((pair.Item2 - averageSecondaryIntensity), 2);
+            }
+            denominator = denominator1 * denominator2;
+            if(denominator > 0)
+            {
+                return numerator / Math.Sqrt(denominator);
+            }
+            return -1;
+        }
+
+        public double DotProduct()
+        {
+            double sum = 0;
+            foreach ((double, double) pair in _intensityPairs)
+            {
+                sum += pair.Item1 * pair.Item2;
+            }
+            return sum;
+        }
+
+        #endregion similarityMethods
+
+        private bool Within(double mz1, double mz2)
+        {
+            return (Math.Abs(mz1 - mz2) < localTolerance);
+        }
+
+        public enum SpectrumNormalizationScheme
+        {
+            squareRootSpectrumSum,
+            spectrumSum,
+            mostAbundantPeak,
+            unnormalized
+        }
+    }
+}

--- a/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
+++ b/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
@@ -14,7 +14,7 @@ namespace MassSpectrometry.MzSpectra
             primaryXArray = primary.XArray;
             secondaryYarray = Normalize(secondary.YArray, scheme);
             secondaryXArray = secondary.XArray;
-            localTolerance = toleranceInPpm / 1000000.0;
+            ppmTolerance = toleranceInPpm;
             _intensityPairs = IntensityPairs(allPeaks);
         }
 
@@ -24,7 +24,7 @@ namespace MassSpectrometry.MzSpectra
             primaryXArray = primary.XArray;
             secondaryYarray = Normalize(secondaryY, scheme);
             secondaryXArray = secondaryX;
-            localTolerance = toleranceInPpm / 1000000.0;
+            ppmTolerance = toleranceInPpm;
             _intensityPairs = IntensityPairs(allPeaks);
         }
 
@@ -32,7 +32,7 @@ namespace MassSpectrometry.MzSpectra
         public double[] primaryXArray { get; private set; }
         public double[] secondaryYarray { get; private set; }
         public double[] secondaryXArray { get; private set; }
-        private double localTolerance;
+        private double ppmTolerance;
         private List<(double, double)> _intensityPairs = new List<(double, double)>();
         
         public List<(double, double)> intensityPairs
@@ -236,7 +236,7 @@ namespace MassSpectrometry.MzSpectra
 
         private bool Within(double mz1, double mz2)
         {
-            return (Math.Abs(mz1 - mz2) < localTolerance);
+            return (Math.Abs(mz1 - mz2)/mz1*1000000.0 < ppmTolerance);
         }
 
         public enum SpectrumNormalizationScheme

--- a/Test/TestSpectralSimilarity.cs
+++ b/Test/TestSpectralSimilarity.cs
@@ -1,0 +1,149 @@
+﻿using MassSpectrometry;
+using MassSpectrometry.MzSpectra;
+using MzLibUtil;
+using NUnit.Framework;
+
+namespace Test
+{
+    [TestFixture]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public sealed class TestSpectralSimilarity
+    {
+        [Test]
+        public void TestAllSpectrumSimilarities()
+        {
+            double ppmTolerance = 10;
+
+            //Test all different similarity calculations
+            MzSpectrum primary = new MzSpectrum(new double[] { 1, 2, 3, 4, 5 }, new double[] { 2, 4, 6, 8, 10 }, false);
+            MzSpectrum secondary = new MzSpectrum(new double[] { 3, 4, 5, 6, 7 }, new double[] { 9, 7, 5, 3, 1 }, false);
+            SpectralSimilarity s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.squareRootSpectrumSum, ppmTolerance, true);
+            Assert.AreEqual(7, s.intensityPairs.Count);
+            Assert.That(s.CosineSimilarity(), Is.EqualTo(0.8).Within(0.01));
+            Assert.That(s.SpectralContrastAngle(), Is.EqualTo(0.59).Within(0.01));
+            Assert.That(s.EuclideanDistance(), Is.EqualTo(0.70).Within(0.01));
+            Assert.That(s.BrayCurtis(), Is.EqualTo(0.66).Within(0.01));
+            Assert.That(s.PearsonsCorrelation(), Is.EqualTo(0.42).Within(0.01));
+            Assert.That(s.DotProduct(), Is.EqualTo(0.17).Within(0.01));
+
+            //Test all normalization schemes
+            primary = new MzSpectrum(new double[] { 1, 2, 3 }, new double[] { 2, 4, 6 }, false);
+            secondary = new MzSpectrum(new double[] { 1 }, new double[] { 2 }, false);
+            s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.mostAbundantPeak, ppmTolerance, true);
+            Assert.That(s.CosineSimilarity(), Is.EqualTo(0.27).Within(0.01));
+            Assert.That(s.SpectralContrastAngle(), Is.EqualTo(0.17).Within(0.01));
+            Assert.That(s.EuclideanDistance(), Is.EqualTo(-0.37).Within(0.01));
+            Assert.That(s.BrayCurtis(), Is.EqualTo(0.22).Within(0.01));
+            Assert.That(s.PearsonsCorrelation(), Is.EqualTo(-0.87).Within(0.01));
+            Assert.That(s.DotProduct(), Is.EqualTo(0.33).Within(0.01));
+
+            s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.spectrumSum, ppmTolerance, true);
+            Assert.That(s.CosineSimilarity(), Is.EqualTo(0.27).Within(0.01));
+            Assert.That(s.SpectralContrastAngle(), Is.EqualTo(0.17).Within(0.01));
+            Assert.That(s.EuclideanDistance(), Is.EqualTo(-.03).Within(0.01));
+            Assert.That(s.BrayCurtis(), Is.EqualTo(0.17).Within(0.01));
+            Assert.That(s.PearsonsCorrelation(), Is.EqualTo(-0.87).Within(0.01));
+            Assert.That(s.DotProduct(), Is.EqualTo(0.17).Within(0.01));
+
+            s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.squareRootSpectrumSum, ppmTolerance, true);
+            Assert.That(s.CosineSimilarity(), Is.EqualTo(0.41).Within(0.01));
+            Assert.That(s.SpectralContrastAngle(), Is.EqualTo(0.27).Within(0.01));
+            Assert.That(s.EuclideanDistance(), Is.EqualTo(0.07).Within(0.01));
+            Assert.That(s.BrayCurtis(), Is.EqualTo(0.24).Within(0.01));
+            Assert.That(s.PearsonsCorrelation(), Is.EqualTo(-0.90).Within(0.01));
+            Assert.That(s.DotProduct(), Is.EqualTo(0.24).Within(0.01));
+
+            s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.unnormalized, ppmTolerance, true);
+            Assert.That(s.CosineSimilarity(), Is.EqualTo(0.41).Within(0.01));
+            Assert.That(s.SpectralContrastAngle(), Is.EqualTo(0.27).Within(0.01));
+            Assert.That(s.EuclideanDistance(), Is.EqualTo(0.07).Within(0.01));
+            Assert.That(s.BrayCurtis(), Is.EqualTo(0.24).Within(0.01));
+            Assert.That(s.PearsonsCorrelation(), Is.EqualTo(-0.90).Within(0.01));
+            Assert.That(s.DotProduct(), Is.EqualTo(0.24).Within(0.01));
+
+            //Make sure there is no crash w/ empty array
+            primary = new MzSpectrum(new double[] { }, new double[] { }, false);
+            secondary = new MzSpectrum(new double[] { }, new double[] { }, false);
+
+            Assert.Throws<MzLibException>(() =>
+            {
+                s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.spectrumSum, ppmTolerance, true);
+            }, "Empty YArray in spectrum.");
+
+            //We should have any zero intensity YArrays but just to be sure
+            primary = new MzSpectrum(new double[] { 1, 2, 3 }, new double[] { 2, 4, 6 }, false);
+            secondary = new MzSpectrum(new double[] { 1 }, new double[] { 0 }, false);
+
+            Assert.Throws<MzLibException>(() =>
+            {
+                s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.spectrumSum, ppmTolerance, true);
+            }, "Spectrum has no intensity.");
+
+            //What happens when all intensity pairs include a zero
+            primary = new MzSpectrum(new double[] { 1, 2, 3 }, new double[] { 2, 4, 6 }, false);
+            secondary = new MzSpectrum(new double[] { 4 }, new double[] { 2 }, false);
+
+            s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.spectrumSum, ppmTolerance, true);
+            Assert.That(s.CosineSimilarity(), Is.EqualTo(0).Within(0.01));
+            Assert.That(s.SpectralContrastAngle(), Is.EqualTo(0).Within(0.01));
+            Assert.That(s.EuclideanDistance(), Is.EqualTo(-0.18).Within(0.01));
+            Assert.That(s.BrayCurtis(), Is.EqualTo(0).Within(0.01));
+            Assert.That(s.PearsonsCorrelation(), Is.EqualTo(-0.77).Within(0.01));
+            Assert.That(s.DotProduct(), Is.EqualTo(0).Within(0.01));
+
+            primary = new MzSpectrum(new double[] { 1, 2, 3 }, new double[] { 0, 4, 6 }, false);
+            secondary = new MzSpectrum(new double[] { 1, 2, 3, 4 }, new double[] { 2, 0, 2, 2 }, false);
+
+            s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.spectrumSum, ppmTolerance, true);
+            Assert.That(s.CosineSimilarity(), Is.EqualTo(0.48).Within(0.01));
+            Assert.That(s.SpectralContrastAngle(), Is.EqualTo(0.32).Within(0.01));
+            Assert.That(s.EuclideanDistance(), Is.EqualTo(0.33).Within(0.01));
+            Assert.That(s.BrayCurtis(), Is.EqualTo(0.33).Within(0.01));
+            Assert.That(s.PearsonsCorrelation(), Is.EqualTo(-0.33).Within(0.01));
+            Assert.That(s.DotProduct(), Is.EqualTo(0.20).Within(0.01));
+
+            //Test what happens when all intensity pairs include 1 zero
+            primary = new MzSpectrum(new double[] { 1, 2, 3 }, new double[] { 0, 4, 6 }, false);
+            secondary = new MzSpectrum(new double[] { 4, 5 }, new double[] { 2, 0 }, false);
+
+            s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.spectrumSum, ppmTolerance, true);
+            Assert.AreEqual(5, s.intensityPairs.Count);
+            Assert.That(s.CosineSimilarity(), Is.EqualTo(0).Within(0.01));
+            Assert.That(s.SpectralContrastAngle(), Is.EqualTo(0).Within(0.01));
+            Assert.That(s.EuclideanDistance(), Is.EqualTo(-0.23).Within(0.01));
+            Assert.That(s.BrayCurtis(), Is.EqualTo(0).Within(0.01));
+            Assert.That(s.PearsonsCorrelation(), Is.EqualTo(-0.40).Within(0.01));
+            Assert.That(s.DotProduct(), Is.EqualTo(0).Within(0.01));
+
+            //explore bounds of binary search
+            primary = new MzSpectrum(new double[] { 1, 2, 3, 4 }, new double[] { 1, 2, 3, 4 }, false);
+            secondary = new MzSpectrum(new double[] { 1.000009, 1.99999, 3.00004, 3.99995 }, new double[] { 1, 2, 3, 4 }, false);
+
+            s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.spectrumSum, ppmTolerance, true);
+            Assert.AreEqual(7, s.intensityPairs.Count);
+
+            //Test alternate constructor
+            primary = new MzSpectrum(new double[] { 1, 2, 3 }, new double[] { 2, 4, 6 }, false);
+            secondary = new MzSpectrum(new double[] { 1 }, new double[] { 2 }, false);
+            s = new SpectralSimilarity(primary, secondary.XArray, secondary.YArray, SpectralSimilarity.SpectrumNormalizationScheme.mostAbundantPeak, ppmTolerance, true);
+            Assert.That(s.CosineSimilarity(), Is.EqualTo(0.27).Within(0.01));
+            Assert.That(s.SpectralContrastAngle(), Is.EqualTo(0.17).Within(0.01));
+            Assert.That(s.EuclideanDistance(), Is.EqualTo(-0.37).Within(0.01));
+            Assert.That(s.BrayCurtis(), Is.EqualTo(0.22).Within(0.01));
+            Assert.That(s.PearsonsCorrelation(), Is.EqualTo(-0.87).Within(0.01));
+            Assert.That(s.DotProduct(), Is.EqualTo(0.33).Within(0.01));
+
+            //Test alternate constructor only library peaks. Since library has one peak, and primary has three peaks, we get only one intensity pair
+            primary = new MzSpectrum(new double[] { 1, 2, 3 }, new double[] { 2, 4, 6 }, false);
+            secondary = new MzSpectrum(new double[] { 1 }, new double[] { 2 }, false);
+            s = new SpectralSimilarity(primary, secondary.XArray, secondary.YArray, SpectralSimilarity.SpectrumNormalizationScheme.mostAbundantPeak, ppmTolerance, false);
+            Assert.AreEqual(1, s.intensityPairs.Count);
+            Assert.That(s.CosineSimilarity(), Is.EqualTo(1.0).Within(0.01));
+            Assert.That(s.SpectralContrastAngle(), Is.EqualTo(1.0).Within(0.01));
+            Assert.That(s.EuclideanDistance(), Is.EqualTo(0.33).Within(0.01));
+            Assert.That(s.BrayCurtis(), Is.EqualTo(0.50).Within(0.01));
+            Assert.That(s.PearsonsCorrelation(), Is.EqualTo(-1.0).Within(0.01));
+            Assert.That(s.DotProduct(), Is.EqualTo(0.33).Within(0.01));
+        }
+    }
+}

--- a/Test/TestSpectralSimilarity.cs
+++ b/Test/TestSpectralSimilarity.cs
@@ -121,7 +121,7 @@ namespace Test
             secondary = new MzSpectrum(new double[] { 1.000011, 1.99997, 3.000031, 3.99995 }, new double[] { 1, 2, 3, 4 }, false);
 
             s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.spectrumSum, ppmTolerance, true);
-            Assert.AreEqual(6, s.intensityPairs.Count);
+            Assert.AreEqual(8, s.intensityPairs.Count);
 
             //Test alternate constructor
             primary = new MzSpectrum(new double[] { 1, 2, 3 }, new double[] { 2, 4, 6 }, false);

--- a/Test/TestSpectralSimilarity.cs
+++ b/Test/TestSpectralSimilarity.cs
@@ -117,10 +117,10 @@ namespace Test
 
             //explore bounds of binary search
             primary = new MzSpectrum(new double[] { 1, 2, 3, 4 }, new double[] { 1, 2, 3, 4 }, false);
-            secondary = new MzSpectrum(new double[] { 1.000009, 1.99999, 3.00004, 3.99995 }, new double[] { 1, 2, 3, 4 }, false);
+            secondary = new MzSpectrum(new double[] { 1.000011, 1.99997, 3.000031, 3.99995 }, new double[] { 1, 2, 3, 4 }, false);
 
             s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.spectrumSum, ppmTolerance, true);
-            Assert.AreEqual(7, s.intensityPairs.Count);
+            Assert.AreEqual(8, s.intensityPairs.Count);
 
             //Test alternate constructor
             primary = new MzSpectrum(new double[] { 1, 2, 3 }, new double[] { 2, 4, 6 }, false);

--- a/Test/TestSpectralSimilarity.cs
+++ b/Test/TestSpectralSimilarity.cs
@@ -2,6 +2,7 @@
 using MassSpectrometry.MzSpectra;
 using MzLibUtil;
 using NUnit.Framework;
+using System;
 
 namespace Test
 {
@@ -120,7 +121,7 @@ namespace Test
             secondary = new MzSpectrum(new double[] { 1.000011, 1.99997, 3.000031, 3.99995 }, new double[] { 1, 2, 3, 4 }, false);
 
             s = new SpectralSimilarity(primary, secondary, SpectralSimilarity.SpectrumNormalizationScheme.spectrumSum, ppmTolerance, true);
-            Assert.AreEqual(8, s.intensityPairs.Count);
+            Assert.AreEqual(6, s.intensityPairs.Count);
 
             //Test alternate constructor
             primary = new MzSpectrum(new double[] { 1, 2, 3 }, new double[] { 2, 4, 6 }, false);
@@ -144,6 +145,14 @@ namespace Test
             Assert.That(s.BrayCurtis(), Is.EqualTo(0.50).Within(0.01));
             Assert.That(s.PearsonsCorrelation(), Is.EqualTo(-1.0).Within(0.01));
             Assert.That(s.DotProduct(), Is.EqualTo(0.33).Within(0.01));
+
+            //Test cosine similarity when there are no peaks from spectrum one matching spectrum 2
+            primary = new MzSpectrum(new double[] { 1, 2, 3 }, new double[] { 2, 4, 6 }, false);
+            secondary = new MzSpectrum(new double[] { 4,6,8 }, new double[] { 2,4,6 }, false);
+            s = new SpectralSimilarity(primary, secondary.XArray, secondary.YArray, SpectralSimilarity.SpectrumNormalizationScheme.mostAbundantPeak, ppmTolerance, false);
+            Assert.AreEqual(3, s.intensityPairs.Count);
+            Assert.That(s.CosineSimilarity(), Is.EqualTo(0).Within(0.01));
+            Assert.That(s.SpectralContrastAngle(), Is.EqualTo(0).Within(0.01));
         }
     }
 }

--- a/TestFlashLFQ/TestFlashLFQ.cs
+++ b/TestFlashLFQ/TestFlashLFQ.cs
@@ -84,6 +84,53 @@ namespace Test
         }
 
         [Test]
+        public static void TestFlashLfqWithPercolatorStyleIds()
+        {
+            // get the raw file paths
+            SpectraFileInfo raw = new SpectraFileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", @"sliced-raw.raw"), "a", 0, 0, 0);
+            SpectraFileInfo mzml = new SpectraFileInfo(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", @"sliced-mzml.mzml"), "a", 1, 0, 0);
+
+            // create some PSMs
+            var pg = new ProteinGroup("MyProtein", "gene", "org");
+            Identification id1 = new Identification(raw, "EGFQVADGPLYR", 1350.65681, 94.12193, 2, new List<ProteinGroup> { pg });
+            Identification id2 = new Identification(raw, "EGFQVADGPLYR", 1350.65681, 94.05811, 2, new List<ProteinGroup> { pg });
+            Identification id3 = new Identification(mzml, "EGFQVADGPLYR", 1350.65681, 94.12193, 2, new List<ProteinGroup> { pg });
+            Identification id4 = new Identification(mzml, "EGFQVADGPLYR", 1350.65681, 94.05811, 2, new List<ProteinGroup> { pg });
+
+            // create the FlashLFQ engine
+            FlashLfqEngine engine = new FlashLfqEngine(new List<Identification> { id1, id2, id3, id4 }, normalize: true, maxThreads: 1);
+
+            // run the engine
+            var results = engine.Run();
+
+            // check raw results
+            Assert.That(results.Peaks[raw].Count == 1);
+            Assert.That(results.Peaks[raw].First().Intensity > 0);
+            Assert.That(!results.Peaks[raw].First().IsMbrPeak);
+            Assert.That(results.PeptideModifiedSequences["EGFQVADGPLYR"].GetIntensity(raw) > 0);
+            Assert.That(results.ProteinGroups["MyProtein"].GetIntensity(raw) > 0);
+
+            // check mzml results
+            Assert.That(results.Peaks[mzml].Count == 1);
+            Assert.That(results.Peaks[mzml].First().Intensity > 0);
+            Assert.That(!results.Peaks[mzml].First().IsMbrPeak);
+            Assert.That(results.PeptideModifiedSequences["EGFQVADGPLYR"].GetIntensity(mzml) > 0);
+            Assert.That(results.ProteinGroups["MyProtein"].GetIntensity(mzml) > 0);
+
+            // check that condition normalization worked
+            int int1 = (int)System.Math.Round(results.Peaks[mzml].First().Intensity, 0);
+            int int2 = (int)System.Math.Round(results.Peaks[raw].First().Intensity, 0);
+            Assert.That(int1 == int2);
+
+            // test peak output
+            results.WriteResults(
+                Path.Combine(TestContext.CurrentContext.TestDirectory, @"peaks.tsv"),
+                Path.Combine(TestContext.CurrentContext.TestDirectory, @"modSeq.tsv"),
+                Path.Combine(TestContext.CurrentContext.TestDirectory, @"protein.tsv"),
+                null,
+                true);
+        }
+        [Test]
         public static void TestEnvelopQuantification()
         {
             Loaders.LoadElements();
@@ -1311,4 +1358,5 @@ namespace Test
             File.Delete(filepath);
         }
     }
+
 }

--- a/TestFlashLFQ/TestFlashLFQ.cs
+++ b/TestFlashLFQ/TestFlashLFQ.cs
@@ -92,10 +92,10 @@ namespace Test
 
             // create some PSMs
             var pg = new ProteinGroup("MyProtein", "gene", "org");
-            Identification id1 = new Identification(raw, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.12193, 2, new List<ProteinGroup> { pg });
-            Identification id2 = new Identification(raw, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.05811, 2, new List<ProteinGroup> { pg });
-            Identification id3 = new Identification(mzml, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.12193, 2, new List<ProteinGroup> { pg });
-            Identification id4 = new Identification(mzml, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.05811, 2, new List<ProteinGroup> { pg });
+            Identification id1 = new Identification(raw, null, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.12193, 2, new List<ProteinGroup> { pg });
+            Identification id2 = new Identification(raw, null, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.05811, 2, new List<ProteinGroup> { pg });
+            Identification id3 = new Identification(mzml, null, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.12193, 2, new List<ProteinGroup> { pg });
+            Identification id4 = new Identification(mzml, null, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.05811, 2, new List<ProteinGroup> { pg });
 
             // create the FlashLFQ engine
             FlashLfqEngine engine = new FlashLfqEngine(new List<Identification> { id1, id2, id3, id4 }, normalize: true, maxThreads: 1);

--- a/TestFlashLFQ/TestFlashLFQ.cs
+++ b/TestFlashLFQ/TestFlashLFQ.cs
@@ -92,10 +92,10 @@ namespace Test
 
             // create some PSMs
             var pg = new ProteinGroup("MyProtein", "gene", "org");
-            Identification id1 = new Identification(raw, "EGFQVADGPLYR", 1350.65681, 94.12193, 2, new List<ProteinGroup> { pg });
-            Identification id2 = new Identification(raw, "EGFQVADGPLYR", 1350.65681, 94.05811, 2, new List<ProteinGroup> { pg });
-            Identification id3 = new Identification(mzml, "EGFQVADGPLYR", 1350.65681, 94.12193, 2, new List<ProteinGroup> { pg });
-            Identification id4 = new Identification(mzml, "EGFQVADGPLYR", 1350.65681, 94.05811, 2, new List<ProteinGroup> { pg });
+            Identification id1 = new Identification(raw, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.12193, 2, new List<ProteinGroup> { pg });
+            Identification id2 = new Identification(raw, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.05811, 2, new List<ProteinGroup> { pg });
+            Identification id3 = new Identification(mzml, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.12193, 2, new List<ProteinGroup> { pg });
+            Identification id4 = new Identification(mzml, "EGFQVAD[15.99]GPLYR", 1350.65681, 94.05811, 2, new List<ProteinGroup> { pg });
 
             // create the FlashLFQ engine
             FlashLfqEngine engine = new FlashLfqEngine(new List<Identification> { id1, id2, id3, id4 }, normalize: true, maxThreads: 1);
@@ -107,14 +107,14 @@ namespace Test
             Assert.That(results.Peaks[raw].Count == 1);
             Assert.That(results.Peaks[raw].First().Intensity > 0);
             Assert.That(!results.Peaks[raw].First().IsMbrPeak);
-            Assert.That(results.PeptideModifiedSequences["EGFQVADGPLYR"].GetIntensity(raw) > 0);
+            Assert.That(results.PeptideModifiedSequences["EGFQVAD[15.99]GPLYR"].GetIntensity(raw) > 0);
             Assert.That(results.ProteinGroups["MyProtein"].GetIntensity(raw) > 0);
 
             // check mzml results
             Assert.That(results.Peaks[mzml].Count == 1);
             Assert.That(results.Peaks[mzml].First().Intensity > 0);
             Assert.That(!results.Peaks[mzml].First().IsMbrPeak);
-            Assert.That(results.PeptideModifiedSequences["EGFQVADGPLYR"].GetIntensity(mzml) > 0);
+            Assert.That(results.PeptideModifiedSequences["EGFQVAD[15.99]GPLYR"].GetIntensity(mzml) > 0);
             Assert.That(results.ProteinGroups["MyProtein"].GetIntensity(mzml) > 0);
 
             // check that condition normalization worked


### PR DESCRIPTION
I'm updating FlashLFQ for percolator input. There are three issues to deal with:
1. there is no filename, only a file integer. We're hoping the percolator people will update their output as a solution. otherwise the user will have to manually change this.
2. there is no retention time. We're modifying FlashLFQ to read retention time from the raw data file using the scan number supplied in the percolator output.
3. many modified sequences are unreadable because they contain characters with no meaning to our sequence parser. These sequences will be used as unique peptide/proteoform identifiers BUT NOT BE USED TO COMPUTE PEPTIDE/PROTEOFORM MASS.