### PR TITLE
Added option to quantify ambiguous peptides in FlashLFQ

### DIFF
--- a/mzLib/FlashLFQ/FlashLFQResults.cs
+++ b/mzLib/FlashLFQ/FlashLFQResults.cs
@@ -1,5 +1,4 @@
 ﻿using MathNet.Numerics.Statistics;
-using Proteomics.AminoAcidPolymer;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/mzLib/FlashLFQ/FlashLFQResults.cs
+++ b/mzLib/FlashLFQ/FlashLFQResults.cs
@@ -1,4 +1,5 @@
 ﻿using MathNet.Numerics.Statistics;
+using Proteomics.AminoAcidPolymer;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -104,7 +105,7 @@ namespace FlashLFQ
             }
         }
 
-        public void CalculatePeptideResults()
+        public void CalculatePeptideResults(bool quantifyAmbiguousPeptides)
         {
             foreach (var sequence in PeptideModifiedSequences)
             {
@@ -117,8 +118,10 @@ namespace FlashLFQ
 
             foreach (var filePeaks in Peaks)
             {
-                var groupedPeaks = filePeaks.Value.Where(p => p.NumIdentificationsByFullSeq == 1)
-                    .GroupBy(p => p.Identifications.First().ModifiedSequence).ToList();
+                var groupedPeaks = filePeaks.Value
+                    .Where(p => p.NumIdentificationsByFullSeq == 1)
+                    .GroupBy(p => p.Identifications.First().ModifiedSequence)
+                    .ToList();
 
                 foreach (var sequenceWithPeaks in groupedPeaks)
                 {
@@ -149,7 +152,9 @@ namespace FlashLFQ
                 }
 
                 // report ambiguous quantification
-                var ambiguousPeaks = filePeaks.Value.Where(p => p.NumIdentificationsByFullSeq > 1).ToList();
+                var ambiguousPeaks = filePeaks.Value
+                    .Where(p => p.NumIdentificationsByFullSeq > 1)
+                    .ToList();
                 foreach (ChromatographicPeak ambiguousPeak in ambiguousPeaks)
                 {
                     foreach (Identification id in ambiguousPeak.Identifications)
@@ -159,16 +164,34 @@ namespace FlashLFQ
                         double alreadyRecordedIntensity = PeptideModifiedSequences[sequence].GetIntensity(filePeaks.Key);
                         double fractionAmbiguous = ambiguousPeak.Intensity / (alreadyRecordedIntensity + ambiguousPeak.Intensity);
 
-                        if (fractionAmbiguous > 0.3)
+                        if (quantifyAmbiguousPeptides)
                         {
-                            PeptideModifiedSequences[sequence].SetIntensity(filePeaks.Key, 0);
+                            // If the peptide intensity hasn't been recorded, the intensity is set equal to the intensity of the ambiguous peak
+                            if (Math.Abs(alreadyRecordedIntensity) < 0.01)
+                            {
+                                PeptideModifiedSequences[sequence].SetDetectionType(filePeaks.Key, DetectionType.MSMSAmbiguousPeakfinding);
+                                PeptideModifiedSequences[sequence].SetIntensity(filePeaks.Key, ambiguousPeak.Intensity);
+                            }
+                            // If the peptide intensity has already been recorded, that value is retained. 
+                            else if (fractionAmbiguous > 0.3)
+                            {
+                                PeptideModifiedSequences[sequence].SetDetectionType(filePeaks.Key, DetectionType.MSMSAmbiguousPeakfinding);
+                            }
+                        }
+                        else if (fractionAmbiguous > 0.3)
+                        {
                             PeptideModifiedSequences[sequence].SetDetectionType(filePeaks.Key, DetectionType.MSMSAmbiguousPeakfinding);
+                            PeptideModifiedSequences[sequence].SetIntensity(filePeaks.Key, 0);
                         }
                     }
                 }
+                
             }
 
-            HandleAmbiguityInFractions();
+            if (!quantifyAmbiguousPeptides)
+            {
+                HandleAmbiguityInFractions();
+            }
         }
 
         private void HandleAmbiguityInFractions()

--- a/mzLib/FlashLFQ/FlashLfqEngine.cs
+++ b/mzLib/FlashLFQ/FlashLfqEngine.cs
@@ -27,6 +27,7 @@ namespace FlashLFQ
         public readonly bool IdSpecificChargeState;
         public readonly bool Normalize;
         public readonly double DiscriminationFactorToCutPeak;
+        public readonly bool QuantifyAmbiguousPeptides;
 
         // MBR settings
         public readonly bool MatchBetweenRuns;
@@ -65,6 +66,7 @@ namespace FlashLFQ
             bool integrate = false,
             int numIsotopesRequired = 2,
             bool idSpecificChargeState = false,
+            bool quantifyAmbiguousPeptides = false,
             bool silent = false,
             int maxThreads = -1,
 
@@ -103,6 +105,7 @@ namespace FlashLFQ
             MbrPpmTolerance = matchBetweenRunsPpmTolerance;
             Integrate = integrate;
             NumIsotopesRequired = numIsotopesRequired;
+            QuantifyAmbiguousPeptides = quantifyAmbiguousPeptides;
             Silent = silent;
             IdSpecificChargeState = idSpecificChargeState;
             MbrRtWindow = maxMbrWindow;
@@ -202,7 +205,7 @@ namespace FlashLFQ
             }
 
             // calculate peptide intensities
-            _results.CalculatePeptideResults();
+            _results.CalculatePeptideResults(QuantifyAmbiguousPeptides);
 
             // do top3 protein quantification
             _results.CalculateProteinResultsMedianPolish(UseSharedPeptidesForProteinQuant);

--- a/mzLib/FlashLFQ/IntensityNormalizationEngine.cs
+++ b/mzLib/FlashLFQ/IntensityNormalizationEngine.cs
@@ -14,9 +14,10 @@ namespace FlashLFQ
         private readonly FlashLfqResults results;
         private readonly bool integrate;
         private readonly bool silent;
+        private readonly bool quantifyAmbiguousPeptides;
         private readonly int maxThreads;
 
-        public IntensityNormalizationEngine(FlashLfqResults results, bool integrate, bool silent, int maxThreads)
+        public IntensityNormalizationEngine(FlashLfqResults results, bool integrate, bool silent, int maxThreads, bool quantifyAmbiguousPeptides = false)
         {
             this.results = results;
             this.integrate = integrate;
@@ -29,7 +30,7 @@ namespace FlashLFQ
         /// </summary>
         public void NormalizeResults()
         {
-            results.CalculatePeptideResults();
+            results.CalculatePeptideResults(quantifyAmbiguousPeptides);
 
             // run normalization functions, recalculating intensity between each function
             if (!silent)
@@ -37,21 +38,21 @@ namespace FlashLFQ
                 Console.WriteLine("Normalizing fractions");
             }
             NormalizeFractions();
-            results.CalculatePeptideResults();
+            results.CalculatePeptideResults(quantifyAmbiguousPeptides);
 
             if (!silent)
             {
                 Console.WriteLine("Normalizing bioreps and conditions");
             }
             NormalizeBioreps();
-            results.CalculatePeptideResults();
+            results.CalculatePeptideResults(quantifyAmbiguousPeptides);
 
             if (!silent)
             {
                 Console.WriteLine("Normalizing techreps");
             }
             NormalizeTechreps();
-            results.CalculatePeptideResults();
+            results.CalculatePeptideResults(quantifyAmbiguousPeptides);
         }
 
         /// <summary>

--- a/mzLib/mzLib.nuspec
+++ b/mzLib/mzLib.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>mzLib</id>
-    <version>1.0.539</version>
+    <version>5.0.538</version>
     <title>mzLib</title>
     <authors>Stef S.</authors>
     <owners>Stef S.</owners>
@@ -31,7 +31,7 @@
 	<dependency id="OpenMcdf" version="2.2.1.3"/>
 	<dependency id="OpenMcdf.Extensions" version="2.2.1.3"/>
 	<dependency id="SharpLearning.Optimization" version="0.28.0"/>
-    <dependency id="OxyPlot.Wpf" version="2.0.0"/>
+        <dependency id="OxyPlot.Wpf" version="2.0.0"/>
       </group>
     </dependencies>
   </metadata>
@@ -48,11 +48,15 @@
     <file src="MzLibUtil\bin\x64\Release\net6.0\MzLibUtil.dll" target="lib\net6.0" />
     <file src="MzML\bin\x64\Release\net6.0\MzML.dll" target="lib\net6.0" />
     <file src="PepXML\bin\x64\Release\net6.0\PepXML.dll" target="lib\net6.0" /> 
-    <file src="Proteomics\bin\x64\Release\net6.0\Proteomics.dll" target="lib\net6.0" />
+    <file src="Proteomics\bin\x64\Release\net6.0\Proteomics.dll" target="lib\net6.0" /> 
     <file src="Proteomics\bin\x64\Release\net6.0\ProteolyticDigestion\proteases.tsv" target="lib\net6.0\ProteolyticDigestion" /> 
     <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UniProtKB_columnNamesForProgrammaticAccess.txt" target="lib\net6.0" /> 
-    <file src="Readers\bin\x64\Release\net6.0\Readers.dll" target="lib\net6.0" />
-	<file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UsefulProteomicsDatabases.dll" target="lib\net6.0" /> 
+    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoRawFileReader.dll" target="lib\net6.0" /> 
+    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.BackgroundSubtraction.dll" target="lib\net6.0" /> 
+    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.Data.dll" target="lib\net6.0" /> 
+    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.MassPrecisionEstimator.dll" target="lib\net6.0" /> 
+    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.RawFileReader.dll" target="lib\net6.0" /> 
+    <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UsefulProteomicsDatabases.dll" target="lib\net6.0" /> 
     <!--net6.0-windows target with mzPlot-->
     <file src="mzPlot\bin\x64\Release\net6.0-windows\mzPlot.dll" target="lib\net6.0-windows7.0" /> 
     <file src="BayesianEstimation\bin\x64\Release\net6.0\BayesianEstimation.dll" target="lib\net6.0-windows7.0" />
@@ -68,7 +72,11 @@
     <file src="Proteomics\bin\x64\Release\net6.0\Proteomics.dll" target="lib\net6.0-windows7.0" /> 
     <file src="Proteomics\bin\x64\Release\net6.0\ProteolyticDigestion\proteases.tsv" target="lib\net6.0-windows7.0\ProteolyticDigestion" /> 
     <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UniProtKB_columnNamesForProgrammaticAccess.txt" target="lib\net6.0-windows7.0" />
-    <file src="Readers\bin\x64\Release\net6.0\Readers.dll" target="lib\net6.0-windows7.0" />
-	<file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UsefulProteomicsDatabases.dll" target="lib\net6.0-windows7.0" /> 
+    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoRawFileReader.dll" target="lib\net6.0-windows7.0" /> 
+    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.BackgroundSubtraction.dll" target="lib\net6.0-windows7.0" /> 
+    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.Data.dll" target="lib\net6.0-windows7.0" /> 
+    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.MassPrecisionEstimator.dll" target="lib\net6.0-windows7.0" /> 
+    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.RawFileReader.dll" target="lib\net6.0-windows7.0" /> 
+    <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UsefulProteomicsDatabases.dll" target="lib\net6.0-windows7.0" /> 
   </files>
 </package>

--- a/mzLib/mzLib.nuspec
+++ b/mzLib/mzLib.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>mzLib</id>
-    <version>5.0.538</version>
+    <version>1.0.539</version>
     <title>mzLib</title>
     <authors>Stef S.</authors>
     <owners>Stef S.</owners>
@@ -31,7 +31,7 @@
 	<dependency id="OpenMcdf" version="2.2.1.3"/>
 	<dependency id="OpenMcdf.Extensions" version="2.2.1.3"/>
 	<dependency id="SharpLearning.Optimization" version="0.28.0"/>
-        <dependency id="OxyPlot.Wpf" version="2.0.0"/>
+    <dependency id="OxyPlot.Wpf" version="2.0.0"/>
       </group>
     </dependencies>
   </metadata>
@@ -48,15 +48,11 @@
     <file src="MzLibUtil\bin\x64\Release\net6.0\MzLibUtil.dll" target="lib\net6.0" />
     <file src="MzML\bin\x64\Release\net6.0\MzML.dll" target="lib\net6.0" />
     <file src="PepXML\bin\x64\Release\net6.0\PepXML.dll" target="lib\net6.0" /> 
-    <file src="Proteomics\bin\x64\Release\net6.0\Proteomics.dll" target="lib\net6.0" /> 
+    <file src="Proteomics\bin\x64\Release\net6.0\Proteomics.dll" target="lib\net6.0" />
     <file src="Proteomics\bin\x64\Release\net6.0\ProteolyticDigestion\proteases.tsv" target="lib\net6.0\ProteolyticDigestion" /> 
     <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UniProtKB_columnNamesForProgrammaticAccess.txt" target="lib\net6.0" /> 
-    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoRawFileReader.dll" target="lib\net6.0" /> 
-    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.BackgroundSubtraction.dll" target="lib\net6.0" /> 
-    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.Data.dll" target="lib\net6.0" /> 
-    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.MassPrecisionEstimator.dll" target="lib\net6.0" /> 
-    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.RawFileReader.dll" target="lib\net6.0" /> 
-    <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UsefulProteomicsDatabases.dll" target="lib\net6.0" /> 
+    <file src="Readers\bin\x64\Release\net6.0\Readers.dll" target="lib\net6.0" />
+	<file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UsefulProteomicsDatabases.dll" target="lib\net6.0" /> 
     <!--net6.0-windows target with mzPlot-->
     <file src="mzPlot\bin\x64\Release\net6.0-windows\mzPlot.dll" target="lib\net6.0-windows7.0" /> 
     <file src="BayesianEstimation\bin\x64\Release\net6.0\BayesianEstimation.dll" target="lib\net6.0-windows7.0" />
@@ -72,11 +68,7 @@
     <file src="Proteomics\bin\x64\Release\net6.0\Proteomics.dll" target="lib\net6.0-windows7.0" /> 
     <file src="Proteomics\bin\x64\Release\net6.0\ProteolyticDigestion\proteases.tsv" target="lib\net6.0-windows7.0\ProteolyticDigestion" /> 
     <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UniProtKB_columnNamesForProgrammaticAccess.txt" target="lib\net6.0-windows7.0" />
-    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoRawFileReader.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.BackgroundSubtraction.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.Data.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.MassPrecisionEstimator.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="ThermoRawFileReader\bin\x64\Release\net6.0\ThermoFisher.CommonCore.RawFileReader.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UsefulProteomicsDatabases.dll" target="lib\net6.0-windows7.0" /> 
+    <file src="Readers\bin\x64\Release\net6.0\Readers.dll" target="lib\net6.0-windows7.0" />
+	<file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UsefulProteomicsDatabases.dll" target="lib\net6.0-windows7.0" /> 
   </files>
 </package>


### PR DESCRIPTION
Introduced option in FlashLFQ for the quantification of ambiguous peptides. This is a feature that was requested by collaborators

"I just wanted to follow up with you on the ambiguous peptide issue ____ was explaining during our meeting. When a peptide is identified as ambiguous, MetaMorpheus outputs a null (zero value) in the AllQuantPeptides and AllQuantPeaks, even when we know that peptide species has a nice strong signal. There is nothing inherently wrong with MetaMorpheus telling us when it’s unsure of an ID (I really like this feature) but the problem is this ambiguous ID is not always carried across all replicates—some replicates have a single confident ID while other replicates have an ambiguous ID (and a null intensity value). With a shotgun experiment on a whole cell lysate, this probably has very little effect on the data but since we are doing peptide-level quant on a purified protein, it is having a more pronounced effect (which is very protein dependent). The easiest solution is probably just to have MetaMorpheus output intensity values whether the ID is ambiguous or not. It is already grouping the ambiguous ID with non-ambiguous IDs from other replicates and it seems to do a pretty good job at doing this grouping, so the real problem is just the null intensity values."