### PR TITLE
Above Averaging Algorithm Rework and Crash Fix

### DIFF
--- a/mzLib/SpectralAveraging/Algorithms/SpectraFileAveraging.cs
+++ b/mzLib/SpectralAveraging/Algorithms/SpectraFileAveraging.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using Easy.Common.Interfaces;
 using MassSpectrometry;
-using MathNet.Numerics.Statistics;
 using MzLibUtil;
 
 namespace SpectralAveraging;

--- a/mzLib/SpectralAveraging/Algorithms/SpectraFileAveraging.cs
+++ b/mzLib/SpectralAveraging/Algorithms/SpectraFileAveraging.cs
@@ -36,10 +36,6 @@ public static class SpectraFileAveraging
                 return AverageEverynScans(scans, parameters);
 
             case SpectraFileAveragingType.AverageDdaScans:
-                parameters.ScanOverlap = 0;
-                return AverageDdaScans(scans, parameters);
-
-            case SpectraFileAveragingType.AverageDdaScansWithOverlap:
                 return AverageDdaScans(scans, parameters);
 
             default: throw new MzLibException("Averaging spectra file processing type not yet implemented");
@@ -90,7 +86,6 @@ public static class SpectraFileAveraging
             var averagedSpectrum = scansToProcess.AverageSpectra(parameters);
             MsDataScan averagedScan = GetAveragedDataScanFromAveragedSpectrum(averagedSpectrum, representativeScan);
             averagedScans.Add(averagedScan);
-           
         }
 
         return averagedScans.ToArray();
@@ -119,17 +114,12 @@ public static class SpectraFileAveraging
             scansToProcess.RemoveAt(0);
         }
         
-        // add MS1 scans from start and end of file that did not get averaged
+        // add all scans that did not get averaged
+        // this includes the MS1 scans from start and end of file and all MS2+ scans
         foreach (var unaveragedScan in scans.Where(original =>
-                     original.MsnOrder == 1 
-                     && !averagedScans.Select(avg => avg.OneBasedScanNumber)
-                         .Contains(original.OneBasedScanNumber)))
-        {
+                     !averagedScans.Select(avg => avg.OneBasedScanNumber).Contains(original.OneBasedScanNumber)))
             averagedScans.Add(unaveragedScan);
-        }
         
-        // add all scans that are not MS1 scans
-        averagedScans.AddRange(scans.Where(p => p.MsnOrder != 1));
         return averagedScans.OrderBy(p => p.OneBasedScanNumber).ToArray();
     }
 

--- a/mzLib/SpectralAveraging/Algorithms/SpectraFileAveraging.cs
+++ b/mzLib/SpectralAveraging/Algorithms/SpectraFileAveraging.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using Easy.Common.Interfaces;
 using MassSpectrometry;
 using MathNet.Numerics.Statistics;
 using MzLibUtil;
@@ -106,69 +108,65 @@ public static class SpectraFileAveraging
     private static MsDataScan[] AverageDdaScans(List<MsDataScan> scans, SpectralAveragingParameters parameters)
     {
         List<MsDataScan> averagedScans = new();
-        var ms1Scans = scans.Where(p => p.MsnOrder == 1).ToList();
-        var ms2Scans = scans.Where(p => p.MsnOrder == 2).ToList();
         List<MsDataScan> scansToProcess = new();
 
-        var scanNumberIndex = 1;
-        int indexer = parameters.NumberOfScansToAverage - parameters.ScanOverlap;
-        for (var i = 0; i < ms1Scans.Count; i += indexer)
+        int representativeScanMs1Index = parameters.NumberOfScansToAverage % 2 == 0 ? // central scan
+            parameters.NumberOfScansToAverage / 2 - 1 : parameters.NumberOfScansToAverage / 2;
+
+        // iterate through all MS1 scans and average them
+        foreach (var scan in scans.Where(p => p.MsnOrder == 1))
         {
-            // get the scans to be averaged
-            scansToProcess.Clear();
-            IEnumerable<MsDataScan> ms2ScansFromAveragedScans;
-            if (i + parameters.NumberOfScansToAverage > ms1Scans.Count) // very end of the file
-                break;
+            scansToProcess.Add(scan);
 
-            scansToProcess = ms1Scans.GetRange(i, parameters.NumberOfScansToAverage);
-            // if next iteration breaks the loop (end of file), then add the rest of the MS2's
-            if (i + indexer + parameters.NumberOfScansToAverage >
-                ms1Scans.Count)
-                ms2ScansFromAveragedScans = ms2Scans.Where(p =>
-                    scansToProcess.Any(m => m.OneBasedScanNumber == p.OneBasedPrecursorScanNumber));
-            // if not, add MS2 scans from MS1's that will not be averaged in the next iteration
-            else
-                ms2ScansFromAveragedScans = ms2Scans.Where(p =>
-                    scansToProcess.GetRange(0, indexer)
-                        .Any(m => m.OneBasedScanNumber == p.OneBasedPrecursorScanNumber));
-
-            // average scans and add to averaged list
-            int middleIndex = scansToProcess.Count / 2;
-            MsDataScan representativeScan = scansToProcess.Count % 2 == 0 ? 
-                scansToProcess[middleIndex - 1] : 
-                scansToProcess[middleIndex];
-
-            var averagedSpectrum = scansToProcess.AverageSpectra(parameters);
-            MsDataScan averagedScan = new(averagedSpectrum, scanNumberIndex, 1,
-                representativeScan.IsCentroid, representativeScan.Polarity, representativeScan.RetentionTime,
-                averagedSpectrum.Range, null, representativeScan.MzAnalyzer,
-                averagedSpectrum.SumOfAllY,
-                scansToProcess.Select(p => p.InjectionTime).Average(), representativeScan.NoiseData,
-                representativeScan.NativeId, representativeScan.SelectedIonMZ,
-                representativeScan.SelectedIonChargeStateGuess,
-                representativeScan.SelectedIonIntensity, representativeScan.IsolationMz,
-                representativeScan.IsolationWidth,
-                representativeScan.DissociationType, representativeScan.OneBasedPrecursorScanNumber,
-                representativeScan.SelectedIonMonoisotopicGuessIntensity);
-            var newNativeId =
-                averagedScan.NativeId.Replace(averagedScan.NativeId.Split("=").Last(), scanNumberIndex.ToString());
-            averagedScan.SetNativeID(newNativeId);
-            averagedScans.Add(averagedScan);
-            var precursorScanIndex = scanNumberIndex;
-            scanNumberIndex++;
-
-            foreach (var scan in ms2ScansFromAveragedScans)
+            // middle of the file, average with new scan from iteration, then remove first scan from list
+            if (scansToProcess.Count == parameters.NumberOfScansToAverage) 
             {
-                newNativeId =
-                    scan.NativeId.Replace(scan.NativeId.Split("=").Last(), scanNumberIndex.ToString());
-                scan.SetNativeID(newNativeId);
-                scan.SetOneBasedScanNumber(scanNumberIndex);
-                scan.SetOneBasedPrecursorScanNumber(precursorScanIndex);
-                averagedScans.Add(scan);
-                scanNumberIndex++;
-            }
-        }
+                MsDataScan centralScan = scansToProcess[representativeScanMs1Index];
+                var averagedSpectrum = scansToProcess.AverageSpectra(parameters);
+                var averagedScan = GetAveragedDataScanFromAveragedSpectrum(averagedSpectrum, centralScan);
 
-        return averagedScans.ToArray();
+                averagedScans.Add(averagedScan);
+                scansToProcess.RemoveAt(0);
+            }
+            // start of the file, not enough scans to average, just add the scans to final output
+            else if (scansToProcess.Count <= representativeScanMs1Index)
+                averagedScans.Add(scan);
+        }
+        
+        // add MS1 scans from end of file that did not get averaged
+        averagedScans.AddRange(scans.Where(p => p.MsnOrder == 1).TakeLast(representativeScanMs1Index));
+        // add all scans that are not MS1 scans
+        averagedScans.AddRange(scans.Where(p => p.MsnOrder != 1));
+
+        return averagedScans.OrderBy(p => p.OneBasedScanNumber).ToArray();
+    }
+
+    private static MsDataScan GetAveragedDataScanFromAveragedSpectrum(MzSpectrum averagedSpectrum, 
+        MsDataScan centralScan)
+    {
+        MsDataScan averagedScan = new(averagedSpectrum,
+            centralScan.OneBasedScanNumber,
+            1,
+            centralScan.IsCentroid,
+            centralScan.Polarity,
+            centralScan.RetentionTime,
+            averagedSpectrum.Range, null,
+            centralScan.MzAnalyzer,
+            averagedSpectrum.SumOfAllY,
+            centralScan.InjectionTime,
+            centralScan.NoiseData,
+            centralScan.NativeId,
+            centralScan.SelectedIonMZ,
+            centralScan.SelectedIonChargeStateGuess,
+            centralScan.SelectedIonIntensity,
+            centralScan.IsolationMz,
+            centralScan.IsolationWidth,
+            centralScan.DissociationType,
+            centralScan.OneBasedPrecursorScanNumber,
+            centralScan.SelectedIonMonoisotopicGuessIntensity);
+        var newNativeId =
+            averagedScan.NativeId.Replace(averagedScan.NativeId.Split("=").Last(), centralScan.OneBasedScanNumber.ToString());
+        averagedScan.SetNativeID(newNativeId);
+        return averagedScan;
     }
 }

--- a/mzLib/SpectralAveraging/DataStructures/Enums/SpectraFileAveragingType.cs
+++ b/mzLib/SpectralAveraging/DataStructures/Enums/SpectraFileAveragingType.cs
@@ -6,5 +6,4 @@ public enum SpectraFileAveragingType
     AverageEverynScans,
     AverageEverynScansWithOverlap,
     AverageDdaScans,
-    AverageDdaScansWithOverlap
 }

--- a/mzLib/Test/AveragingTests/TestAveragingSpectraWriteFile.cs
+++ b/mzLib/Test/AveragingTests/TestAveragingSpectraWriteFile.cs
@@ -29,7 +29,7 @@ namespace Test.AveragingTests
             SpectraPath = Path.Combine(OutputDirectory, "TDYeastFractionMS1.mzML");
             Scans = MsDataFileReader.GetDataFile(SpectraPath).GetAllScansList().Take(50).ToList();
 
-            Parameters.SpectraFileAveragingType = SpectraFileAveragingType.AverageDdaScansWithOverlap;
+            Parameters.SpectraFileAveragingType = SpectraFileAveragingType.AverageDdaScans;
             DdaCompositeSpectra = SpectraFileAveraging.AverageSpectraFile(Scans, Parameters);
             Assert.That(DdaCompositeSpectra.Length > 1);
         }

--- a/mzLib/Test/AveragingTests/TestSpectraFileAveraging.cs
+++ b/mzLib/Test/AveragingTests/TestSpectraFileAveraging.cs
@@ -267,6 +267,40 @@ namespace Test.AveragingTests
         }
 
 
+
+        [Test]
+        public static void DummyTest()
+        {
+            string filePath = @"B:\Users\Nic\SharedWithMe\tiltedAverageBroke\JD071923_BoNT_Elastase_5.raw";
+            var scanList = MsDataFileReader.GetDataFile(filePath).GetAllScansList();
+            SpectralAveragingParameters parameters = new SpectralAveragingParameters()
+            {
+                OutlierRejectionType = OutlierRejectionType.SigmaClipping,
+                SpectralWeightingType = SpectraWeightingType.WeightEvenly,
+                NormalizationType = NormalizationType.RelativeToTics,
+                BinSize = 0.01,
+                MinSigmaValue = 0.5,
+                MaxSigmaValue = 3,
+                NumberOfScansToAverage = 5,
+                ScanOverlap = 4,
+                MaxThreadsToUsePerFile = 1,
+                OutputType = OutputType.MzML,
+                SpectraFileAveragingType = SpectraFileAveragingType.AverageDdaScansWithOverlap,
+                SpectralAveragingType = SpectralAveragingType.MzBinning
+            };
+
+            var averagedScans = SpectraFileAveraging.AverageSpectraFile(scanList, parameters);
+
+            var duplicates = averagedScans
+                .GroupBy(x => (x.OneBasedScanNumber, x.OneBasedPrecursorScanNumber))
+                .Where(group => group.Count() > 1)
+                .ToDictionary(p => p.Key, p => p.ToList());
+
+        }
+
+
+
+
         [Test]
         public static void TestAverageAll()
         {

--- a/mzLib/Test/AveragingTests/TestSpectraFileAveraging.cs
+++ b/mzLib/Test/AveragingTests/TestSpectraFileAveraging.cs
@@ -358,7 +358,6 @@ namespace Test.AveragingTests
             Assert.That(averagedScans.First().MassSpectrum.YArray.SequenceEqual(expected));
         }
 
-
         [Test]
         [TestCase(5, nameof(DummyDDAScansOutOfOrder))]
         [TestCase(4, nameof(DummyDDAScansOutOfOrder))]

--- a/mzLib/mzLib.nuspec
+++ b/mzLib/mzLib.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>mzLib</id>
-    <version>5.0.540</version>
+    <version>5.0.601</version>
     <title>mzLib</title>
     <authors>Stef S.</authors>
     <owners>Stef S.</owners>

--- a/mzLib/mzLib.nuspec
+++ b/mzLib/mzLib.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>mzLib</id>
-    <version>5.0.601</version>
+    <version>5.0.540</version>
     <title>mzLib</title>
     <authors>Stef S.</authors>
     <owners>Stef S.</owners>


### PR DESCRIPTION
Crash was caused by MS1 and MS2 scans being out of order. The previous algorithm mistakenly added duplicates of the same MS2 scan, leading to a crash on writing the mzML file as the scan numbers were not unique. 

This PR changes how averaging DDA scans works by first removing the overlap parameter. The algorithm will iterate through all MS1 scans, adding the number to be averaged to a local collection. The collection will be averaged, the first scan removed, and the next scan inserted before restarting the loop. All unaveraged scans (leading or lagging MS1s or all MSn+) will then be added at the end. 

Due to this change in the algorithm, the tests had to be reconsidered. 
Test now ensure that the same number of MS1 and MS2 scans are present in the averaged spectrum, that they are in the same order, and that their retention times are correct after averaging. 

Converting the averaged MzSpectrum into a MsDataScan was excised to a helper method to clean up the algorithmic methods. 

This PR was packed and added to MetaMorpheus. The accompanying MetaMorpheus PR is #2318 and will need to be slightly amended once this version of Mzlib is released