### PR TITLE
Fixing uniprot queries

### DIFF
--- a/mzLib/UsefulProteomicsDatabases/Loaders.cs
+++ b/mzLib/UsefulProteomicsDatabases/Loaders.cs
@@ -170,7 +170,7 @@ namespace UsefulProteomicsDatabases
             Uri uri = new(url);
             HttpClient client = new();
             HttpResponseMessage urlResponse = Task.Run(() => client.GetAsync(uri)).Result;
-            using (FileStream stream = new(outputFile, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+            using (FileStream stream = new(outputFile, FileMode.CreateNew))
             {
                 Task.Run(() => urlResponse.Content.CopyToAsync(stream)).Wait();
             }

--- a/mzLib/UsefulProteomicsDatabases/Loaders.cs
+++ b/mzLib/UsefulProteomicsDatabases/Loaders.cs
@@ -170,7 +170,7 @@ namespace UsefulProteomicsDatabases
             Uri uri = new(url);
             HttpClient client = new();
             HttpResponseMessage urlResponse = Task.Run(() => client.GetAsync(uri)).Result;
-            using (FileStream stream = new(outputFile, FileMode.CreateNew))
+            using (FileStream stream = new(outputFile, FileMode.OpenOrCreate, FileAccess.ReadWrite))
             {
                 Task.Run(() => urlResponse.Content.CopyToAsync(stream)).Wait();
             }

--- a/mzLib/UsefulProteomicsDatabases/ProteinDbRetriever.cs
+++ b/mzLib/UsefulProteomicsDatabases/ProteinDbRetriever.cs
@@ -19,17 +19,22 @@ namespace UsefulProteomicsDatabases
         /// <param name="reviewed">if yes file contains only reviewd proteins</param>
         /// <param name="compress">if yes file is saved as .gz</param>
         /// <param name="absolutePathToStorageDirectory"></param>
-        public static string RetrieveProteome(string proteomeID, string absolutePathToStorageDirectory, ProteomeFormat format, Reviewed reviewed, Compress compress, IncludeIsoforms include)
+        public static string RetrieveProteome(string proteomeID, string absolutePathToStorageDirectory, ProteomeFormat format, 
+            Reviewed reviewed, Compress compress, IncludeIsoforms include)
         {
             if (Directory.Exists(absolutePathToStorageDirectory))
             {
                 string htmlQueryString = "";
                 string filename = "\\" + proteomeID;
+                bool compressBool = false; 
+                bool isoformBool = false; 
+                bool reviewedBool = false; 
                 if (format == ProteomeFormat.fasta)
                 {
                     if (reviewed == Reviewed.yes)
                     {
                         filename += "_reviewed";
+                        reviewedBool = true; 
                     }
                     else
                     {
@@ -39,19 +44,23 @@ namespace UsefulProteomicsDatabases
                     if (include == IncludeIsoforms.yes)
                     {
                         filename += "_isoform";
+                        isoformBool = true;
                     }
                     filename += ".fasta";
                     if (compress == Compress.yes)
                     {
                         filename += ".gz";
+                        compressBool = true;
                     }
-                    htmlQueryString = "https://www.uniprot.org/uniprot/?query=proteome:" + proteomeID + " reviewed:" + reviewed + "&compress=" + compress + "&format=" + format + "&include:" + include;
+                    htmlQueryString = "https://rest.uniprot.org/uniprot/search?query=" + proteomeID + "+AND+" + "reviewed:" + reviewedBool.ToString().ToLower() + 
+                        "&compressed=" + compressBool.ToString().ToLower() + "&format=" + format + "&includeIsoforms:" + isoformBool.ToString().ToLower();
                 }
                 else if (format == ProteomeFormat.xml)
                 {
                     if (reviewed == Reviewed.yes)
                     {
                         filename += "_reviewed";
+                        reviewedBool = true; 
                     }
                     else
                     {
@@ -61,8 +70,10 @@ namespace UsefulProteomicsDatabases
                     if (compress == Compress.yes)
                     {
                         filename += ".gz";
+                        compressBool = true; 
                     }
-                    htmlQueryString = "https://www.uniprot.org/uniprot/?query=proteome:" + proteomeID + " reviewed:" + reviewed + "&compress=" + compress + "&format=" + format;
+                    htmlQueryString = "https://rest.uniprot.org/proteome/search?query=" + proteomeID + "+AND+reviewed:" + reviewedBool.ToString().ToLower()
+                        + "&compressed=" + compressBool.ToString().ToLower() + "&format=" + format;
                 }
                 if (htmlQueryString.Length > 0)
                 {
@@ -86,7 +97,8 @@ namespace UsefulProteomicsDatabases
         {
             if (Directory.Exists(destinationFolder))
             {
-                string htmlQueryString = "https://www.uniprot.org/proteomes/?query=*&format=tab&compress=yes&columns=id,name,organism-id,proteincount,busco,cpd,assembly%20representation";
+                
+                string htmlQueryString = "https://rest.uniprot.org/proteomes/search?query=*&format=tsv&compressed=true";
                 string filename = "availableUniProtProteomes.txt.gz";
 
                 string filepath = Path.Combine(destinationFolder, filename);


### PR DESCRIPTION
I fixed the queries for the methods in DownloadAvailableUniProtProteomes and RetrieveProteome. That fixed 3 unit tests. The four still failing all have something to do with xml, so potentially the xml structure of the UniProt downloads has changed. That is out of my wheelhouse though 