### PR TITLE
Zero column effects result in identical intensity values

### DIFF
--- a/mzLib/TestFlashLFQ/TestFlashLFQ.cs
+++ b/mzLib/TestFlashLFQ/TestFlashLFQ.cs
@@ -1037,7 +1037,7 @@ namespace Test
         [Test, TestCaseSource("MedianPolishTestCases")]
         public static void TestMedianPolishWithIntensity(double[][] intensityArray, double[] expectedRowEffects, double[] expectedColumnEffects, double expectedOverallEffect)
         {
-            FlashLfqResults.MedianPolish(intensityArray);
+            FlashLfqResults.WeightedMeanPolish(intensityArray);
             var rowEffects = intensityArray.Select(p => p[0]).Skip(1).ToArray();
             var columnEffects = intensityArray[0].Skip(1).ToArray();
             var overallEffect = intensityArray[0][0];
@@ -1058,7 +1058,7 @@ namespace Test
                 new double[] { 0, 7, 8 } 
             };
 
-            FlashLfqResults.MedianPolish(array2D);
+            FlashLfqResults.WeightedMeanPolish(array2D);
             var rowEffects = array2D.Select(p => p[0]).Skip(1).ToArray();
             var columnEffects = array2D[0].Skip(1).ToArray();
             var overallEffect = array2D[0][0];


### PR DESCRIPTION
This reverts the change to FlashLFQ which caused proteins with 0 column effects after median/mean polish to have no reported protein group intensity values for samples corresponding to the 0 column effect columns.

Now, overall effect of median/mean polish is reported as the intensity in cases where the column effect is 0.

Currently testing this with the E. coli vignette data, will update with the results