### PR TITLE
Bug in ChemicalFormula.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,9 @@ ModelManifest.xml
 # Macintosh files
 **/.DS_Store
 
+/mzLib/Test/DataFiles/WT_ESO_+_B_B5_01_4035.mzML
+/mzLib/.idea/.idea.mzLib/.idea/workspace.xml
+/mzLib/.idea/.idea.mzLib/.idea/vcs.xml
+/mzLib/.idea/.idea.mzLib/.idea/projectSettingsUpdater.xml
+/mzLib/.idea/.idea.mzLib/.idea/indexLayout.xml
+/mzLib/.idea/.idea.mzLib/.idea/encodings.xml

--- a/mzLib/Chemistry/ChemicalFormula.cs
+++ b/mzLib/Chemistry/ChemicalFormula.cs
@@ -287,8 +287,8 @@ namespace Chemistry
             else
             {
                 Elements[element] += count;
-                if (Elements[element] <= 0)
-                    Elements.Remove(element);
+                //if (Elements[element] <= 0)
+                //    Elements.Remove(element);
             }
             formulaString = null;
         }

--- a/mzLib/Chemistry/ChemicalFormula.cs
+++ b/mzLib/Chemistry/ChemicalFormula.cs
@@ -72,7 +72,10 @@ namespace Chemistry
         {
             get
             {
-                return Isotopes.Sum(b => b.Key.AtomicMass * b.Value) + Elements.Sum(b => b.Key.AverageMass * b.Value);
+                return Isotopes.Where(b => b.Value > 0)
+                           .Sum(b => b.Key.AtomicMass * b.Value) 
+                       + Elements.Where(b => b.Value > 0)
+                           .Sum(b => b.Key.AverageMass * b.Value);
             }
         }
 
@@ -83,7 +86,9 @@ namespace Chemistry
         {
             get
             {
-                return Isotopes.Sum(b => b.Key.AtomicMass * b.Value) + Elements.Sum(b => b.Key.PrincipalIsotope.AtomicMass * b.Value);
+                return Isotopes
+                    .Where(b => b.Value > 0)
+                    .Sum(b => b.Key.AtomicMass * b.Value) + Elements.Where(b => b.Value > 0).Sum(b => b.Key.PrincipalIsotope.AtomicMass * b.Value);
             }
         }
 
@@ -94,7 +99,9 @@ namespace Chemistry
         {
             get
             {
-                return Isotopes.Sum(b => b.Value) + Elements.Sum(b => b.Value);
+                return Isotopes
+                    .Where(b => b.Value > 0)
+                    .Sum(b => b.Value) + Elements.Sum(b => b.Value);
             }
         }
 
@@ -106,9 +113,9 @@ namespace Chemistry
             get
             {
                 HashSet<int> ok = new HashSet<int>();
-                foreach (var i in Isotopes)
+                foreach (var i in Isotopes.Where(b => b.Value > 0))
                     ok.Add(i.Key.AtomicNumber);
-                foreach (var i in Elements)
+                foreach (var i in Elements.Where(b => b.Value > 0))
                     ok.Add(i.Key.AtomicNumber);
                 return ok.Count;
             }
@@ -121,7 +128,7 @@ namespace Chemistry
         {
             get
             {
-                return Isotopes.Count;
+                return Isotopes.Count(b => b.Value > 0);
             }
         }
 
@@ -142,7 +149,8 @@ namespace Chemistry
         {
             get
             {
-                return Isotopes.Sum(b => b.Key.Protons * b.Value) + Elements.Sum(b => b.Key.Protons * b.Value);
+                return Isotopes.Where(b => b.Value > 0)
+                    .Sum(b => b.Key.Protons * b.Value) + Elements.Sum(b => b.Key.Protons * b.Value);
             }
         }
 
@@ -156,6 +164,8 @@ namespace Chemistry
             {
                 int carbonCount = CountWithIsotopes("C");
                 int hydrogenCount = CountWithIsotopes("H");
+                if (carbonCount < 1 || hydrogenCount < 1)
+                    return 0; 
                 return hydrogenCount / (double)carbonCount;
             }
         }
@@ -289,6 +299,8 @@ namespace Chemistry
                 Elements[element] += count;
                 //if (Elements[element] <= 0)
                 //    Elements.Remove(element);
+                if (Elements[element] == 0)
+                    Elements.Remove(element);
             }
             formulaString = null;
         }

--- a/mzLib/Test/TestChemicalFormula.cs
+++ b/mzLib/Test/TestChemicalFormula.cs
@@ -1058,7 +1058,7 @@ namespace Test
         {
             ChemicalFormula f = ChemicalFormula.ParseFormula("CO");
             f.Add("O", -10);
-            Assert.That(f.Formula == "C");
+            Assert.That(f.Formula == "CO-9");
             Assert.That(f.NumberOfUniqueElementsByAtomicNumber == 1);
             Assert.That(f.MonoisotopicMass == 12);
         }

--- a/mzLib/Test/TestChemicalFormula.cs
+++ b/mzLib/Test/TestChemicalFormula.cs
@@ -158,11 +158,24 @@ namespace Test
             ChemicalFormula formulaA = ChemicalFormula.ParseFormula("C2H3NO");
             ChemicalFormula formulaB = ChemicalFormula.ParseFormula("C-1H-2");
             ChemicalFormula formulaC = ChemicalFormula.ParseFormula("CHNO");
-
+            
             formulaA.Add(formulaB);
 
             Assert.AreEqual(formulaA, formulaC);
         }
+
+        [Test]
+        public static void AddTwoDeamidations()
+        {
+            ChemicalFormula baseFormula = new ChemicalFormula();
+            ChemicalFormula deamidation = ChemicalFormula.ParseFormula("N-1H-1O");
+
+            baseFormula.Add(deamidation);
+            baseFormula.Add(deamidation);
+
+            Assert.AreEqual("H-2N-2O2", baseFormula.Formula);
+        }
+        
 
         [Test]
         public static void AddNegativeIsotopeToFormula()


### PR DESCRIPTION
This is to fix a bug that I found. 

The bug occurs when multiple subtractive chemical formulas are added to ChemicalFormula such that the number of Elements in the Chemical Formula becomes less than zero. 

This is a problem when there are multiple modifications like deamidations occurring on a peptide. Below is a picture of what I found in a PSMS.psmtsv file: 
![image](https://user-images.githubusercontent.com/64652734/225764213-4b7e3656-a8b5-4b91-9122-4e16f9e4207a.png)

The correct answer should be H-2N-2O2. 

Original code was written by Stefan; Rob made a commit adding lines 290-291 in ChemicalFormula.cs indicating that this was a bug fix. These lines added a check that removes elements with less than 1 element present. Indeed, when I commented out Rob's bug fix, two tests in TestChemicalFormula.cs failed. 

If anybody has any thoughts on how to fix this, I would be all ears. My plan right now is to modify the ChemicalFormula properties so that they calculate for only positive values of elements. Using  TestChemicalFormula TestAddLargeNegative() as an example, I can get the tests to pass by modifying the MonoisotopicMass property to only count the elements with values greater than zero. That way, all the masses and element counts are correct, but MetaMorpheus will output the correct string when dealing with subtractive modifications. 

Initial commit demonstrates the issue with the solution of just removing the control flow Rob added.

@rmillikin @Alexander-Sol @trishorts @nbollis @elaboy 