### PR TITLE
Edited the MatchedFramgentIon Equals method

### DIFF
--- a/mzLib/Omics/Fragmentation/MatchedFragmentIon.cs
+++ b/mzLib/Omics/Fragmentation/MatchedFragmentIon.cs
@@ -78,8 +78,8 @@ namespace Omics.Fragmentation
 
             return this.NeutralTheoreticalProduct.Equals(other.NeutralTheoreticalProduct)
                 && this.Charge == other.Charge
-                && this.Mz == other.Mz
-                && this.Intensity == other.Intensity;
+                && Math.Abs(Mz - other.Mz) < 0.0001
+                && Math.Abs(Intensity - other.Intensity) < 0.0001;
         }
 
         public override int GetHashCode()

--- a/mzLib/Test/TestFragments.cs
+++ b/mzLib/Test/TestFragments.cs
@@ -888,6 +888,15 @@ namespace Test
         }
 
         [Test]
+        public static void TestMatchedFragmentIonEquals()
+        {
+            Product P = new Product(ProductType.b, FragmentationTerminus.N, 1, 1, 1, 0);
+            MatchedFragmentIon ion1 = new MatchedFragmentIon(P, experMz: 150, experIntensity: 99.99999, charge: 2);
+            MatchedFragmentIon ion2 = new MatchedFragmentIon(P, experMz: 149.99999, experIntensity: 100, charge: 2);
+            Assert.AreEqual(ion1, ion2);
+        }
+
+        [Test]
         public static void Test_CID_Fragmentation_No_Unmodified_B1_ions()
         {
             //FOR CID B1 ions should always be missing whether or not there is a modification on first amino acid or not.


### PR DESCRIPTION
Previously, the MatchedFragmentIon.Equals method used a naive check (==) when comparing mz and intensity of two fragment ions. 

This causes issues when comparing ions that are equivalent, but were converted to string and then back to ion objects, because of how double comparison works. For example, comparing ions between an equivalent PSM and PsmFromTsv would show that the ions weren't equal, due to very small differences in the intensity/mz values.