### PR TITLE
Changed Masses and Intensities field in IsotopicDistribution

### DIFF
--- a/mzLib/Chemistry/IsotopicDistribution.cs
+++ b/mzLib/Chemistry/IsotopicDistribution.cs
@@ -56,8 +56,9 @@ namespace Chemistry
             intensities = new double[count];
         }
 
-        public IEnumerable<double> Masses { get { return masses; } }
-        public IEnumerable<double> Intensities { get { return intensities; } }
+        // Clone() produces shallow copies, but because double is a primitive type, this is acceptable
+        public double[] Masses { get { return (double[]) masses.Clone(); } }
+        public double[] Intensities { get { return (double[]) intensities.Clone(); } }
 
         public static IsotopicDistribution GetDistribution(ChemicalFormula formula)
         {

--- a/mzLib/Chemistry/IsotopicDistribution.cs
+++ b/mzLib/Chemistry/IsotopicDistribution.cs
@@ -57,8 +57,8 @@ namespace Chemistry
         }
 
         // Clone() produces shallow copies, but because double is a primitive type, this is acceptable
-        public double[] Masses { get { return (double[]) masses.Clone(); } }
-        public double[] Intensities { get { return (double[]) intensities.Clone(); } }
+        public double[] Masses => (double[]) masses.Clone();
+        public double[] Intensities => (double[]) intensities.Clone();
 
         public static IsotopicDistribution GetDistribution(ChemicalFormula formula)
         {


### PR DESCRIPTION
These fields now return double arrays, instead of IEnumerable. This ensures that the return type is ordered.

Blog post on relevant syntax: 
https://www.codeproject.com/Articles/1064964/A-Csharp-Gotcha-Initialization-vs-Expression-Bodie

Closes #672 