### PR TITLE
Change CompareTo method within DoubleRange to adhere to conventions

### DIFF
--- a/mzLib/MzLibUtil/DoubleRange.cs
+++ b/mzLib/MzLibUtil/DoubleRange.cs
@@ -86,7 +86,7 @@ namespace MzLibUtil
         /// If the 'item' falls within the range, 0 is returned
         /// </summary>
         /// <param name="item"> A double the range will be compared against </param>
-        /// <returns></returns>
+        /// <returns> 1, 0, or -1 </returns>
         public int CompareTo(double item)
         {
             if (Minimum.CompareTo(item) > 0)

--- a/mzLib/MzLibUtil/DoubleRange.cs
+++ b/mzLib/MzLibUtil/DoubleRange.cs
@@ -79,12 +79,20 @@ namespace MzLibUtil
             return $"[{Minimum.ToString(format, System.Globalization.CultureInfo.InvariantCulture)};{Maximum.ToString(format, System.Globalization.CultureInfo.InvariantCulture)}]";
         }
 
+        /// <summary>
+        /// Compares the DoubleRange to a double 'item' passed in.
+        /// If the 'item' falls below the range, 1 is returned (the range is greater than the item)
+        /// If the 'item' falls above the range, -1 is returned (the range is less than the item)
+        /// If the 'item' falls within the range, 0 is returned
+        /// </summary>
+        /// <param name="item"> A double the range will be compared against </param>
+        /// <returns></returns>
         public int CompareTo(double item)
         {
             if (Minimum.CompareTo(item) > 0)
-                return -1;
-            if (Maximum.CompareTo(item) < 0)
                 return 1;
+            if (Maximum.CompareTo(item) < 0)
+                return -1;
             return 0;
         }
 

--- a/mzLib/Test/TestRangeAndTolerances.cs
+++ b/mzLib/Test/TestRangeAndTolerances.cs
@@ -42,6 +42,40 @@ namespace Test
             Console.WriteLine($"Analysis time: {Stopwatch.Elapsed.Hours}h {Stopwatch.Elapsed.Minutes}m {Stopwatch.Elapsed.Seconds}s");
         }
 
+        #region DoubleRangeTests
+
+        [Test]
+        public void RangeCompareToTest()
+        {
+            // In C#, the convention is that when writing CompareTo methods,
+            // the instance is compared to the object (argument)
+            // If the instance is less than the argument, a negative value is returned
+            // If the instance is greater than the argument, a positive value is returned
+            // An example of this is given below
+            Double five = 5;
+            double ten = 10;
+            Assert.That(five.CompareTo(ten) < 0);
+
+            // Range is greater than value
+            var range = new DoubleRange(3, 10);
+            int value = 1;
+
+            int comparison = range.CompareTo(value);
+            Assert.AreEqual(1, comparison);
+
+            // Range contains value
+            value = 5;
+
+            comparison = range.CompareTo(value);
+            Assert.AreEqual(0, comparison);
+            
+            //Range is less than value
+            value = 12;
+
+            comparison = range.CompareTo(value);
+            Assert.AreEqual(-1, comparison);
+        }
+
         [Test]
         public void RangeSubRange()
         {
@@ -163,39 +197,6 @@ namespace Test
         }
 
         [Test]
-        public void RangeCompareToBelow()
-        {
-            var range = new DoubleRange(3, 10);
-            int value = 1;
-
-            int comp = range.CompareTo(value);
-
-            Assert.AreEqual(-1, comp);
-        }
-
-        [Test]
-        public void RangeCompareToWithin()
-        {
-            var range = new DoubleRange(3, 10);
-            int value = 5;
-
-            int comp = range.CompareTo(value);
-
-            Assert.AreEqual(0, comp);
-        }
-
-        [Test]
-        public void RangeCompareToAbove()
-        {
-            var range = new DoubleRange(3, 10);
-            int value = 12;
-
-            int comp = range.CompareTo(value);
-
-            Assert.AreEqual(1, comp);
-        }
-
-        [Test]
         public void RangesAreEquivalentNotReference()
         {
             var range1 = new DoubleRange(3, 10);
@@ -203,6 +204,9 @@ namespace Test
 
             Assert.AreNotSame(range1, range2);
         }
+
+
+        #endregion
 
         [Test]
         public void ToleranceParseAndWithin()


### PR DESCRIPTION
In C#, the convention for CompareTo methods is to compare the instance to the item passed as an argument. For example

`Double five = 5;`
`double ten = 10;`
`five.CompareTo(ten);`

Would return -1, because five is less than ten. The current implementation of DoubleRange.CompareTo() has this reversed. This PR fixes that (admittedly pedantic) issue.

https://learn.microsoft.com/en-us/dotnet/api/system.int32.compareto?view=net-7.0
https://learn.microsoft.com/en-us/dotnet/api/system.double.compareto?view=net-7.0