### PR TITLE
Mrs noise estimation

### DIFF
--- a/mzLib/SpectralAveraging/Algorithms/SpectralWeighting.cs
+++ b/mzLib/SpectralAveraging/Algorithms/SpectralWeighting.cs
@@ -85,7 +85,7 @@ public static class SpectralWeighting
             .ForAll(x =>
             {
                 bool mrsSuccess = MRSNoiseEstimator.MRSNoiseEstimation(x.Array, 0.01, out double noiseEstimate);
-                if (!mrsSuccess || double.IsNaN(noiseEstimate))
+                if (!mrsSuccess || double.IsNaN(noiseEstimate) || noiseEstimate == 0d)
                 {
                     noiseEstimate = BasicStatistics.CalculateStandardDeviation(x.Array);
                 }

--- a/mzLib/SpectralAveraging/Algorithms/SpectralWeighting.cs
+++ b/mzLib/SpectralAveraging/Algorithms/SpectralWeighting.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using MzLibUtil;
 
 namespace SpectralAveraging;
@@ -29,7 +32,7 @@ public static class SpectralWeighting
                 return WeightByTicValue(yArrays);
 
             case SpectraWeightingType.MrsNoiseEstimation:
-                throw new MzLibException("Austin will fill this in when he returns from vacation");
+                return WeightByMrsNoiseEstimation(yArrays);
             //return WeightByMrsNoiseEstimation(xArrays, yArrays);
 
             default:
@@ -64,41 +67,71 @@ public static class SpectralWeighting
         return weights;
     }
 
-
-    // NOTE: This will be implemented when Austin gets back from vacation
-    // leaving him a nice place to put it
-
     /// <summary>
-    ///     Given the noise estimates and the scale estimates, calculates the weight given to
-    ///     each spectra when averaging using w_i = 1 / (k * noise_estimate)^2,
-    ///     where k = scaleEstimate_reference / scaleEstimate_i
+    /// Given the noise estimates and the scale estimates, calculates the weight given to
+    /// each spectra when averaging using w_i = 1 / (k * noise_estimate)^2,
+    /// where k = scaleEstimate_reference / scaleEstimate_i. Reference spectra defaults to the
+    /// first spectra
     /// </summary>
-    private static Dictionary<int, double> WeightByMrsNoiseEstimation(double[][] xArrays, double[][] yArrays)
+    private static Dictionary<int, double> WeightByMrsNoiseEstimation(double[][] yArrays)
     {
         var weights = new Dictionary<int, double>();
-        // get noise and scale estimates
-        //SortedDictionary<int, double> noiseEstimates = CalculateNoiseEstimates(pixelStack);
-        //SortedDictionary<int, double> scaleEstimates = CalculateScaleEstimates(pixelStack);
+        // get noise estimate
+        ConcurrentDictionary<int, double> noiseEstimates = new(); 
 
-        //// calculate weights
-        //double referenceScale = scaleEstimates[0];
-        //foreach (var entry in noiseEstimates)
-        //{
-        //    var successScale = scaleEstimates.TryGetValue(entry.Key,
-        //        out double scale);
-        //    if (!successScale) continue;
+        yArrays
+            .Select((w,i) => new {Index = i, Array = w})
+            .AsParallel()
+            .ForAll(x =>
+            {
+                bool mrsSuccess = MRSNoiseEstimator.MRSNoiseEstimation(x.Array, 0.01, out double noiseEstimate);
+                if (!mrsSuccess || double.IsNaN(noiseEstimate))
+                {
+                    noiseEstimate = BasicStatistics.CalculateStandardDeviation(x.Array);
+                }
 
-        //    var successNoise = noiseEstimates.TryGetValue(entry.Key,
-        //        out double noise);
-        //    if (!successNoise) continue;
+                noiseEstimates.TryAdd(x.Index, noiseEstimate);
+            });
+        // get scale estimate 
+        ConcurrentDictionary<int, double> scaleEstimates = new(); 
+        yArrays.Select((w,i) => new {Index = i, Array = w})
+            .AsParallel()
+            .ForAll(x =>
+            {
+                double scale = Math.Sqrt(BasicStatistics.BiweightMidvariance(x.Array));
+                scaleEstimates.TryAdd(x.Index, Math.Sqrt(scale));
+            });
 
-        //    double k = referenceScale / scale;
-
-        //    double weight = 1d / Math.Pow((k * noise), 2);
-
-        //    weights.TryAdd(entry.Key, weight);
-        //}
+        CalculateWeights(noiseEstimates, scaleEstimates, weights);
 
         return weights;
     }
+    /// <summary>
+    /// Given the noise estimates and the scale estimates, calculates the weight given to
+    /// each spectra when averaging using w_i = 1 / (k * noise_estimate)^2,
+    /// where k = scaleEstimate_reference / scaleEstimate_i
+    /// </summary>
+    private static void CalculateWeights(IDictionary<int, double> noiseEstimates, 
+        IDictionary<int, double> scaleEstimates, IDictionary<int, double> weights,int referenceSpectra = 0)
+    {
+        double referenceScale = scaleEstimates[referenceSpectra];
+        foreach (var entry in noiseEstimates)
+        {
+            var successScale = scaleEstimates.TryGetValue(entry.Key,
+                out double scale);
+            if (!successScale) continue;
+
+            var successNoise = noiseEstimates.TryGetValue(entry.Key,
+                out double noise);
+            if (!successNoise) continue;
+
+            double k = referenceScale / scale;
+
+            double weight = 1d / Math.Pow((k * noise), 2);
+
+            weights.TryAdd(entry.Key, weight);
+        }
+    }
+
+    
 }

--- a/mzLib/SpectralAveraging/MrsNoiseEstimation/Level.cs
+++ b/mzLib/SpectralAveraging/MrsNoiseEstimation/Level.cs
@@ -1,0 +1,14 @@
+﻿namespace SpectralAveraging;
+
+public class Level
+{
+    public Level(int scale, double[] waveletCoeff, double[] scalingCoeff)
+    {
+        Scale = scale;
+        WaveletCoeff = waveletCoeff;
+        ScalingCoeff = scalingCoeff;
+    }
+    public int Scale { get; private set; }
+    public double[] WaveletCoeff { get; private set; }
+    public double[] ScalingCoeff { get; private set; }
+}

--- a/mzLib/SpectralAveraging/MrsNoiseEstimation/MRSNoiseEstimator.cs
+++ b/mzLib/SpectralAveraging/MrsNoiseEstimation/MRSNoiseEstimator.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SpectralAveraging
+{
+    public static class MRSNoiseEstimator
+    {
+        /// <summary>
+        /// Method to calculate the estimate of the noise standard deviation using the Multi-Resolution
+        /// Support methods defined by Jean‐Luc Starck and Fionn Murtagh (Feb. 1998). Calculates a Maximum Overlap
+        /// Discrete wavelet transform, then creates a multi-resolution support to find a set of noise pixels. Takes the standard
+        /// deviation of these pixels to estimate the standard deviation of the noise. 
+        /// </summary>
+        /// <param name="signal">A time or frequency domain signal.</param>
+        /// <param name="epsilon">Determines threshold for convergence between two iterations.</param>
+        /// <param name="maxIterations">Maximum number of iterations to perform.</param>
+        /// <returns></returns>
+        public static bool MRSNoiseEstimation(double[] signal, double epsilon,
+            out double noiseEstimate, int maxIterations = 25, 
+            WaveletType waveletType = WaveletType.Haar)
+        {
+            int iterations = 0; 
+            // 1. Estimate the standard deviation of the noise in the original signal. 
+            double stdevPrevious = BasicStatistics.CalculateStandardDeviation(signal);
+
+            // 2. Compute the modwt of the image
+            WaveletFilter filter = new(); 
+            filter.CreateFiltersFromCoeffs(waveletType);
+            ModWtOutput wtOutput = WaveletMath.ModWt(signal, filter);
+
+            // 3. Set n = 0; (this is done implicitly while in the do while loop.)
+
+            double[] signalIterable = new double[signal.Length]; 
+            signal.CopyTo(signalIterable, 0);
+
+
+            signalIterable = CreateSmoothedSignal(signalIterable, wtOutput);
+            
+            double criticalVal;
+            double stdevNext;
+            do
+            {
+                // 4. Compute the multiresolution support M that is derived from the wavelet coefficients
+                // and the standard deviation of the noise at each level. 
+                // 5. Select all points that belong to the noise; they don't have an significant coefficients above noise 
+                var booleanizedLevels = BooleanizeLevels(wtOutput,
+                    stdevPrevious, 1.97); 
+                int[] mrsIndices = CreateMultiResolutionSupport(booleanizedLevels);
+
+                // 6. For the selected pixels, calculate original array - smoothed array and compute the standard deviation 
+                // for those values. 
+                // don't modify the original signal, use a deep copy instead: 
+                stdevNext = ComputeStdevOfNoisePixels(signalIterable, mrsIndices);
+
+                // 7. n = n + l. 
+                // 8. start again at 4 if sigma_I^n - sigma_I^(n-1) / sigma_I^(n) > epsilon. 
+                criticalVal = Math.Abs(stdevNext - stdevPrevious) / stdevPrevious;
+
+                // setup for next iteration 
+                iterations++; 
+                stdevPrevious = stdevNext;
+            } while (criticalVal > epsilon && iterations <= maxIterations);
+
+            noiseEstimate = stdevPrevious; 
+            return iterations < maxIterations;
+        }
+
+        /// <summary>
+        /// Converts the ModWtOutput into a list of int arrays based on a noise estimate.  
+        /// </summary>
+        /// <param name="wtOutput">Output object of the Mod wavelet transform.</param>
+        /// <param name="noiseEstimate">The initial noise estimation of the signal.</param>
+        /// <param name="noiseThreshold">A multiple of the noise estimate. noiseThreshold * noiseEstimate
+        /// is the cutoff value determining whether or not a pixel is signal or noise.</param>
+        /// <returns>List<int[]>. Each element in the int[] is either a 0 or positive integer, representing a noise value (if 0)
+        /// or a signal value (if >9).</int></returns>
+        private static List<int[]> BooleanizeLevels(ModWtOutput wtOutput, double noiseEstimate, double noiseThreshold)
+        {
+            List<int[]> booleanizedLevels = new();
+            foreach (Level level in wtOutput.Levels)
+            {
+                booleanizedLevels.Add(BooleanizeLevel(level, noiseEstimate, noiseThreshold));
+            }
+            return booleanizedLevels;
+        }
+
+        /// <summary>
+        /// Private method used to booleanize individual levels. 
+        /// </summary>
+        /// <param name="level">The level within a ModWtOuput.</param>
+        /// <param name="noiseEstimate">Initial noise estimate of the signal.</param>
+        /// <param name="threshold">Multiple of the noise estimate used to define the noise cutoff level.</param>
+        /// <returns></returns>
+        private static int[] BooleanizeLevel(Level level, double noiseEstimate, double threshold)
+        {
+            int[] results = new int[level.WaveletCoeff.Length];
+            double valToExceed = threshold * noiseEstimate;
+
+            for (int i = 0; i < results.Length; i++)
+            {
+                if (Math.Abs(level.WaveletCoeff[i]) >= valToExceed)
+                {
+                    results[i] = 1;
+                }
+                else
+                {
+                    results[i] = 0;
+                }
+            }
+            return results;
+        }
+
+        private static double[] CreateSmoothedSignal(double[] originalSignal, ModWtOutput output)
+        {
+            double[] results = new double[originalSignal.Length];
+            int lastLevel = output.MaxScale; 
+            double[] summedWt = output.Levels[lastLevel-1].ScalingCoeff;
+
+            for (int i = 0; i < results.Length; i++)
+            {
+                results[i] = originalSignal[i] - summedWt[i]; 
+            }
+
+            return results; 
+        }
+
+        /// <summary>
+        /// Sums the booleanized levels (a list of int[]) to creates a single integer array. 
+        /// </summary>
+        /// <param name="booleanizedLevels"></param>
+        /// <returns>An integer array where 0 indicates a noise pixel and a positive integer >0 equals a
+        /// signal pixel.</returns>
+        private static int[] CreateMultiResolutionSupport(List<int[]> booleanizedLevels)
+        {
+            int[] outputArray = new int[booleanizedLevels[0].Length];
+            for (int i = 0; i < outputArray.Length; i++)
+            {
+                outputArray[i] = booleanizedLevels.Select(k => k.ElementAt(i)).Sum();
+            }
+            return outputArray;
+        }
+
+        /// <summary>
+        /// Computes the standard deviation of the noise pixels of a signal given the signal, the
+        /// output of the ModWt wavelet transform and the indexes generated from multi-resolution support. 
+        /// </summary>
+        /// <param name="wtOutput">The output of the mod wavelet transform.</param>
+        /// <param name="signal">A signal that has been smoothed by subtracting the wavelet coefficients from the original signal.</param>
+        /// <param name="noiseIndices">An array of noise indices with either a zero or a positive integer value.
+        /// Zero represents a noise pixel; positive integer represents a non-noise pixel.</param>
+        /// <returns>The standard deviation of the noise pixels.</returns>
+        private static double ComputeStdevOfNoisePixels(double[] signal, int[] noiseIndices)
+        {
+            List<double> noiseValues = new();
+            // for each index in noiseIndices, get the values of the noise index, which will be either zero or one. 
+            // If the value is zero, that means the value is a noise value. Otherwise, the index represents a signal. 
+            for (int k = 0; k < noiseIndices.Length; k++)
+            {
+                if (noiseIndices[k] == 0)
+                {
+                    noiseValues.Add(signal.ElementAt(k));
+                }
+            }
+            // returns the standard deviation of the noise values. 
+            return BasicStatistics.CalculateStandardDeviation(noiseValues);
+        }
+    }
+
+    
+}

--- a/mzLib/SpectralAveraging/MrsNoiseEstimation/ModWtOutput.cs
+++ b/mzLib/SpectralAveraging/MrsNoiseEstimation/ModWtOutput.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SpectralAveraging;
+
+public class ModWtOutput
+{
+    public ModWtOutput(int maxScale, WaveletType waveletType, BoundaryType boundaryType)
+    {
+        Levels = new List<Level>();
+        MaxScale = maxScale;
+        WaveletType = waveletType;
+        BoundaryType = boundaryType;
+    }
+
+    public List<Level> Levels { get; private set; }
+    public int MaxScale { get; private set; }
+    public WaveletType WaveletType { get; }
+    public BoundaryType BoundaryType { get; }
+
+    public void AddLevel(double[] waveletCoeff, double[] scalingCoeff, int scale,
+        BoundaryType boundaryType, int originalSignalLength, int filterLength)
+    {
+        if (boundaryType == BoundaryType.Reflection)
+        {
+            int startIndex = ((int)Math.Pow(2, scale) - 1) * (filterLength - 1);
+            int stopIndex = Math.Min(startIndex + originalSignalLength, waveletCoeff.Length - 1);
+            Levels.Add(new Level(scale,
+                waveletCoeff[startIndex..stopIndex],
+                scalingCoeff[startIndex..stopIndex]));
+        }
+    }
+}

--- a/mzLib/SpectralAveraging/MrsNoiseEstimation/ModWtOutput.cs
+++ b/mzLib/SpectralAveraging/MrsNoiseEstimation/ModWtOutput.cs
@@ -6,19 +6,15 @@ namespace SpectralAveraging;
 
 public class ModWtOutput
 {
-    public ModWtOutput(int maxScale, WaveletType waveletType, BoundaryType boundaryType)
+    internal ModWtOutput(int maxScale)
     {
         Levels = new List<Level>();
         MaxScale = maxScale;
-        WaveletType = waveletType;
-        BoundaryType = boundaryType;
     }
 
-    public List<Level> Levels { get; private set; }
-    public int MaxScale { get; private set; }
-    public WaveletType WaveletType { get; }
-    public BoundaryType BoundaryType { get; }
-
+    internal List<Level> Levels { get; private set; }
+    internal int MaxScale { get; private set; }
+    
     public void AddLevel(double[] waveletCoeff, double[] scalingCoeff, int scale,
         BoundaryType boundaryType, int originalSignalLength, int filterLength)
     {

--- a/mzLib/SpectralAveraging/MrsNoiseEstimation/WaveletEnums.cs
+++ b/mzLib/SpectralAveraging/MrsNoiseEstimation/WaveletEnums.cs
@@ -1,0 +1,12 @@
+﻿namespace SpectralAveraging;
+
+public enum WaveletType
+{
+    Haar = 1, 
+    Db4 = 2
+}
+
+public enum BoundaryType
+{
+    Reflection = 1
+}

--- a/mzLib/SpectralAveraging/MrsNoiseEstimation/WaveletFilter.cs
+++ b/mzLib/SpectralAveraging/MrsNoiseEstimation/WaveletFilter.cs
@@ -1,0 +1,61 @@
+﻿using System;
+
+namespace SpectralAveraging;
+
+public class WaveletFilter
+{
+    public double[] WaveletCoefficients { get; private set; }
+    public double[] ScalingCoefficients { get; private set; }
+    public WaveletType WaveletType { get; private set; }
+
+    private void CreateFiltersFromCoeffs(double[] filterCoeffs)
+    {
+        WaveletCoefficients = new double[filterCoeffs.Length];
+        ScalingCoefficients = new double[filterCoeffs.Length];
+
+        // calculate wavelet coefficients
+        for (int i = 0; i < ScalingCoefficients.Length; i++)
+        {
+            ScalingCoefficients[i] = filterCoeffs[i] / Math.Sqrt(2d);
+        }
+        WaveletCoefficients = WaveletMathUtils.QMF(ScalingCoefficients, inverse: true);
+    }
+
+    public void CreateFiltersFromCoeffs(WaveletType waveletType)
+    {
+        switch (waveletType)
+        {
+            case WaveletType.Haar:
+            {
+                WaveletType = WaveletType.Haar;
+                CreateFiltersFromCoeffs(_haarCoefficients);
+                return;
+            }
+            case WaveletType.Db4:
+            {
+                WaveletType = WaveletType.Db4; 
+                CreateFiltersFromCoeffs(_db4Coefficients);
+                return; 
+            }
+        }
+    }
+    #region Wavelet Coefficients
+    private readonly double[] _haarCoefficients =
+    {
+        0.7071067811865475,
+        0.7071067811865475
+    };
+
+    private readonly double[] _db4Coefficients =
+    {
+        0.2304, 
+        0.7148, 
+        0.6309, 
+        -0.0280, 
+        -0.1870, 
+        0.0308, 
+        0.0329, 
+        -0.0106
+    };
+#endregion
+}

--- a/mzLib/SpectralAveraging/MrsNoiseEstimation/WaveletFilter.cs
+++ b/mzLib/SpectralAveraging/MrsNoiseEstimation/WaveletFilter.cs
@@ -31,12 +31,12 @@ public class WaveletFilter
                 CreateFiltersFromCoeffs(_haarCoefficients);
                 return;
             }
-            case WaveletType.Db4:
-            {
-                WaveletType = WaveletType.Db4; 
-                CreateFiltersFromCoeffs(_db4Coefficients);
-                return; 
-            }
+            //case WaveletType.Db4:
+            //{
+            //    WaveletType = WaveletType.Db4; 
+            //    CreateFiltersFromCoeffs(_db4Coefficients);
+            //    return; 
+            //}
         }
     }
     #region Wavelet Coefficients

--- a/mzLib/SpectralAveraging/MrsNoiseEstimation/WaveletMath.cs
+++ b/mzLib/SpectralAveraging/MrsNoiseEstimation/WaveletMath.cs
@@ -1,0 +1,111 @@
+﻿using System;
+
+namespace SpectralAveraging
+{
+    public class WaveletMath
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="V">Original signal</param>
+        /// <param name="N">Length of original signal</param>
+        /// <param name="j">Current scale</param>
+        /// <param name="h">Wavelet filter</param>
+        /// <param name="g">Scaling filter</param>
+        /// <param name="L">Length of filter</param>
+        /// <param name="Wj">Wavelet coefficients out</param>
+        /// <param name="Vj">Scaling coefficients out</param>
+        internal static void ModwtForward(double[] V, int N, int j,
+            double[] h, double[] g, int L, ref double[] Wj, ref double[] Vj)
+        {
+            int t, k, n;
+            double k_div;
+
+            for (t = 0; t < N; t++)
+            {
+                k = t;
+                Wj[t] = h[0] * V[k];
+                Vj[t] = g[0] * V[k];
+                for (n = 1; n < L; n++)
+                {
+                    k -= (int)Math.Pow(2, (j-1));
+                    k_div = -(double)k / (double)N;
+                    if (k < 0) k += (int)Math.Ceiling(k_div) * N;
+                    Wj[t] += h[n] * V[k];
+                    Vj[t] += g[n] * V[k]; 
+                }
+            }
+        }
+
+        internal static int CalculateNumberScales(int signalLength, int filterLength)
+        {
+            double val = Math.Log(((signalLength - 1) / (filterLength - 1)) + 1) / Math.Log(2); 
+            return (int)Math.Floor(val); 
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="signal"></param>
+        /// <param name="waveletFilter"></param>
+        /// <param name="scalingFilter"></param>
+        /// <param name="numScales"></param>
+        internal static ModWtOutput ModWt(double[] signal, double[] waveletFilter, 
+            double[] scalingFilter, WaveletType waveletType)
+        {
+            // calculate the number of scales to iterate over
+            int numScales = CalculateNumberScales(signal.Length, waveletFilter.Length); 
+
+            // use reflected boundary
+            double[] reflectedSignal = CreateReflectedArray(signal); 
+
+            var output = new ModWtOutput(numScales, waveletType, BoundaryType.Reflection);
+
+            double[] scalingCoeffs = new double[reflectedSignal.Length];
+            reflectedSignal.CopyTo(scalingCoeffs, 0);
+
+
+            for (int i = 0; i < numScales; i++)
+            {
+                double[] tempScalingCoeffs = new double[reflectedSignal.Length]; 
+                scalingCoeffs.CopyTo(tempScalingCoeffs,0);
+
+                double[] waveletCoeffs = new double[reflectedSignal.Length];
+                ModwtForward(scalingCoeffs, reflectedSignal.Length, i + 1, waveletFilter,
+                    scalingFilter, waveletFilter.Length, ref waveletCoeffs, 
+                    ref tempScalingCoeffs);
+                output.AddLevel(waveletCoeffs, scalingCoeffs, i, BoundaryType.Reflection, signal.Length, waveletFilter.Length);
+
+                scalingCoeffs = tempScalingCoeffs; 
+            }
+            return output; 
+        }
+
+        internal static double[] CreateReflectedArray(double[] original)
+        {
+            double[] reflectedArray = new double[original.Length*2];
+            double[] copyOfOriginal = new double[original.Length];
+
+            // copy original into new
+            Buffer.BlockCopy(original, 0, copyOfOriginal, 0, sizeof(double)*copyOfOriginal.Length);
+            // reverse copy of the original array
+            Array.Reverse(copyOfOriginal);
+            // Combine the original and the reverse arrays 
+            Buffer.BlockCopy(original, 0, reflectedArray, 0, original.Length*sizeof(double));
+
+            int reverseArrayOffset = sizeof(double) * (copyOfOriginal.Length); 
+            // original array is copied starting at element zero
+            Buffer.BlockCopy(copyOfOriginal, 0, 
+                // dst array contains the original signal, so need to offset the copying 
+                // of the reflected signal. 
+                reflectedArray, reverseArrayOffset, 
+                copyOfOriginal.Length * sizeof(double));
+            return reflectedArray; 
+
+        }
+
+        internal static ModWtOutput ModWt(double[] signal, WaveletFilter filters)
+        {
+            return ModWt(signal, filters.WaveletCoefficients, filters.ScalingCoefficients, filters.WaveletType);
+        }
+    }
+}

--- a/mzLib/SpectralAveraging/MrsNoiseEstimation/WaveletMath.cs
+++ b/mzLib/SpectralAveraging/MrsNoiseEstimation/WaveletMath.cs
@@ -58,7 +58,7 @@ namespace SpectralAveraging
             // use reflected boundary
             double[] reflectedSignal = CreateReflectedArray(signal); 
 
-            var output = new ModWtOutput(numScales, waveletType, BoundaryType.Reflection);
+            var output = new ModWtOutput(numScales);
 
             double[] scalingCoeffs = new double[reflectedSignal.Length];
             reflectedSignal.CopyTo(scalingCoeffs, 0);

--- a/mzLib/SpectralAveraging/MrsNoiseEstimation/WaveletMathUtils.cs
+++ b/mzLib/SpectralAveraging/MrsNoiseEstimation/WaveletMathUtils.cs
@@ -1,0 +1,35 @@
+﻿using System; 
+namespace SpectralAveraging;
+internal static class WaveletMathUtils
+{
+    /// <summary>
+    /// Calcualte the quadruture mirror filter for x, an array of filter coefficients
+    /// </summary>
+    /// <param name="x"></param>
+    /// <param name="inverse"></param>
+    /// <returns></returns>
+    internal static double[] QMF(double[] x, bool inverse = false)
+    {
+        double[] y = new double[x.Length];
+        Buffer.BlockCopy(x, 0, y, 0, x.Length * sizeof(double));
+        Array.Reverse(y);
+        if (inverse)
+        {
+            // start the for loop from the back
+            int firstIndex = 1;
+            for (int i = x.Length - 1; i >= 0; i--)
+            {
+                y[i] *= Math.Pow(-1d, firstIndex);
+                firstIndex++;
+            }
+        }
+        else
+        {
+            for (int i = 0; i < x.Length; i++)
+            {
+                y[i] *= Math.Pow(-1d, i + 1);
+            }
+        }
+        return y;
+    }
+}

--- a/mzLib/SpectralAveraging/Util/BasicStatistics.cs
+++ b/mzLib/SpectralAveraging/Util/BasicStatistics.cs
@@ -68,14 +68,14 @@ public class BasicStatistics
     /// <returns>The median absolute deviation from median.</returns>
     public static double MedianAbsoluteDeviationFromMedian(double[] array)
     {
-        double arrayMedian = BasicStatistics.CalculateMedian(array);
+        double arrayMedian = CalculateMedian(array);
         double[] results = new double[array.Length];
         for (int j = 0; j < array.Length; j++)
         {
             results[j] = Math.Abs(array[j] - arrayMedian);
         }
 
-        return BasicStatistics.CalculateMedian(results);
+        return CalculateMedian(results);
     }
     /// <summary>
     /// Calcultes the biweight midvariance for an array. Algorithm orignally found here:
@@ -88,7 +88,7 @@ public class BasicStatistics
         double[] y_i = new double[array.Length];
         double[] a_i = new double[array.Length];
         double MAD_X = MedianAbsoluteDeviationFromMedian(array);
-        double median = BasicStatistics.CalculateMedian(array);
+        double median = CalculateMedian(array);
         for (int i = 0; i < y_i.Length; i++)
         {
             y_i[i] = (array[i] - median) / (9d * MAD_X);

--- a/mzLib/SpectralAveraging/Util/BasicStatistics.cs
+++ b/mzLib/SpectralAveraging/Util/BasicStatistics.cs
@@ -7,18 +7,6 @@ namespace SpectralAveraging;
 
 public class BasicStatistics
 {
-
-    public static double CalculateMedian(IEnumerable<double> toCalc)
-    {
-        IEnumerable<double> sortedValues = toCalc.OrderByDescending(p => p).ToList();
-        double median;
-        int count = sortedValues.Count();
-        if (count % 2 == 0)
-            median = sortedValues.Skip(count / 2 - 1).Take(2).Average();
-        else
-            median = sortedValues.ElementAt(count / 2);
-        return median;
-    }
     public static double CalculateNonZeroMedian(IEnumerable<double> toCalc)
     {
         toCalc = toCalc.Where(p => p != 0).ToList();
@@ -68,14 +56,14 @@ public class BasicStatistics
     /// <returns>The median absolute deviation from median.</returns>
     public static double MedianAbsoluteDeviationFromMedian(double[] array)
     {
-        double arrayMedian = CalculateMedian(array);
+        double arrayMedian = array.Median();
         double[] results = new double[array.Length];
         for (int j = 0; j < array.Length; j++)
         {
             results[j] = Math.Abs(array[j] - arrayMedian);
         }
 
-        return CalculateMedian(results);
+        return results.Median();
     }
     /// <summary>
     /// Calcultes the biweight midvariance for an array. Algorithm orignally found here:
@@ -88,7 +76,7 @@ public class BasicStatistics
         double[] y_i = new double[array.Length];
         double[] a_i = new double[array.Length];
         double MAD_X = MedianAbsoluteDeviationFromMedian(array);
-        double median = CalculateMedian(array);
+        double median = array.Median();
         for (int i = 0; i < y_i.Length; i++)
         {
             y_i[i] = (array[i] - median) / (9d * MAD_X);

--- a/mzLib/SpectralAveraging/Util/BasicStatistics.cs
+++ b/mzLib/SpectralAveraging/Util/BasicStatistics.cs
@@ -7,8 +7,18 @@ namespace SpectralAveraging;
 
 public class BasicStatistics
 {
-   
 
+    public static double CalculateMedian(IEnumerable<double> toCalc)
+    {
+        IEnumerable<double> sortedValues = toCalc.OrderByDescending(p => p).ToList();
+        double median;
+        int count = sortedValues.Count();
+        if (count % 2 == 0)
+            median = sortedValues.Skip(count / 2 - 1).Take(2).Average();
+        else
+            median = sortedValues.ElementAt(count / 2);
+        return median;
+    }
     public static double CalculateNonZeroMedian(IEnumerable<double> toCalc)
     {
         toCalc = toCalc.Where(p => p != 0).ToList();
@@ -48,5 +58,60 @@ public class BasicStatistics
         if (!toCalc.Any())
             return 0;
         return CalculateStandardDeviation(toCalc, average);
+    }
+    /// <summary>
+    /// Calculates the median absolute deviation from the median, which is then used in
+    /// calculating the biweight midvariance. Original algorithm found here:
+    /// https://pixinsight.com/doc/tools/ImageIntegration/ImageIntegration.html#__equation_26__
+    /// </summary>
+    /// <param name="array">Array of values to be calculated.</param>
+    /// <returns>The median absolute deviation from median.</returns>
+    public static double MedianAbsoluteDeviationFromMedian(double[] array)
+    {
+        double arrayMedian = BasicStatistics.CalculateMedian(array);
+        double[] results = new double[array.Length];
+        for (int j = 0; j < array.Length; j++)
+        {
+            results[j] = Math.Abs(array[j] - arrayMedian);
+        }
+
+        return BasicStatistics.CalculateMedian(results);
+    }
+    /// <summary>
+    /// Calcultes the biweight midvariance for an array. Algorithm orignally found here:
+    /// https://pixinsight.com/doc/tools/ImageIntegration/ImageIntegration.html#__equation_27__
+    /// </summary>
+    /// <param name="array">Array of doubles.</param>
+    /// <returns>The biweight midvariance.</returns>
+    public static double BiweightMidvariance(double[] array)
+    {
+        double[] y_i = new double[array.Length];
+        double[] a_i = new double[array.Length];
+        double MAD_X = MedianAbsoluteDeviationFromMedian(array);
+        double median = BasicStatistics.CalculateMedian(array);
+        for (int i = 0; i < y_i.Length; i++)
+        {
+            y_i[i] = (array[i] - median) / (9d * MAD_X);
+            if (y_i[i] < 1d)
+            {
+                a_i[i] = 1d;
+            }
+            else
+            {
+                a_i[i] = 0;
+            }
+        }
+
+        // biweight midvariance calculation
+
+        double denomSum = 0;
+        double numeratorSum = 0;
+        for (int i = 0; i < y_i.Length; i++)
+        {
+            numeratorSum += a_i[i] * Math.Pow(array[i] - median, 2) * Math.Pow(1 - y_i[i] * y_i[i], 4);
+            denomSum += a_i[i] * (1 - 5 * y_i[i] * y_i[i]) * (1 - y_i[i] * y_i[i]);
+        }
+
+        return (double)y_i.Length * numeratorSum / Math.Pow(Math.Abs(denomSum), 2);
     }
 }

--- a/mzLib/Test/AveragingTests/TestStatistics.cs
+++ b/mzLib/Test/AveragingTests/TestStatistics.cs
@@ -111,21 +111,6 @@ namespace Test.AveragingTests
         }
 
         [Test]
-        public static void TestCalculateMedian()
-        {
-            double[] arr1 = new double[] { 0, 0, 0, 1, 2, 3, 4, 5, 6, 0, 0, 0 };
-            double[] arr2 = new double[] { 0, 0, 0, 1, 2, 3, 4, 5, 6, 0, 0 };
-
-            double resultArr1 = BasicStatistics.CalculateMedian(arr1);
-            double resultArr2 = BasicStatistics.CalculateMedian(arr2);
-            double expectedArr1 = 0.5;
-            double expectedArr2 = 1.0; 
-
-            Assert.That(expectedArr1, Is.EqualTo(resultArr1).Within(0.01));
-            Assert.That(expectedArr2, Is.EqualTo(resultArr2).Within(0.01));
-        }
-
-        [Test]
         public static void TestMedianAbsoluteDeviationFromMedian()
         {
             double[] arr1 = new double[] { 0, 0, 0, 1, 2, 3, 4, 5, 6, 0, 0, 0 };

--- a/mzLib/Test/AveragingTests/TestStatistics.cs
+++ b/mzLib/Test/AveragingTests/TestStatistics.cs
@@ -109,5 +109,39 @@ namespace Test.AveragingTests
             double std7 = BasicStatistics.CalculateNonZeroStandardDeviation(arr7);
             Assert.That(Math.Abs(std7 - 0) < 0.001);
         }
+
+        [Test]
+        public static void TestCalculateMedian()
+        {
+            double[] arr1 = new double[] { 0, 0, 0, 1, 2, 3, 4, 5, 6, 0, 0, 0 };
+            double[] arr2 = new double[] { 0, 0, 0, 1, 2, 3, 4, 5, 6, 0, 0 };
+
+            double resultArr1 = BasicStatistics.CalculateMedian(arr1);
+            double resultArr2 = BasicStatistics.CalculateMedian(arr2);
+            double expectedArr1 = 0.5;
+            double expectedArr2 = 1.0; 
+
+            Assert.That(expectedArr1, Is.EqualTo(resultArr1).Within(0.01));
+            Assert.That(expectedArr2, Is.EqualTo(resultArr2).Within(0.01));
+        }
+
+        [Test]
+        public static void TestMedianAbsoluteDeviationFromMedian()
+        {
+            double[] arr1 = new double[] { 0, 0, 0, 1, 2, 3, 4, 5, 6, 0, 0, 0 };
+            double expectedArr1 = 0.5;
+            double results = BasicStatistics.MedianAbsoluteDeviationFromMedian(arr1);
+            
+            Assert.That(expectedArr1, Is.EqualTo(results).Within(0.01));
+        }
+
+        [Test]
+        public static void TestBiweightMidvariance()
+        {
+            double[] arr1 = new double[] { 1, 2, 3, 4, 5, 6 };
+            double expectedArr1 = 1.5;
+            double results = BasicStatistics.MedianAbsoluteDeviationFromMedian(arr1);
+            Assert.That(expectedArr1, Is.EqualTo(results).Within(0.01));
+        }
     }
 }

--- a/mzLib/Test/AveragingTests/TestWeighting.cs
+++ b/mzLib/Test/AveragingTests/TestWeighting.cs
@@ -63,34 +63,23 @@ namespace Test.AveragingTests
         [Test]
         public static void TestWeightByMrsNoiseEstimation()
         {
-            //var xArrays = new[]
-            //{
-            //    new double[] { 0, 1, 2, 3, 3.49, 4 },
-            //    new double[] { 0, 1, 2, 3, 4 },
-            //    new double[] { 0.1, 1.1, 2.1, 3.1, 4.1}
-            //};
-            //var yArrays = new[]
-            //{
-            //    new double[] { 10, 11, 12, 12, 13, 14 },
-            //    new double[] { 11, 12, 13, 14, 15 },
-            //    new double[] { 20, 25, 30, 35, 40 }
-            //};
-            //var binSize = 1.0;
-
-            //PixelStack bs = new(xArrays, yArrays, binSize);
-            //bs.PerformNormalization();
-            //SpectralWeighting.CalculateSpectraWeights(bs, new SpectralAveragingParameters() { SpectralWeightingType = SpectraWeightingType.MrsNoiseEstimation });
-            //double[] expectedWeights = new[]
-            //{
-            //    //1539.23913, 
-            //    //1636.63560,
-            //    //755.37045
-            //    2073.60000,
-            //    3785.99353127,
-            //    889.4099838
-            //};
-            //Assert.That(bs.Weights.Values.ToArray(),
-            //    Is.EqualTo(expectedWeights).Within(0.01));
+            var xArrays = new[]
+            {
+                new double[] { 0, 1, 2, 3, 3.49, 4 },
+                new double[] { 0, 1, 2, 3, 4 },
+                new double[] { 0.1, 1.1, 2.1, 3.1, 4.1}
+            };
+            var yArrays = new[]
+            {
+                new double[] { 10, 11, 12, 12, 13, 14 },
+                new double[] { 11, 12, 13, 14, 15 },
+                new double[] { 20, 25, 30, 35, 40 }
+            };
+            Dictionary<int, double> weights = SpectralWeighting.CalculateSpectraWeights(xArrays, 
+                yArrays, SpectraWeightingType.MrsNoiseEstimation);
+            double[] expectedWeights = { 0.499999, 0.45036, 0.090072 }; 
+            
+            Assert.That(weights.Values, Is.EqualTo(expectedWeights).Within(0.001));
         }
     }
 }


### PR DESCRIPTION
Added spectra weighting by MRS noise estimation. 

MRS noise estimation uses a wavelet transform to discriminate which parts of a signal are noise versus signal. The standard deviation of the noise is then calculated using only the noise values, giving a more robust and accurate noise estimation than just taking the standard deviation of the signal. The noise estimate is subsequently used in calculating the weight of a spectra when averaging. 

MRS noise estimation algorithm is as follows: 

1. Estimate the standard deviation of the noise in the original signal using the regular standard deviation. 
2. Compute the maximal overlap discrete wavelet transform of the image. 
3. Set n = 0; (this is done implicitly while in the do while loop.)
4. Compute the multiresolution support M that is derived from the wavelet coefficients and the standard deviation of the noise at each level. The multiresolution support creates a boolean array where a true indicates at the location in the array, there is a value higher than the noise estimate, and false means there is not a value higher than the noise estimate. 
5. Select all points that belong to the noise; these points don't have significant wavelet coefficients above noise. Significant is defined as 3*estimated standard deviation. 
6. For the selected pixels, calculate original array - smoothed array (where the smoothed array is the original signal array - the sum of the wavelet coefficients across all scales) and compute the standard deviation for only those values.
7. n = n + l. 
8. start again at 4 if (sigma_I^n - sigma_I^(n-1)) / sigma_I^(n) > epsilon. 

![image](https://user-images.githubusercontent.com/64652734/213772087-388b7816-64a2-4c59-9ba7-ad21b05dff79.png)

