### PR TITLE
Fixed bug in GetClosestIndex for arrays of length 1 or 2

### DIFF
--- a/mzLib/Chemistry/ClassExtensions.cs
+++ b/mzLib/Chemistry/ClassExtensions.cs
@@ -77,10 +77,11 @@ namespace Chemistry
             }
 
             defaultImplementationIndex = ~defaultImplementationIndex; // point to the first value larger than the target.
-            if (defaultImplementationIndex == 0)
-                return 0;
             if (defaultImplementationIndex == sortedArray.Length)
                 return defaultImplementationIndex - 1;
+            if (defaultImplementationIndex == 0)
+                return 0;
+            
 
             int closestIndex;
             switch (searchType)

--- a/mzLib/Chemistry/ClassExtensions.cs
+++ b/mzLib/Chemistry/ClassExtensions.cs
@@ -76,10 +76,15 @@ namespace Chemistry
                 return defaultImplementationIndex; 
             }
 
-            defaultImplementationIndex = ~defaultImplementationIndex; // point to the first value larger than the target.
+            // Negative indices mean no exact match. Taking there bitwise complement yield the index
+            // of the first element with a value greater than the target.
+            defaultImplementationIndex = ~defaultImplementationIndex; 
+
             if (defaultImplementationIndex == sortedArray.Length)
+                // This implies that the target value was greater than the largest element in the array
                 return defaultImplementationIndex - 1;
             if (defaultImplementationIndex == 0)
+                // This implies that the target value was less than the smallest element in the array
                 return 0;
             
 

--- a/mzLib/Test/TestClassExtensions.cs
+++ b/mzLib/Test/TestClassExtensions.cs
@@ -34,6 +34,20 @@ namespace Test
             // Test different search options
             Assert.AreEqual(sortedArray.GetClosestIndex(4.75, ArraySearchOption.Next), 4);
             Assert.AreEqual(sortedArray.GetClosestIndex(4.75, ArraySearchOption.Previous), 3);
+
+            double[] smallerSortedArray = { 1, 2 };
+
+            Assert.AreEqual(smallerSortedArray.GetClosestIndex( -1), 0);
+            Assert.AreEqual(smallerSortedArray.GetClosestIndex(0), 0);
+            Assert.AreEqual(smallerSortedArray.GetClosestIndex(1), 0);
+            Assert.AreEqual(smallerSortedArray.GetClosestIndex(1.9), 1);
+            Assert.AreEqual(smallerSortedArray.GetClosestIndex(Double.MaxValue), 1);
+
+            double[] smallestSortedArray = { 1 };
+            Assert.AreEqual(smallestSortedArray.GetClosestIndex(-1), 0);
+            Assert.AreEqual(smallestSortedArray.GetClosestIndex(0), 0);
+            Assert.AreEqual(smallestSortedArray.GetClosestIndex(1), 0);
+            Assert.AreEqual(smallestSortedArray.GetClosestIndex(Double.MaxValue), 0);
         }
 
         [Test]


### PR DESCRIPTION
If you had an array of length 1 or 2, then closest search would sometime try and get the element at index -1, throwing an ArrayIndexOutOfBounds Exception. This was fixed by re-ordering the index check+return statements.