### PR TITLE
removed the zero-equivalent intensity filtering from mzMl

### DIFF
--- a/mzLib/Readers/MzML/Mzml.cs
+++ b/mzLib/Readers/MzML/Mzml.cs
@@ -621,22 +621,7 @@ namespace Readers
                                     {
                                         throw new MzLibException("Could not determine the MS order or centroid/profile status");
                                     }
-
-                                    //Remove Zero Intensity Peaks
-                                    double zeroEquivalentIntensity = 0.01;
-                                    int zeroIntensityCount = intensities.Count(i => i < zeroEquivalentIntensity);
-                                    int intensityValueCount = intensities.Count();
-                                    if (zeroIntensityCount > 0 && zeroIntensityCount < intensityValueCount)
-                                    {
-                                        Array.Sort(intensities, mzs);
-                                        double[] nonZeroIntensities = new double[intensityValueCount - zeroIntensityCount];
-                                        double[] nonZeroMzs = new double[intensityValueCount - zeroIntensityCount];
-                                        intensities = intensities.SubArray(zeroIntensityCount, intensityValueCount - zeroIntensityCount);
-                                        mzs = mzs.SubArray(zeroIntensityCount, intensityValueCount - zeroIntensityCount);
-                                        Array.Sort(mzs, intensities);
-                                    }
-
-
+                                    
                                     // peak filtering
                                     if (filterParams != null && intensities.Length > 0 &&
                                         ((filterParams.ApplyTrimmingToMs1 && msOrder.Value == 1) || (filterParams.ApplyTrimmingToMsMs && msOrder.Value > 1)))
@@ -869,20 +854,6 @@ namespace Readers
                         high = double.Parse(cv.value, CultureInfo.InvariantCulture);
                     }
                 }
-            }
-
-            //Remove Zero Intensity Peaks
-            double zeroEquivalentIntensity = 0.01;
-            int zeroIntensityCount = intensities.Count(i => i < zeroEquivalentIntensity);
-            int intensityValueCount = intensities.Count();
-            if (zeroIntensityCount > 0 && zeroIntensityCount < intensityValueCount)
-            {
-                Array.Sort(intensities, masses);
-                double[] nonZeroIntensities = new double[intensityValueCount - zeroIntensityCount];
-                double[] nonZeroMzs = new double[intensityValueCount - zeroIntensityCount];
-                intensities = intensities.SubArray(zeroIntensityCount, intensityValueCount - zeroIntensityCount);
-                masses = masses.SubArray(zeroIntensityCount, intensityValueCount - zeroIntensityCount);
-                Array.Sort(masses, intensities);
             }
 
             if (filterParams != null && intensities.Length > 0 && ((filterParams.ApplyTrimmingToMs1 && msOrder.Value == 1) || (filterParams.ApplyTrimmingToMsMs && msOrder.Value > 1)))


### PR DESCRIPTION
Removes the pre-filtering of "zero-equivalent values" from loading an mzML file. I noticed this behavior when trying to load in simulated data where most values were under 0.01. 