### PR TITLE
Pro alanase

### DIFF
--- a/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
+++ b/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
@@ -22,3 +22,4 @@ collagenase	GPX|GPX			full
 StcE-trypsin	"TX|T,TX|S,SX|T,SX|S,K|,R|"			full		StcE/Trpsin			
 CNBr_old	M|			full	MS:1001307	CNBr	(?<=M)		
 CNBr_N	|M			full	MS:1001307	CNBr	(?<=M)	Test on M	
+ProAlanase	"P|,A"			full		

--- a/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
+++ b/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
@@ -14,11 +14,12 @@ semi-trypsin	"K|,R|"			semi	MS:1001313	Trypsin/P	(?<=[KR])
 trypsin	"K|,R|"			full	MS:1001313	Trypsin/P	(?<=[KR])		
 tryptophan oxidation	W|			full					
 non-specific	X|			full	MS:1001956	unspecific cleavage			
-top-down				none	MS:1001955	no cleavage						
+top-down				none	MS:1001955	no cleavage			
 singleN				SingleN	MS:1001957	single cleavage			
 singleC				SingleC	MS:1001958	single cleavage			
 peptidomics				none		no cleavage			
 collagenase	GPX|GPX			full					
 StcE-trypsin	"TX|T,TX|S,SX|T,SX|S,K|,R|"			full		StcE/Trpsin			
 CNBr_old	M|			full	MS:1001307	CNBr	(?<=M)		
-CNBr_N	|M			full	MS:1001307	CNBr	(?<=M)	Test on M	
+CNBr_N	|M			full	MS:1001307	CNBr	(?<=M)	Test on M			
+ProAlanase	"P|,A"			full	

--- a/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
+++ b/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
@@ -22,4 +22,4 @@ collagenase	GPX|GPX			full
 StcE-trypsin	"TX|T,TX|S,SX|T,SX|S,K|,R|"			full		StcE/Trpsin			
 CNBr_old	M|			full	MS:1001307	CNBr	(?<=M)		
 CNBr_N	|M			full	MS:1001307	CNBr	(?<=M)	Test on M	
-ProAlanase	"P|,A"			full		
+ProAlanase	"P| ,A|"			full		

--- a/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
+++ b/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
@@ -14,12 +14,11 @@ semi-trypsin	"K|,R|"			semi	MS:1001313	Trypsin/P	(?<=[KR])
 trypsin	"K|,R|"			full	MS:1001313	Trypsin/P	(?<=[KR])		
 tryptophan oxidation	W|			full					
 non-specific	X|			full	MS:1001956	unspecific cleavage			
-top-down				none	MS:1001955	no cleavage			
+top-down				none	MS:1001955	no cleavage						
 singleN				SingleN	MS:1001957	single cleavage			
 singleC				SingleC	MS:1001958	single cleavage			
 peptidomics				none		no cleavage			
 collagenase	GPX|GPX			full					
 StcE-trypsin	"TX|T,TX|S,SX|T,SX|S,K|,R|"			full		StcE/Trpsin			
 CNBr_old	M|			full	MS:1001307	CNBr	(?<=M)		
-CNBr_N	|M			full	MS:1001307	CNBr	(?<=M)	Test on M			
-ProAlanase	"P|,A"			full	
+CNBr_N	|M			full	MS:1001307	CNBr	(?<=M)	Test on M	

--- a/mzLib/mzLib.nuspec
+++ b/mzLib/mzLib.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>mzLib</id>
-    <version>2.0.123</version>
+    <version>0.0.1</version>
     <title>mzLib</title>
     <authors>Stef S.</authors>
     <owners>Stef S.</owners>

--- a/mzLib/mzLib.nuspec
+++ b/mzLib/mzLib.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>mzLib</id>
-    <version>0.0.1</version>
+    <version>2.0.123</version>
     <title>mzLib</title>
     <authors>Stef S.</authors>
     <owners>Stef S.</owners>


### PR DESCRIPTION
New Site-Specific Endoprotease that Targets Proline and Alanine

    Cleaves primarily C-terminal to proline and alanine residues
    Active at acidic pH (1–5.5) with a pH optimum of ~1.5
    Short digestion times of 1–2 hours
