### PR TITLE
Change directory before restore in release workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,11 +34,9 @@ jobs:
         cd mzLib;
         dotnet test --no-build --verbosity normal
           --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura
-          /p:CoverletOutput='../../coberturatest.xml'
           ./Test/Test.csproj;
         dotnet test --no-build --verbosity normal
           --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura
-          /p:CoverletOutput='../../coberturatestlfq.xml'
           ./TestFlashLFQ/TestFlashLFQ.csproj;
     - name: Directory lists
       run:
@@ -48,4 +46,4 @@ jobs:
       uses: codecov/codecov-action@v2
       with:
         verbose: true
-        files: ./coberturatest.xml,./coberturatestlfq.xml
+        files: mzLib/Test*/TestResults/*/coverage.cobertura.xml

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,20 +24,20 @@ jobs:
         dotnet build --no-restore;
         dotnet build --no-restore ./Test/Test.csproj;
         dotnet build --no-restore ./TestFlashLFQ/TestFlashLFQ.csproj;
-    - name: Add msbuild
+    - name: Add coverlet collector
       run:
         cd mzLib;
-        dotnet add Test/Test.csproj package coverlet.msbuild;
-        dotnet add TestFlashLFQ/TestFlashLFQ.csproj package coverlet.msbuild;
+        dotnet add Test/Test.csproj package coverlet.collector;
+        dotnet add TestFlashLFQ/TestFlashLFQ.csproj package coverlet.collector;
     - name: Test
       run:
         cd mzLib;
         dotnet test --no-build --verbosity normal
-          /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+          --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura
           /p:CoverletOutput='../../coberturatest.xml'
           ./Test/Test.csproj;
         dotnet test --no-build --verbosity normal
-          /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+          --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura
           /p:CoverletOutput='../../coberturatestlfq.xml'
           ./TestFlashLFQ/TestFlashLFQ.csproj;
     - name: Directory lists

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,17 +15,16 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.x
-
       - name: Verify commit exists in origin/master
         run: |
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
           git branch --remote --contains | grep origin/${env:RELEASE_BRANCH}
         env:
           RELEASE_BRANCH: master
-
       - name: Restore dependencies
-        run: dotnet restore
-
+        run: |
+          cd mzLib
+          dotnet restore
       - name: Build
         run: |
           $version= &git describe --tags

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ A library for mass spectrometry projects.
 [![codecov](https://codecov.io/gh/smith-chem-wisc/mzLib/branch/master/graph/badge.svg)](https://codecov.io/gh/smith-chem-wisc/mzLib)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/10000/badge.svg)](https://scan.coverity.com/projects/mzlib)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1047dac2ae8d4d94b104c3cb3ca44926)](https://www.codacy.com/app/solntsev_2/mzLib?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=smith-chem-wisc/mzLib&amp;utm_campaign=Badge_Grade)
-[![NuGet version (mzLib)](https://img.shields.io/nuget/v/mzLib.svg?style=flat-square)](https://www.nuget.org/packages/mzLib/)
-
+[![NuGet Badge](https://buildstats.info/nuget/mzLib)](https://www.nuget.org/packages/mzLib/)
 
 Releases are here: https://www.nuget.org/packages/mzLib/
 


### PR DESCRIPTION
Apparently coverlet.collector is more dependable than coverlet.msbuild (https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/VSTestIntegration.md)