### PR TITLE
weighted mean polish

### DIFF
--- a/mzLib/FlashLFQ/FlashLFQResults.cs
+++ b/mzLib/FlashLFQ/FlashLFQResults.cs
@@ -347,16 +347,17 @@ namespace FlashLFQ
                 if (proteinGroupToPeptides.TryGetValue(proteinGroup, out var peptidesForThisProtein))
                 {
                     // set up peptide intensity table
-                    int numSamples = 0;
-                    foreach (var condition in SpectraFiles.GroupBy(p => p.Condition))
+                    // top row is the column effects, left column is the row effects
+                    // the other cells are peptide intensity measurements
+                    int numSamples = SpectraFiles.Select(p => p.Condition + p.BiologicalReplicate).Distinct().Count();
+                    double[][] peptideIntensityMatrix = new double[peptidesForThisProtein.Count + 1][];
+                    for (int i = 0; i < peptideIntensityMatrix.Length; i++)
                     {
-                        int conditionSamples = condition.Select(p => p.BiologicalReplicate).Distinct().Count();
-                        numSamples += conditionSamples;
+                        peptideIntensityMatrix[i] = new double[numSamples + 1];
                     }
 
-                    double[,] peptideIntensityMatrix = new double[peptidesForThisProtein.Count, numSamples];
-
                     // populate matrix w/ log2-transformed peptide intensities
+                    // if a value is missing, it will be filled with NaN
                     int sampleN = 0;
                     foreach (var group in SpectraFiles.GroupBy(p => p.Condition).OrderBy(p => p.Key))
                     {
@@ -398,25 +399,78 @@ namespace FlashLFQ
                                 }
 
                                 int sampleNumber = sample.Key;
-                                sampleIntensity = Math.Log(sampleIntensity, 2);
 
-                                if (double.IsInfinity(sampleIntensity))
+                                if (sampleIntensity == 0)
                                 {
                                     sampleIntensity = double.NaN;
                                 }
+                                else
+                                {
+                                    sampleIntensity = Math.Log(sampleIntensity, 2);
+                                }
 
-                                peptideIntensityMatrix[peptidesForThisProtein.IndexOf(peptide), sampleN] = sampleIntensity;
+                                peptideIntensityMatrix[peptidesForThisProtein.IndexOf(peptide) + 1][sampleN + 1] = sampleIntensity;
                             }
 
                             sampleN++;
                         }
                     }
 
+                    // if there are any peptides that have only one measurement, mark them as NaN
+                    // unless we have ONLY peptides with one measurement
+                    var peptidesWithMoreThanOneMmt = peptideIntensityMatrix.Skip(1).Count(row => row.Skip(1).Count(cell => !double.IsNaN(cell)) > 1);
+                    if (peptidesWithMoreThanOneMmt > 0)
+                    {
+                        for (int i = 1; i < peptideIntensityMatrix.Length; i++)
+                        {
+                            int validValueCount = peptideIntensityMatrix[i].Count(p => !double.IsNaN(p) && p != 0);
+
+                            if (validValueCount < 2 && numSamples >= 2)
+                            {
+                                for (int j = 1; j < peptideIntensityMatrix[0].Length; j++)
+                                {
+                                    peptideIntensityMatrix[i][j] = double.NaN;
+                                }
+                            }
+                        }
+                    }
+
                     // do median polish protein quantification
                     // row effects in a protein can be considered ~ relative ionization efficiency
                     // column effects are differences between conditions
-                    MedianPolish(peptideIntensityMatrix, 10, 0.0001, out var rowEffects, out var columnEffects, out var overallEffect);
-                    double referenceProteinIntensity = Math.Pow(2, overallEffect);
+                    MedianPolish(peptideIntensityMatrix);
+
+                    double overallEffect = peptideIntensityMatrix[0][0];
+                    double[] columnEffects = peptideIntensityMatrix[0].Skip(1).ToArray();
+                    double referenceProteinIntensity = Math.Pow(2, overallEffect) * peptidesForThisProtein.Count;
+
+                    // check for unquantifiable proteins; these are proteins w/ quantified peptides, but
+                    // the protein is still not quantifiable because there are not peptides to compare across runs
+                    List<string> possibleUnquantifiableSample = new List<string>();
+                    sampleN = 0;
+                    foreach (var group in SpectraFiles.GroupBy(p => p.Condition).OrderBy(p => p.Key))
+                    {
+                        foreach (var sample in group.GroupBy(p => p.BiologicalReplicate).OrderBy(p => p.Key))
+                        {
+                            bool isMissingValue = true;
+
+                            foreach (SpectraFileInfo spectraFile in sample)
+                            {
+                                if (peptidesForThisProtein.Any(p => p.GetIntensity(spectraFile) != 0))
+                                {
+                                    isMissingValue = false;
+                                    break;
+                                }
+                            }
+
+                            if (!isMissingValue && columnEffects[sampleN] == 0)
+                            {
+                                possibleUnquantifiableSample.Add(group.Key + "_" + sample.Key);
+                            }
+
+                            sampleN++;
+                        }
+                    }
 
                     // set the sample protein intensities
                     sampleN = 0;
@@ -428,15 +482,16 @@ namespace FlashLFQ
                             // than an intensity, but unlike a fold-change it's not relative to a particular sample.
                             // by multiplying this value by the reference protein intensity calculated earlier, then we get 
                             // a protein intensity value
-                            double sampleProteinIntensity = Math.Pow(2, columnEffects[sampleN]) * referenceProteinIntensity;
+                            double columnEffect = columnEffects[sampleN];
+                            double sampleProteinIntensity = Math.Pow(2, columnEffect) * referenceProteinIntensity;
 
-                            // the column effect can be 0 in many cases. sometimes it's a valid value and sometimes it's not.
+                            // the column effect can be 0 in some cases. sometimes it's a valid value and sometimes it's not.
                             // so we need to check to see if it is actually a valid value
                             bool isMissingValue = true;
 
-                            foreach (var sampleNum in sample)
+                            foreach (SpectraFileInfo spectraFile in sample)
                             {
-                                if (peptidesForThisProtein.Any(p => p.GetIntensity(sampleNum) != 0))
+                                if (peptidesForThisProtein.Any(p => p.GetIntensity(spectraFile) != 0))
                                 {
                                     isMissingValue = false;
                                     break;
@@ -445,12 +500,13 @@ namespace FlashLFQ
 
                             if (!isMissingValue)
                             {
-                                proteinGroup.SetIntensity(sample.First(), sampleProteinIntensity);
-
-                                // TODO: this will fix cases where protein quantities are the identical as a result of a median polish issue
-                                if (columnEffects[sampleN] == 0)
+                                if (possibleUnquantifiableSample.Count > 1 && possibleUnquantifiableSample.Contains(group.Key + "_" + sample.Key))
                                 {
                                     proteinGroup.SetIntensity(sample.First(), double.NaN);
+                                }
+                                else
+                                {
+                                    proteinGroup.SetIntensity(sample.First(), sampleProteinIntensity);
                                 }
                             }
 
@@ -578,168 +634,81 @@ namespace FlashLFQ
             }
         }
 
-        public static void MedianPolish(double[,] table, int maxIterations, double improvementCutoff, out double[] rowEffects, out double[] columnEffects, out double overallEffect)
+        public static void MedianPolish(double[][] table, int maxIterations = 10, double improvementCutoff = 0.0001)
         {
-            overallEffect = 0;
-            rowEffects = new double[table.GetLength(0)];
-            columnEffects = new double[table.GetLength(1)];
-            List<double> values = new List<double>();
-            List<double> rowMedians = new List<double>();
-            List<double> columnMedians = new List<double>();
-            double lastIterationSumOfAbsoluteResiduals = 0;
+            // technically, this is weighted mean polish and not median polish.
+            // but it should give similar results while being more robust to issues
+            // arising from missing values.
+            // the weights are inverse square difference to median.
 
-            // compute overall effect
-            foreach (double value in table)
+            // subtract overall effect
+            List<double> allValues = table.SelectMany(p => p.Where(p => !double.IsNaN(p) && p != 0)).ToList();
+
+            if (allValues.Any())
             {
-                if (!double.IsNaN(value))
+                double overallEffect = allValues.Median();
+                table[0][0] += overallEffect;
+
+                for (int r = 1; r < table.Length; r++)
                 {
-                    values.Add(value);
+                    for (int c = 1; c < table[0].Length; c++)
+                    {
+                        table[r][c] -= overallEffect;
+                    }
                 }
             }
 
-            if (values.Any())
-            {
-                overallEffect += values.Median();
-            }
+            double sumAbsoluteResiduals = double.MaxValue;
 
-            // subtract overall effect from table
-            for (int j = 0; j < table.GetLength(0); j++)
-            {
-                for (int k = 0; k < table.GetLength(1); k++)
-                {
-                    table[j, k] -= overallEffect;
-                }
-            }
-
-            // compute sum of absolute residuals
-            foreach (double value in table)
-            {
-                if (!double.IsNaN(value))
-                {
-                    lastIterationSumOfAbsoluteResiduals += Math.Abs(value);
-                }
-            }
-
-            // iterate the median polish algorithm
             for (int i = 0; i < maxIterations; i++)
             {
-                rowMedians.Clear();
-                columnMedians.Clear();
-
-                // compute sum of absolute residuals
-                double thisIterationSumOfAbsoluteResiduals = 0;
-                foreach (double value in table)
+                // subtract row effects
+                for (int r = 0; r < table.Length; r++)
                 {
-                    if (!double.IsNaN(value))
+                    List<double> rowValues = table[r].Skip(1).Where(p => !double.IsNaN(p)).ToList();
+
+                    if (rowValues.Any())
                     {
-                        thisIterationSumOfAbsoluteResiduals += Math.Abs(value);
+                        double rowMedian = rowValues.Median();
+                        double[] weights = rowValues.Select(p => 1.0 / Math.Max(0.0001, Math.Pow(p - rowMedian, 2))).ToArray();
+                        double rowEffect = rowValues.Sum(p => p * weights[rowValues.IndexOf(p)]) / weights.Sum();
+                        table[r][0] += rowEffect;
+
+                        for (int c = 1; c < table[0].Length; c++)
+                        {
+                            table[r][c] -= rowEffect;
+                        }
                     }
                 }
 
-                if (Math.Abs((thisIterationSumOfAbsoluteResiduals - lastIterationSumOfAbsoluteResiduals) / lastIterationSumOfAbsoluteResiduals) < improvementCutoff && i > 0)
+                // subtract column effects
+                for (int c = 0; c < table[0].Length; c++)
+                {
+                    List<double> colValues = table.Skip(1).Select(p => p[c]).Where(p => !double.IsNaN(p)).ToList();
+
+                    if (colValues.Any())
+                    {
+                        double colMedian = colValues.Median();
+                        double[] weights = colValues.Select(p => 1.0 / Math.Max(0.0001, Math.Pow(p - colMedian, 2))).ToArray();
+                        double colEffect = colValues.Sum(p => p * weights[colValues.IndexOf(p)]) / weights.Sum();
+                        table[0][c] += colEffect;
+
+                        for (int r = 1; r < table.Length; r++)
+                        {
+                            table[r][c] -= colEffect;
+                        }
+                    }
+                }
+
+                // calculate sum of absolute residuals and end the algorithm if it is not improving
+                double iterationSumAbsoluteResiduals = table.Skip(1).SelectMany(p => p.Skip(1)).Where(p => !double.IsNaN(p)).Sum(p => Math.Abs(p));
+
+                if (Math.Abs((iterationSumAbsoluteResiduals - sumAbsoluteResiduals) / sumAbsoluteResiduals) < improvementCutoff)
                 {
                     break;
                 }
 
-                // compute row medians
-                double columnEffectMedian = columnEffects.Median();
-
-                for (int j = 0; j < table.GetLength(0); j++)
-                {
-                    values.Clear();
-
-                    for (int k = 0; k < table.GetLength(1); k++)
-                    {
-                        double value = table[j, k];
-
-                        if (!double.IsNaN(value))
-                        {
-                            values.Add(value);
-                        }
-                    }
-
-                    double rowMedian = 0;
-
-                    if (values.Any())
-                    {
-                        rowMedian = values.Median();
-                    }
-
-                    rowMedians.Add(rowMedian);
-                }
-
-                // add row medians to row effects
-                for (int j = 0; j < table.GetLength(0); j++)
-                {
-                    rowEffects[j] += rowMedians[j];
-                }
-
-                overallEffect += columnEffectMedian;
-
-                // subtract row effects from table
-                for (int j = 0; j < columnEffects.Length; j++)
-                {
-                    columnEffects[j] -= columnEffectMedian;
-                }
-
-                for (int j = 0; j < table.GetLength(0); j++)
-                {
-                    for (int k = 0; k < table.GetLength(1); k++)
-                    {
-                        table[j, k] -= rowMedians[j];
-                    }
-                }
-
-                // compute column medians
-                double rowEffectMedian = rowEffects.Median();
-
-                for (int k = 0; k < table.GetLength(1); k++)
-                {
-                    values.Clear();
-
-                    for (int j = 0; j < table.GetLength(0); j++)
-                    {
-                        double value = table[j, k];
-
-                        if (!double.IsNaN(value))
-                        {
-                            values.Add(value);
-                        }
-                    }
-
-                    double columnMedian = 0;
-
-                    if (values.Any())
-                    {
-                        columnMedian = values.Median();
-                    }
-
-                    columnMedians.Add(columnMedian);
-                }
-
-                // add column medians to column effects
-                for (int k = 0; k < table.GetLength(1); k++)
-                {
-                    columnEffects[k] += columnMedians[k];
-                }
-
-                overallEffect += rowEffectMedian;
-
-                // subtract column effects from table
-                for (int j = 0; j < rowEffects.Length; j++)
-                {
-                    rowEffects[j] -= rowEffectMedian;
-                }
-
-                for (int k = 0; k < table.GetLength(1); k++)
-                {
-                    for (int j = 0; j < table.GetLength(0); j++)
-                    {
-                        table[j, k] -= columnMedians[k];
-                    }
-                }
-
-                lastIterationSumOfAbsoluteResiduals = thisIterationSumOfAbsoluteResiduals;
+                sumAbsoluteResiduals = iterationSumAbsoluteResiduals;
             }
         }
     }

--- a/mzLib/TestFlashLFQ/TestFlashLFQ.cs
+++ b/mzLib/TestFlashLFQ/TestFlashLFQ.cs
@@ -1689,6 +1689,39 @@ namespace Test
             Assert.That(Math.Abs(log2FoldChange) > 0);
         }
 
+        [Test]
+        public static void TestMedianPolish_OneValue()
+        {
+            // this represents the intensities of peptides from a single protein
+            var peptideIntensities = new double[][]
+            { 
+                // each column is a sample, each row is a peptide
+                new double[] { 9796546 },
+            };
+
+            var res = QuantifyMedianPolishProteinFromPeptideArray(peptideIntensities);
+            var protein = res.ProteinGroups.First().Value;
+
+            Assert.That(protein.GetIntensity(res.SpectraFiles[0]) > 0);
+        }
+
+        [Test]
+        public static void TestMedianPolish_OneValidValue()
+        {
+            // this represents the intensities of peptides from a single protein
+            var peptideIntensities = new double[][]
+            { 
+                // each column is a sample, each row is a peptide
+                new double[] { 9796546, 0 },
+            };
+
+            var res = QuantifyMedianPolishProteinFromPeptideArray(peptideIntensities);
+            var protein = res.ProteinGroups.First().Value;
+
+            Assert.That(protein.GetIntensity(res.SpectraFiles[0]) > 0);
+            Assert.That(protein.GetIntensity(res.SpectraFiles[1]) == 0);
+        }
+
         private static FlashLfqResults QuantifyMedianPolishProteinFromPeptideArray(double[][] peptideIntensities)
         {
             // pass intensity info into FlashLFQ, initializing required objects

--- a/mzLib/TestFlashLFQ/TestFlashLFQ.cs
+++ b/mzLib/TestFlashLFQ/TestFlashLFQ.cs
@@ -993,7 +993,7 @@ namespace Test
             Assert.AreEqual(4, peaks[0].Count(m => m.IsMbrPeak == false));
             Assert.AreEqual(5, peaks[1].Count(m => m.IsMbrPeak == false));
 
-            CollectionAssert.AreEquivalent(new string[]{ "Q7KZF4", "Q7KZF4", "P52298", "Q15149" }, peaks[0].SelectMany(i => i.Identifications).Select(g => g.ProteinGroups.First()).Select(m => m.ProteinGroupName).ToArray());
+            CollectionAssert.AreEquivalent(new string[] { "Q7KZF4", "Q7KZF4", "P52298", "Q15149" }, peaks[0].SelectMany(i => i.Identifications).Select(g => g.ProteinGroups.First()).Select(m => m.ProteinGroupName).ToArray());
             CollectionAssert.AreEquivalent(new string[] { "Q7KZF4", "P52298", "Q15149", "Q7KZF4", "Q7KZF4", "P52298" }, peaks[1].SelectMany(i => i.Identifications).Select(g => g.ProteinGroups.First()).Select(m => m.ProteinGroupName).ToArray());
 
             Assert.AreEqual(6, peptides.Count);
@@ -1008,39 +1008,39 @@ namespace Test
         public static IEnumerable<object[]> MedianPolishTestCases()
         {
             yield return
-               new object[] 
+               new object[]
                {
-                    new double[,] { { 19.00979255, 17.59643536 }, { 17.07315813, 14.91169105 } }, //array of intensities: two peptides and two conditions
+                    new double[][] { new double[] { 0, 0, 0 }, new double[] { 0, 19.00979255, 17.59643536 }, new double[] { 0, 17.07315813, 14.91169105 } }, //array of intensities: two peptides and two conditions
                     new double[] { 1.1553446825000004, -1.1553446825000004 }, //expected row effects
-                    new double[] { 0.8937060674999997, -0.8937060674999997 }, //expected column effects
+                    new double[] { 0.8937060674999997, -0.89370606749999981 }, //expected column effects
                     17.1477692725 // expected overall effect
                };
             yield return
                new object[]
                {
-                    new double[,] { { 16.64839239, Double.NaN }, { Double.NaN, 17.79219321 } }, //array of intensities: two peptides and two conditions
+                    new double[][] { new double[] { 0, 0, 0 }, new double[] { 0, 16.64839239, Double.NaN }, new double[] { 0, Double.NaN, 17.79219321 } }, //array of intensities: two peptides and two conditions
                     new double[] { -0.57190040999999958, 0.57190040999999958 }, //expected row effects
                     new double[] {  0, 0 }, //expected column effects
-                    17.220292800000003 // expected overall effect
+                    17.2202928 // expected overall effect
                };
             yield return
-               new object[] 
+               new object[]
                {
-                    new double[,] { { 22.29123276, 20.82476044 }, { Double.NaN, 19.63885674 } }, //array of intensities: two peptides and two conditions
+                    new double[][] { new double[] { 0, 0, 0 }, new double[] { 0, 22.29123276, 20.82476044 }, new double[] { 0, Double.NaN, 19.63885674 } }, //array of intensities: two peptides and two conditions
                     new double[] { 0.59295324853698594, -0.59295324853698594 }, //expected row effects
-                    new double[] { 0.73323616000000058, -0.73323476146301325 }, //expected column effects
+                    new double[] { 0.73323616000000058, -0.73323476146301336 }, //expected column effects
                     20.965043351463017 // expected overall effect
                };
 
         }
 
         [Test, TestCaseSource("MedianPolishTestCases")]
-        public static void TestMedianPolishWithIntensity(double[,] intensityArray, double[] expectedRowEffects, double[] expectedColumnEffects, double expectedOverallEffect)
+        public static void TestMedianPolishWithIntensity(double[][] intensityArray, double[] expectedRowEffects, double[] expectedColumnEffects, double expectedOverallEffect)
         {
-            int maxIterations = 10;
-            double improvementCutoff = 0.0001;
-
-            FlashLfqResults.MedianPolish(intensityArray, maxIterations, improvementCutoff, out var rowEffects, out var columnEffects, out var overallEffect);
+            FlashLfqResults.MedianPolish(intensityArray);
+            var rowEffects = intensityArray.Select(p => p[0]).Skip(1).ToArray();
+            var columnEffects = intensityArray[0].Skip(1).ToArray();
+            var overallEffect = intensityArray[0][0];
 
             CollectionAssert.AreEqual(expectedRowEffects, rowEffects);
             CollectionAssert.AreEqual(expectedColumnEffects, columnEffects);
@@ -1050,11 +1050,18 @@ namespace Test
         [Test]
         public static void TestMedianPolish()
         {
-            double[,] array2D = new double[,] { { 1, 2 }, { 3, 4 }, { 5, 6 }, { 7, 8 } };
-            int maxIterations = 10;
-            double improvementCutoff = 0.0001;
+            double[][] array2D = new double[][] { 
+                new double[] { 0, 0, 0 },
+                new double[] { 0, 1, 2 }, 
+                new double[] { 0, 3, 4 }, 
+                new double[] { 0, 5, 6 }, 
+                new double[] { 0, 7, 8 } 
+            };
 
-            FlashLfqResults.MedianPolish(array2D, maxIterations,improvementCutoff,out var rowEffects,out var columnEffects,out var overallEffect);
+            FlashLfqResults.MedianPolish(array2D);
+            var rowEffects = array2D.Select(p => p[0]).Skip(1).ToArray();
+            var columnEffects = array2D[0].Skip(1).ToArray();
+            var overallEffect = array2D[0][0];
 
             double[] expectedRowEffects = new double[] { -3, -1, 1, 3 };
             double[] expectedColumnEffects = new double[] { -0.5, 0.5 };
@@ -1522,10 +1529,10 @@ namespace Test
 
             // the quantities reported for protein1 should have no missing values and should be ~identical (rounded)
             var protein1Results = textResults[1].Split(new char[] { '\t' });
-            Assert.That((int)double.Parse(protein1Results[3]) == 748375);
-            Assert.That((int)double.Parse(protein1Results[4]) == 748375);
-            Assert.That((int)double.Parse(protein1Results[5]) == 748375);
-            Assert.That((int)double.Parse(protein1Results[6]) == 748375);
+            Assert.That((int)double.Parse(protein1Results[3]) > 0);
+            Assert.That((int)double.Parse(protein1Results[4]) == (int)double.Parse(protein1Results[3]));
+            Assert.That((int)double.Parse(protein1Results[5]) == (int)double.Parse(protein1Results[3]));
+            Assert.That((int)double.Parse(protein1Results[6]) == (int)double.Parse(protein1Results[3]));
 
             // protein2 doesn't get quantified because it only has 1 peptide and it's shared,
             // and we said to not quantified shared peptides
@@ -1539,19 +1546,154 @@ namespace Test
         }
 
         [Test]
-        public void TestMedianPolishNan()
+        public void TestMedianPolish_UnquantifiableProtein()
         {
             // this represents the intensities of peptides from a single protein
-            var peptideIntensities = new double[][] 
+            var peptideIntensities = new double[][]
             { 
                 // each column is a sample, each row is a peptide
-                new double[] { 0,    1000 }, 
+                new double[] { 0,    1000 },
                 new double[] { 1000, 0 }
             };
 
+            var res = QuantifyMedianPolishProteinFromPeptideArray(peptideIntensities);
+            var protein = res.ProteinGroups.First().Value;
+
+            // intensity should be NaN (protein is not quantifiable)
+            foreach (SpectraFileInfo file in res.SpectraFiles)
+            {
+                Assert.That(double.IsNaN(protein.GetIntensity(file)));
+            }
+        }
+
+        [Test]
+        public static void TestMedianPolish_WithMissingPeptideValues()
+        {
+            // this represents the intensities of peptides from a single protein
+            var peptideIntensities = new double[][]
+            { 
+                // each column is a sample, each row is a peptide
+                new double[] { 9796546,     9852023.625 },
+                new double[] { 2193142.286, 2132802.28 },
+                new double[] { 22670965.15, 0 },
+                new double[] { 0,           0 },
+                new double[] { 0,           2121691.667 },
+                new double[] { 13807677.53, 12251660.38 },
+                new double[] { 0,           0 },
+                new double[] { 19007964.63, 18208648.31 },
+                new double[] { 15951524.58, 16042378.83 },
+                new double[] { 14890408.31, 14411359.03 },
+                new double[] { 27894671.25, 27384454.5 },
+                new double[] { 20857567.75, 21912047.75 },
+                new double[] { 9142974.708, 17019194.54 },
+                new double[] { 29630634,    29207244.17 },
+                new double[] { 4463091.969, 3933777.311 },
+                new double[] { 18686402.29, 19290511.46 },
+                new double[] { 20132718.25, 22085322 },
+                new double[] { 4073149.652, 4451360.921 }
+            };
+
+            var res = QuantifyMedianPolishProteinFromPeptideArray(peptideIntensities);
+            var protein = res.ProteinGroups.First().Value;
+
+            // intensity should be >0 in both samples
+            foreach (SpectraFileInfo file in res.SpectraFiles)
+            {
+                Assert.That(protein.GetIntensity(file) > 0);
+            }
+
+            var log2FoldChange = Math.Log(protein.GetIntensity(res.SpectraFiles[0]), 2) - Math.Log(protein.GetIntensity(res.SpectraFiles[1]), 2);
+            Assert.That(Math.Abs(log2FoldChange) < 0.02);
+            Assert.That(Math.Abs(log2FoldChange) > 0);
+        }
+
+        [Test]
+        public static void TestMedianPolish_WithSimilarIntensityRanks()
+        {
+            var peptideIntensities = new double[][]
+            { 
+                // each column is a sample, each row is a peptide
+                new double[] { 19007964.63, 18208648.31, 0 },
+                new double[] { 14890408.31, 14411359.03, 14910408.31 },
+                new double[] { 27894671.25, 27384454.5,  27914671.25 },
+                new double[] { 20857567.75, 21912047.75, 20877567.75 },
+                new double[] { 9142974.708, 17019194.54, 9162974.708 },
+                new double[] { 29630634,    29207244.17, 0 },
+                new double[] { 4463091.969, 3933777.311, 4483091.969 },
+                new double[] { 18686402.29, 19290511.46, 18706402.29 },
+                new double[] { 4073149.652, 4451360.921, 4093149.652 }
+            };
+
+            var res = QuantifyMedianPolishProteinFromPeptideArray(peptideIntensities);
+            var protein = res.ProteinGroups.First().Value;
+
+            Assert.That(protein.GetIntensity(res.SpectraFiles[0]) > 0);
+            Assert.That(protein.GetIntensity(res.SpectraFiles[1]) > 0);
+            Assert.That(protein.GetIntensity(res.SpectraFiles[2]) > 0);
+
+            // test change between file2 and file0
+            var log2FoldChange = Math.Log(protein.GetIntensity(res.SpectraFiles[2]), 2) - Math.Log(protein.GetIntensity(res.SpectraFiles[0]), 2);
+            Assert.That(log2FoldChange > 0);
+            Assert.That(log2FoldChange < 0.01);
+
+            // test change between file2 and file0
+            log2FoldChange = Math.Log(protein.GetIntensity(res.SpectraFiles[1]), 2) - Math.Log(protein.GetIntensity(res.SpectraFiles[0]), 2);
+            Assert.That(log2FoldChange < 0);
+            Assert.That(log2FoldChange > -0.03);
+        }
+
+        [Test]
+        public static void TestMedianPolish_TrueChanger()
+        {
+            var peptideIntensities = new double[][]
+            { 
+                // each column is a sample, each row is a peptide
+                new double[] { 1000, 1010, 2050, 2010 },
+                new double[] { 2000, 1900, 3900, 4100 },
+            };
+
+            FlashLfqResults res = QuantifyMedianPolishProteinFromPeptideArray(peptideIntensities);
+            var protein = res.ProteinGroups.First().Value;
+
+            Assert.That(protein.GetIntensity(res.SpectraFiles[0]) > 0);
+            Assert.That(protein.GetIntensity(res.SpectraFiles[1]) > 0);
+            Assert.That(protein.GetIntensity(res.SpectraFiles[2]) > 0);
+            Assert.That(protein.GetIntensity(res.SpectraFiles[3]) > 0);
+
+            var log2FoldChange = Math.Log(protein.GetIntensity(res.SpectraFiles[0]), 2) - Math.Log(protein.GetIntensity(res.SpectraFiles[2]), 2);
+            Assert.That(Math.Abs(log2FoldChange) < 1.1);
+            Assert.That(Math.Abs(log2FoldChange) > 0.9);
+        }
+
+        [Test]
+        public static void TestMedianPolish_MissingProteinValue()
+        {
+            // this represents the intensities of peptides from a single protein
+            var peptideIntensities = new double[][]
+            { 
+                // each column is a sample, each row is a peptide
+                new double[] { 9796546,     9852023.625, 0 },
+                new double[] { 2193142.286, 2132802.28,  0 },
+                new double[] { 13807677.53, 12251660.38, 0 },
+            };
+
+            var res = QuantifyMedianPolishProteinFromPeptideArray(peptideIntensities);
+            var protein = res.ProteinGroups.First().Value;
+
+            Assert.That(protein.GetIntensity(res.SpectraFiles[0]) > 0);
+            Assert.That(protein.GetIntensity(res.SpectraFiles[1]) > 0);
+            Assert.That(protein.GetIntensity(res.SpectraFiles[2]) == 0);
+
+            var log2FoldChange = Math.Log(protein.GetIntensity(res.SpectraFiles[0]), 2) - Math.Log(protein.GetIntensity(res.SpectraFiles[1]), 2);
+            Assert.That(Math.Abs(log2FoldChange) < 0.05);
+            Assert.That(Math.Abs(log2FoldChange) > 0);
+        }
+
+        private static FlashLfqResults QuantifyMedianPolishProteinFromPeptideArray(double[][] peptideIntensities)
+        {
             // pass intensity info into FlashLFQ, initializing required objects
             FlashLfqResults res = new FlashLfqResults(
-                peptideIntensities.Select(p => new SpectraFileInfo("", "cond", Array.IndexOf(peptideIntensities, p), 0, 0)).ToList(), 
+                peptideIntensities[0].Select(p => new SpectraFileInfo("", "cond", Array.IndexOf(peptideIntensities[0], p), 0, 0)).ToList(),
                 new List<Identification>());
 
             ProteinGroup protein = new ProteinGroup("accession1", "gene1", "organism1");
@@ -1570,14 +1712,9 @@ namespace Test
                 }
             }
 
-            // calculate the protein intensities with median polish
-            res.CalculateProteinResultsMedianPolish(useSharedPeptides: false);
+            res.CalculateProteinResultsMedianPolish(false);
 
-            // intensity should be NaN (protein is not quantifiable)
-            foreach (SpectraFileInfo file in res.SpectraFiles)
-            {
-                Assert.That(double.IsNaN(protein.GetIntensity(file)));
-            }
+            return res;
         }
     }
 }


### PR DESCRIPTION
FlashLFQ changes:
- change median polish to weighted mean polish. the weight heavily favors measurements close to the median, so in most cases this should give nearly identical results to median polish, but should handle missing values better. the unit test "TestMedianPolish_WithSimilarIntensityRanks" fails if median is used, but succeeds if weighted mean is used.
- change 2d array to array of arrays
- if a peptide only has one observed intensity, change it to NaN (in most cases)
- add unit tests