### PR TITLE
Edited normalization methods within SpectralSimilarity 

### DIFF
--- a/mzLib/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
+++ b/mzLib/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
@@ -177,37 +177,40 @@ namespace MassSpectrometry.MzSpectra
 
         #region normalization
 
-        private double[] NormalizeSquareRootSpectrumSum(double[] spectrum)
+        public double[] NormalizeSquareRootSpectrumSum(double[] spectrum)
         {
             double sqrtSum = spectrum.Select(y => Math.Sqrt(y)).Sum();
+            double[] normalizedSpectrum = new double[spectrum.Length];
 
             for (int i = 0; i < spectrum.Length; i++)
             {
-                spectrum[i] = Math.Sqrt(spectrum[i]) / sqrtSum;
+                normalizedSpectrum[i] = Math.Sqrt(spectrum[i]) / sqrtSum;
             }
-            return spectrum;
+            return normalizedSpectrum;
         }
 
-        private double[] NormalizeMostAbundantPeak(double[] spectrum)
+        public double[] NormalizeMostAbundantPeak(double[] spectrum)
         {
             double max = spectrum.Max();
+            double[] normalizedSpectrum = new double[spectrum.Length];
 
             for (int i = 0; i < spectrum.Length; i++)
             {
-                spectrum[i] = spectrum[i] / max;
+                normalizedSpectrum[i] = spectrum[i] / max;
             }
-            return spectrum;
+            return normalizedSpectrum;
         }
 
-        private double[] NormalizeSpectrumSum(double[] spectrum)
+        public double[] NormalizeSpectrumSum(double[] spectrum)
         {
             double sum = spectrum.Sum();
+            double[] normalizedSpectrum = new double[spectrum.Length];
 
             for (int i = 0; i < spectrum.Length; i++)
             {
-                spectrum[i] = spectrum[i] / sum;
+                normalizedSpectrum[i] = spectrum[i] / sum;
             }
-            return spectrum;
+            return normalizedSpectrum;
         }
 
         #endregion normalization

--- a/mzLib/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
+++ b/mzLib/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
@@ -177,7 +177,7 @@ namespace MassSpectrometry.MzSpectra
 
         #region normalization
 
-        public double[] NormalizeSquareRootSpectrumSum(double[] spectrum)
+        public static double[] NormalizeSquareRootSpectrumSum(double[] spectrum)
         {
             double sqrtSum = spectrum.Select(y => Math.Sqrt(y)).Sum();
             double[] normalizedSpectrum = new double[spectrum.Length];
@@ -189,7 +189,7 @@ namespace MassSpectrometry.MzSpectra
             return normalizedSpectrum;
         }
 
-        public double[] NormalizeMostAbundantPeak(double[] spectrum)
+        public static double[] NormalizeMostAbundantPeak(double[] spectrum)
         {
             double max = spectrum.Max();
             double[] normalizedSpectrum = new double[spectrum.Length];
@@ -201,7 +201,7 @@ namespace MassSpectrometry.MzSpectra
             return normalizedSpectrum;
         }
 
-        public double[] NormalizeSpectrumSum(double[] spectrum)
+        public static double[] NormalizeSpectrumSum(double[] spectrum)
         {
             double sum = spectrum.Sum();
             double[] normalizedSpectrum = new double[spectrum.Length];


### PR DESCRIPTION
These methods no longer alter the arrays passed in as arguments. Additionally, the methods have been made public. 

Closes #676 