### PR TITLE
From Private to Protected, allows control from inherited classes

### DIFF
--- a/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -22,7 +22,7 @@ namespace Proteomics.ProteolyticDigestion
         /// Dictionary of modifications on the peptide. The N terminus is index 1.
         /// The key indicates which residue modification is on (with 1 being N terminus).
         /// </summary>
-        [NonSerialized] private Dictionary<int, Modification> _allModsOneIsNterminus; //we currently only allow one mod per position
+        [NonSerialized] protected Dictionary<int, Modification> _allModsOneIsNterminus; //we currently only allow one mod per position
         [NonSerialized] protected bool? _hasChemicalFormulas;
         [NonSerialized] private string _sequenceWithChemicalFormulas;
         [NonSerialized] protected double? _monoisotopicMass;

--- a/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -1,4 +1,4 @@
-﻿ using Chemistry;
+﻿using Chemistry;
 using MassSpectrometry;
 using Proteomics.AminoAcidPolymer;
 using Proteomics.Fragmentation;

--- a/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -23,10 +23,10 @@ namespace Proteomics.ProteolyticDigestion
         /// The key indicates which residue modification is on (with 1 being N terminus).
         /// </summary>
         [NonSerialized] private Dictionary<int, Modification> _allModsOneIsNterminus; //we currently only allow one mod per position
-        [NonSerialized] private bool? _hasChemicalFormulas;
+        [NonSerialized] protected bool? _hasChemicalFormulas;
         [NonSerialized] private string _sequenceWithChemicalFormulas;
-        [NonSerialized] private double? _monoisotopicMass;
-        [NonSerialized] private double? _mostAbundantMonoisotopicMass;
+        [NonSerialized] protected double? _monoisotopicMass;
+        [NonSerialized] protected double? _mostAbundantMonoisotopicMass;
         [NonSerialized] private ChemicalFormula _fullChemicalFormula;
         [NonSerialized] private DigestionParams _digestionParams;
         private static readonly double WaterMonoisotopicMass = PeriodicTable.GetElement("H").PrincipalIsotope.AtomicMass * 2 + PeriodicTable.GetElement("O").PrincipalIsotope.AtomicMass;


### PR DESCRIPTION
Changing some fields from private to protected will allow control over private fields from a custom child class.