### PR TITLE
Disabled Development Tests from Running Automatically

### DIFF
--- a/mzLib/Development/Deconvolution/StandardDeconvolutionTest.cs
+++ b/mzLib/Development/Deconvolution/StandardDeconvolutionTest.cs
@@ -14,6 +14,7 @@ namespace Development.Deconvolution
     /// </remarks>
     /// </summary>
     [TestFixture]
+    [Ignore("Only needed when developing deconvolution methods")]
     [ExcludeFromCodeCoverage]
     public class StandardDeconvolutionTest
     {

--- a/mzLib/Development/Deconvolution/TestCases/TestDevelopmentTestCases.cs
+++ b/mzLib/Development/Deconvolution/TestCases/TestDevelopmentTestCases.cs
@@ -8,6 +8,7 @@ namespace Development.Deconvolution
 
 {
     [TestFixture]
+    [Ignore("Only needed when developing deconvolution methods")]
     [ExcludeFromCodeCoverage]
     public static class TestDevelopmentTestCases
     {


### PR DESCRIPTION
These tests take some time and are only useful when developing a new deconvolution method. 

