### PR TITLE
Nucleotide, Rnase, Digestion Params Clone Method, and Interface Modificaiton

### DIFF
--- a/mzLib/Omics/Digestion/IDigestionParams.cs
+++ b/mzLib/Omics/Digestion/IDigestionParams.cs
@@ -11,5 +11,8 @@ namespace Omics.Digestion
         int MaxMods { get; set; }
         DigestionAgent DigestionAgent { get; }
         FragmentationTerminus FragmentationTerminus { get; }
+
+        CleavageSpecificity SearchModeType { get; }
+        IDigestionParams Clone();
     }
 }

--- a/mzLib/Omics/Digestion/IDigestionParams.cs
+++ b/mzLib/Omics/Digestion/IDigestionParams.cs
@@ -11,8 +11,13 @@ namespace Omics.Digestion
         int MaxMods { get; set; }
         DigestionAgent DigestionAgent { get; }
         FragmentationTerminus FragmentationTerminus { get; }
-
         CleavageSpecificity SearchModeType { get; }
-        IDigestionParams Clone();
+
+        /// <summary>
+        /// new terminus parameter is for non and semi specific searches
+        /// </summary>
+        /// <param name="newTerminus"></param>
+        /// <returns></returns>
+        IDigestionParams Clone(FragmentationTerminus? newTerminus = null);
     }
 }

--- a/mzLib/Omics/Digestion/IDigestionParams.cs
+++ b/mzLib/Omics/Digestion/IDigestionParams.cs
@@ -19,6 +19,7 @@ namespace Omics.Digestion
 
         /// <summary>
         /// new terminus parameter is for non and semi specific searches
+        /// The Fragmentation terminus will never be null, if a null value is inputted, the fragmentation terminus will be set to the fragmentation terminus of the object being cloned.
         /// </summary>
         /// <param name="newTerminus"></param>
         /// <returns></returns>

--- a/mzLib/Omics/Digestion/IDigestionParams.cs
+++ b/mzLib/Omics/Digestion/IDigestionParams.cs
@@ -11,6 +11,10 @@ namespace Omics.Digestion
         int MaxMods { get; set; }
         DigestionAgent DigestionAgent { get; }
         FragmentationTerminus FragmentationTerminus { get; }
+        /// <summary>
+        /// Search mode type refers to the CleavageSpecificity enum and is used for MetaMorpheus to determine if it should perform a non-specific, semi-specific, or fully specific search.
+        /// For the initial implementation, RNA will have it hardcoded to a fully specific search.
+        /// </summary>
         CleavageSpecificity SearchModeType { get; }
 
         /// <summary>

--- a/mzLib/Omics/IBioPolymer.cs
+++ b/mzLib/Omics/IBioPolymer.cs
@@ -15,9 +15,13 @@ namespace Omics
         string Organism { get; }
         string Accession { get; }
         /// <summary>
-        /// The list of gene names consists of tuples, where Item1 is the type of gene name, and Item2 is the nameof the specific molecule.
-        /// There may be many genes and names of a certain type produced when reading an XML protein database.
-        /// For RNA there may be a gene name and a specific transcript name due to splice variants.
+        /// This tuple originates from reading UniProt XML protein entries. It consists of two parts.
+        /// The second part is the gene name, which is also often referred to as the gene symbol.
+        /// The first part is a descriptor for the second part. For example, "primary" is a word used for the
+        /// first part to indicate that the gene symbol/name that follows is the name most widely accepted
+        /// by the community. The word "synonym" in the first part would indicate that the gene name in the
+        /// second part is an alternative. The word "ORF", which stands for open reading frame in the first part
+        /// is also acceptable. Here, the second part will include a range, for example "AO055_05240"
         /// </summary>
         IEnumerable<Tuple<string, string>> GeneNames { get; }
         IDictionary<int, List<Modification>> OneBasedPossibleLocalizedModifications { get; }

--- a/mzLib/Omics/IBioPolymer.cs
+++ b/mzLib/Omics/IBioPolymer.cs
@@ -15,7 +15,9 @@ namespace Omics
         string Organism { get; }
         string Accession { get; }
         /// <summary>
-        /// The list of gene names consists of tuples, where Item1 is the type of gene name, and Item2 is the name. There may be many genes and names of a certain type produced when reading an XML protein database.
+        /// The list of gene names consists of tuples, where Item1 is the type of gene name, and Item2 is the nameof the specific molecule.
+        /// There may be many genes and names of a certain type produced when reading an XML protein database.
+        /// For RNA there may be a gene name and a specific transcript name due to splice variants.
         /// </summary>
         IEnumerable<Tuple<string, string>> GeneNames { get; }
         IDictionary<int, List<Modification>> OneBasedPossibleLocalizedModifications { get; }

--- a/mzLib/Omics/IBioPolymer.cs
+++ b/mzLib/Omics/IBioPolymer.cs
@@ -12,6 +12,7 @@ namespace Omics
     public interface IBioPolymer 
     {
         string Name { get; }
+        string FullName { get; }
         string BaseSequence { get; }
         int Length { get; }
         string DatabaseFilePath { get; }
@@ -19,6 +20,10 @@ namespace Omics
         bool IsContaminant { get; }
         string Organism { get; }
         string Accession { get; }
+        /// <summary>
+        /// The list of gene names consists of tuples, where Item1 is the type of gene name, and Item2 is the name. There may be many genes and names of a certain type produced when reading an XML protein database.
+        /// </summary>
+        IEnumerable<Tuple<string, string>> GeneNames { get; }
         IDictionary<int, List<Modification>> OneBasedPossibleLocalizedModifications { get; }
         char this[int zeroBasedIndex] => BaseSequence[zeroBasedIndex];
 

--- a/mzLib/Omics/IBioPolymer.cs
+++ b/mzLib/Omics/IBioPolymer.cs
@@ -1,10 +1,4 @@
-﻿using Chemistry;
-using MassSpectrometry;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Omics.Digestion;
+﻿using Omics.Digestion;
 using Omics.Modifications;
 
 namespace Omics

--- a/mzLib/Omics/IBioPolymerWithSetMods.cs
+++ b/mzLib/Omics/IBioPolymerWithSetMods.cs
@@ -23,6 +23,14 @@ namespace Omics
         int OneBasedStartResidue { get; }
         int OneBasedEndResidue { get; }
         int MissedCleavages { get; }
+        /// <summary>
+        /// Description of where the BioPolymerWithSetMods originated from examples include
+        /// Top-down truncation: full-length proteoform C-terminal digestion truncation
+        /// Top-down truncation: DECOY full-length proteoform N-terminal digestion truncation
+        /// Bottom-up search: full
+        /// Bottom-up search: DECOY full
+        /// Bottom-up search : chain(49-597) start
+        /// </summary>
         string Description { get; }
         CleavageSpecificity CleavageSpecificityForFdrCategory { get; set; }
         char PreviousResidue { get; }

--- a/mzLib/Omics/IBioPolymerWithSetMods.cs
+++ b/mzLib/Omics/IBioPolymerWithSetMods.cs
@@ -23,6 +23,7 @@ namespace Omics
         int OneBasedStartResidue { get; }
         int OneBasedEndResidue { get; }
         int MissedCleavages { get; }
+        string Description { get; }
         CleavageSpecificity CleavageSpecificityForFdrCategory { get; set; }
         char PreviousResidue { get; }
         char NextResidue { get; }
@@ -40,6 +41,8 @@ namespace Omics
 
         public void FragmentInternally(DissociationType dissociationType, int minLengthOfFragments,
             List<Product> products);
+
+        public IBioPolymerWithSetMods Localize(int j, double massToLocalize);
 
         public static string GetBaseSequenceFromFullSequence(string fullSequence)
         {

--- a/mzLib/Proteomics/ProteolyticDigestion/DigestionParams.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/DigestionParams.cs
@@ -107,14 +107,13 @@ namespace Proteomics.ProteolyticDigestion
 
         public IDigestionParams Clone()
         {
-            var clone = new DigestionParams(Protease.Name, MaxMissedCleavages, MinLength, MaxLength, MaxModificationIsoforms,
-                InitiatorMethionineBehavior, MaxMods, SearchModeType, FragmentationTerminus,
+            if (SearchModeType == CleavageSpecificity.None)
+                return new DigestionParams(SpecificProtease.Name, MaxMissedCleavages, MinLength, MaxLength,
+                    MaxModificationIsoforms, InitiatorMethionineBehavior, MaxMods, SearchModeType, FragmentationTerminus,
+                    GeneratehUnlabeledProteinsForSilac, KeepNGlycopeptide, KeepOGlycopeptide);
+            return new DigestionParams(Protease.Name, MaxMissedCleavages, MinLength, MaxLength,
+                MaxModificationIsoforms, InitiatorMethionineBehavior, MaxMods, SearchModeType, FragmentationTerminus,
                 GeneratehUnlabeledProteinsForSilac, KeepNGlycopeptide, KeepOGlycopeptide);
-            if (SpecificProtease != null)
-            {
-                clone.RecordSpecificProtease();
-            }
-            return clone;
         }
             
 

--- a/mzLib/Proteomics/ProteolyticDigestion/DigestionParams.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/DigestionParams.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Omics.Digestion;
+﻿using Omics.Digestion;
 using Omics.Fragmentation;
-using Proteomics.ProteolyticDigestion;
 
 namespace Proteomics.ProteolyticDigestion 
 {

--- a/mzLib/Proteomics/ProteolyticDigestion/DigestionParams.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/DigestionParams.cs
@@ -103,14 +103,15 @@ namespace Proteomics.ProteolyticDigestion
                    + GeneratehUnlabeledProteinsForSilac + "," + KeepNGlycopeptide + "," + KeepOGlycopeptide;
         }
 
-        public IDigestionParams Clone()
+        public IDigestionParams Clone(FragmentationTerminus? newTerminus = null)
         {
+            var terminus = newTerminus ?? FragmentationTerminus;
             if (SearchModeType == CleavageSpecificity.None)
                 return new DigestionParams(SpecificProtease.Name, MaxMissedCleavages, MinLength, MaxLength,
-                    MaxModificationIsoforms, InitiatorMethionineBehavior, MaxMods, SearchModeType, FragmentationTerminus,
+                    MaxModificationIsoforms, InitiatorMethionineBehavior, MaxMods, SearchModeType, terminus,
                     GeneratehUnlabeledProteinsForSilac, KeepNGlycopeptide, KeepOGlycopeptide);
             return new DigestionParams(Protease.Name, MaxMissedCleavages, MinLength, MaxLength,
-                MaxModificationIsoforms, InitiatorMethionineBehavior, MaxMods, SearchModeType, FragmentationTerminus,
+                MaxModificationIsoforms, InitiatorMethionineBehavior, MaxMods, SearchModeType, terminus,
                 GeneratehUnlabeledProteinsForSilac, KeepNGlycopeptide, KeepOGlycopeptide);
         }
             

--- a/mzLib/Proteomics/ProteolyticDigestion/DigestionParams.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/DigestionParams.cs
@@ -105,6 +105,19 @@ namespace Proteomics.ProteolyticDigestion
                    + GeneratehUnlabeledProteinsForSilac + "," + KeepNGlycopeptide + "," + KeepOGlycopeptide;
         }
 
+        public IDigestionParams Clone()
+        {
+            var clone = new DigestionParams(Protease.Name, MaxMissedCleavages, MinLength, MaxLength, MaxModificationIsoforms,
+                InitiatorMethionineBehavior, MaxMods, SearchModeType, FragmentationTerminus,
+                GeneratehUnlabeledProteinsForSilac, KeepNGlycopeptide, KeepOGlycopeptide);
+            if (SpecificProtease != null)
+            {
+                clone.RecordSpecificProtease();
+            }
+            return clone;
+        }
+            
+
         private void RecordSpecificProtease()
         {
             SpecificProtease = Protease;

--- a/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -613,7 +613,7 @@ namespace Proteomics.ProteolyticDigestion
             }
         }
 
-        public PeptideWithSetModifications Localize(int j, double massToLocalize)
+        public IBioPolymerWithSetMods Localize(int j, double massToLocalize)
         {
             var dictWithLocalizedMass = new Dictionary<int, Modification>(AllModsOneIsNterminus);
             double massOfExistingMod = 0;

--- a/mzLib/Test/Test.csproj
+++ b/mzLib/Test/Test.csproj
@@ -33,6 +33,7 @@
     <ProjectReference Include="..\Proteomics\Proteomics.csproj" />
     <ProjectReference Include="..\SpectralAveraging\SpectralAveraging.csproj" />
     <ProjectReference Include="..\Readers\Readers.csproj" />
+    <ProjectReference Include="..\Transcriptomics\Transcriptomics.csproj" />
     <ProjectReference Include="..\UsefulProteomicsDatabases\UsefulProteomicsDatabases.csproj" />
   </ItemGroup>
 
@@ -477,7 +478,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Transcriptomics\" />
     <Folder Include="TestData\" />
   </ItemGroup>
 

--- a/mzLib/Test/TestProteinDigestion.cs
+++ b/mzLib/Test/TestProteinDigestion.cs
@@ -470,5 +470,84 @@ namespace Test
             Assert.AreEqual(digestionParams.SpecificProtease, digestionParamsClone.SpecificProtease);
             Assert.That(!ReferenceEquals(digestionParams, digestionParamsClone));
         }
+
+
+
+        [Test]
+        public static void TestDigestionParamsCloneWithNewTerminus()
+        {
+            DigestionParams digestionParams = new DigestionParams(
+                protease: "top-down",
+                maxMissedCleavages: 0,
+                minPeptideLength: 1,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain,
+                keepNGlycopeptide: true,
+                keepOGlycopeptide: true);
+
+            DigestionParams digestionParamsClone = (DigestionParams)digestionParams.Clone(FragmentationTerminus.N);
+            Assert.AreNotEqual(digestionParams, digestionParamsClone);
+            Assert.AreEqual(digestionParams.InitiatorMethionineBehavior, digestionParamsClone.InitiatorMethionineBehavior);
+            Assert.AreEqual(digestionParams.MaxMissedCleavages, digestionParamsClone.MaxMissedCleavages);
+            Assert.AreEqual(digestionParams.MaxModificationIsoforms, digestionParamsClone.MaxModificationIsoforms);
+            Assert.AreEqual(digestionParams.MinLength, digestionParamsClone.MinLength);
+            Assert.AreEqual(digestionParams.MaxLength, digestionParamsClone.MaxLength);
+            Assert.AreEqual(digestionParams.MaxMods, digestionParamsClone.MaxMods);
+            Assert.AreEqual(digestionParams.Protease, digestionParamsClone.Protease);
+            Assert.AreEqual(digestionParams.SearchModeType, digestionParamsClone.SearchModeType);
+            Assert.AreEqual(FragmentationTerminus.N, digestionParamsClone.FragmentationTerminus);
+            Assert.AreEqual(digestionParams.GeneratehUnlabeledProteinsForSilac, digestionParamsClone.GeneratehUnlabeledProteinsForSilac);
+            Assert.AreEqual(digestionParams.KeepNGlycopeptide, digestionParamsClone.KeepNGlycopeptide);
+            Assert.AreEqual(digestionParams.KeepOGlycopeptide, digestionParamsClone.KeepOGlycopeptide);
+            Assert.AreEqual(digestionParams.SpecificProtease, digestionParamsClone.SpecificProtease);
+            Assert.That(!ReferenceEquals(digestionParams, digestionParamsClone));
+
+            digestionParams = new DigestionParams(
+                protease: "top-down",
+                maxMissedCleavages: 0,
+                minPeptideLength: 1,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain,
+                keepNGlycopeptide: true,
+                keepOGlycopeptide: true,
+                maxModificationIsoforms: 5,
+                maxModsForPeptides: 6,
+                maxPeptideLength: 7,
+                searchModeType: CleavageSpecificity.None,
+                fragmentationTerminus: FragmentationTerminus.None,
+                generateUnlabeledProteinsForSilac: false);
+
+            digestionParamsClone = (DigestionParams)digestionParams.Clone(FragmentationTerminus.N);
+            Assert.AreNotEqual(digestionParams, digestionParamsClone);
+            Assert.AreEqual(digestionParams.InitiatorMethionineBehavior, digestionParamsClone.InitiatorMethionineBehavior);
+            Assert.AreEqual(digestionParams.MaxMissedCleavages, digestionParamsClone.MaxMissedCleavages);
+            Assert.AreEqual(digestionParams.MaxModificationIsoforms, digestionParamsClone.MaxModificationIsoforms);
+            Assert.AreEqual(digestionParams.MinLength, digestionParamsClone.MinLength);
+            Assert.AreEqual(digestionParams.MaxLength, digestionParamsClone.MaxLength);
+            Assert.AreEqual(digestionParams.MaxMods, digestionParamsClone.MaxMods);
+            Assert.AreEqual(ProteaseDictionary.Dictionary["singleN"], digestionParamsClone.Protease);
+            Assert.AreEqual(digestionParams.SearchModeType, digestionParamsClone.SearchModeType);
+            Assert.AreEqual(FragmentationTerminus.N, digestionParamsClone.FragmentationTerminus);
+            Assert.AreEqual(digestionParams.GeneratehUnlabeledProteinsForSilac, digestionParamsClone.GeneratehUnlabeledProteinsForSilac);
+            Assert.AreEqual(digestionParams.KeepNGlycopeptide, digestionParamsClone.KeepNGlycopeptide);
+            Assert.AreEqual(digestionParams.KeepOGlycopeptide, digestionParamsClone.KeepOGlycopeptide);
+            Assert.AreEqual(digestionParams.SpecificProtease, digestionParamsClone.SpecificProtease);
+            Assert.That(!ReferenceEquals(digestionParams, digestionParamsClone));
+
+            digestionParamsClone = (DigestionParams)digestionParams.Clone(FragmentationTerminus.C);
+            Assert.AreNotEqual(digestionParams, digestionParamsClone);
+            Assert.AreEqual(digestionParams.InitiatorMethionineBehavior, digestionParamsClone.InitiatorMethionineBehavior);
+            Assert.AreEqual(digestionParams.MaxMissedCleavages, digestionParamsClone.MaxMissedCleavages);
+            Assert.AreEqual(digestionParams.MaxModificationIsoforms, digestionParamsClone.MaxModificationIsoforms);
+            Assert.AreEqual(digestionParams.MinLength, digestionParamsClone.MinLength);
+            Assert.AreEqual(digestionParams.MaxLength, digestionParamsClone.MaxLength);
+            Assert.AreEqual(digestionParams.MaxMods, digestionParamsClone.MaxMods);
+            Assert.AreEqual(ProteaseDictionary.Dictionary["singleC"], digestionParamsClone.Protease);
+            Assert.AreEqual(digestionParams.SearchModeType, digestionParamsClone.SearchModeType);
+            Assert.AreEqual(FragmentationTerminus.C, digestionParamsClone.FragmentationTerminus);
+            Assert.AreEqual(digestionParams.GeneratehUnlabeledProteinsForSilac, digestionParamsClone.GeneratehUnlabeledProteinsForSilac);
+            Assert.AreEqual(digestionParams.KeepNGlycopeptide, digestionParamsClone.KeepNGlycopeptide);
+            Assert.AreEqual(digestionParams.KeepOGlycopeptide, digestionParamsClone.KeepOGlycopeptide);
+            Assert.AreEqual(digestionParams.SpecificProtease, digestionParamsClone.SpecificProtease);
+            Assert.That(!ReferenceEquals(digestionParams, digestionParamsClone));
+        }
     }
 }

--- a/mzLib/Test/TestProteinDigestion.cs
+++ b/mzLib/Test/TestProteinDigestion.cs
@@ -14,6 +14,7 @@ using Omics.Modifications;
 using UsefulProteomicsDatabases;
 using static Chemistry.PeriodicTable;
 using Stopwatch = System.Diagnostics.Stopwatch;
+using OxyPlot.Wpf;
 
 namespace Test
 {
@@ -409,6 +410,66 @@ namespace Test
             var ye = prot.Digest(digestionParams, new List<Modification>(), variableModifications).ToList();
 
             Assert.AreEqual(2, ye.Count);
+        }
+
+        [Test]
+        public static void TestDigestionParamsClone()
+        {
+            DigestionParams digestionParams = new DigestionParams(
+                protease: "top-down",
+                maxMissedCleavages: 0,
+                minPeptideLength: 1,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain,
+                keepNGlycopeptide: true,
+                keepOGlycopeptide: true);
+
+            DigestionParams digestionParamsClone = (DigestionParams)digestionParams.Clone();
+            Assert.AreEqual(digestionParams, digestionParamsClone);
+            Assert.AreEqual(digestionParams.InitiatorMethionineBehavior, digestionParamsClone.InitiatorMethionineBehavior);
+            Assert.AreEqual(digestionParams.MaxMissedCleavages, digestionParamsClone.MaxMissedCleavages);
+            Assert.AreEqual(digestionParams.MaxModificationIsoforms, digestionParamsClone.MaxModificationIsoforms);
+            Assert.AreEqual(digestionParams.MinLength, digestionParamsClone.MinLength);
+            Assert.AreEqual(digestionParams.MaxLength, digestionParamsClone.MaxLength);
+            Assert.AreEqual(digestionParams.MaxMods, digestionParamsClone.MaxMods);
+            Assert.AreEqual(digestionParams.Protease, digestionParamsClone.Protease);
+            Assert.AreEqual(digestionParams.SearchModeType, digestionParamsClone.SearchModeType);
+            Assert.AreEqual(digestionParams.FragmentationTerminus, digestionParamsClone.FragmentationTerminus);
+            Assert.AreEqual(digestionParams.GeneratehUnlabeledProteinsForSilac, digestionParamsClone.GeneratehUnlabeledProteinsForSilac);
+            Assert.AreEqual(digestionParams.KeepNGlycopeptide, digestionParamsClone.KeepNGlycopeptide);
+            Assert.AreEqual(digestionParams.KeepOGlycopeptide, digestionParamsClone.KeepOGlycopeptide);
+            Assert.AreEqual(digestionParams.SpecificProtease, digestionParamsClone.SpecificProtease);
+            Assert.That(!ReferenceEquals(digestionParams, digestionParamsClone));
+
+            digestionParams = new DigestionParams(
+                protease: "top-down",
+                maxMissedCleavages: 0,
+                minPeptideLength: 1,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain,
+                keepNGlycopeptide: true,
+                keepOGlycopeptide: true,
+                maxModificationIsoforms: 5,
+                maxModsForPeptides: 6,
+                maxPeptideLength: 7,
+                searchModeType: CleavageSpecificity.None,
+                fragmentationTerminus: FragmentationTerminus.C,
+                generateUnlabeledProteinsForSilac: false);
+
+            digestionParamsClone = (DigestionParams)digestionParams.Clone();
+            Assert.AreEqual(digestionParams, digestionParamsClone);
+            Assert.AreEqual(digestionParams.InitiatorMethionineBehavior, digestionParamsClone.InitiatorMethionineBehavior);
+            Assert.AreEqual(digestionParams.MaxMissedCleavages, digestionParamsClone.MaxMissedCleavages);
+            Assert.AreEqual(digestionParams.MaxModificationIsoforms, digestionParamsClone.MaxModificationIsoforms);
+            Assert.AreEqual(digestionParams.MinLength, digestionParamsClone.MinLength);
+            Assert.AreEqual(digestionParams.MaxLength, digestionParamsClone.MaxLength);
+            Assert.AreEqual(digestionParams.MaxMods, digestionParamsClone.MaxMods);
+            Assert.AreEqual(digestionParams.Protease, digestionParamsClone.Protease);
+            Assert.AreEqual(digestionParams.SearchModeType, digestionParamsClone.SearchModeType);
+            Assert.AreEqual(digestionParams.FragmentationTerminus, digestionParamsClone.FragmentationTerminus);
+            Assert.AreEqual(digestionParams.GeneratehUnlabeledProteinsForSilac, digestionParamsClone.GeneratehUnlabeledProteinsForSilac);
+            Assert.AreEqual(digestionParams.KeepNGlycopeptide, digestionParamsClone.KeepNGlycopeptide);
+            Assert.AreEqual(digestionParams.KeepOGlycopeptide, digestionParamsClone.KeepOGlycopeptide);
+            Assert.AreEqual(digestionParams.SpecificProtease, digestionParamsClone.SpecificProtease);
+            Assert.That(!ReferenceEquals(digestionParams, digestionParamsClone));
         }
     }
 }

--- a/mzLib/Test/TestProteinDigestion.cs
+++ b/mzLib/Test/TestProteinDigestion.cs
@@ -14,7 +14,6 @@ using Omics.Modifications;
 using UsefulProteomicsDatabases;
 using static Chemistry.PeriodicTable;
 using Stopwatch = System.Diagnostics.Stopwatch;
-using OxyPlot.Wpf;
 
 namespace Test
 {

--- a/mzLib/Test/Transcriptomics/TestNucleotide.cs
+++ b/mzLib/Test/Transcriptomics/TestNucleotide.cs
@@ -1,0 +1,151 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Chemistry;
+using Transcriptomics;
+using UsefulProteomicsDatabases;
+
+namespace Test.Transcriptomics
+{
+    internal class TestNucleotide
+    {
+        internal record NucleotideTestCase(Nucleotide Nucleotide, string Name, char OneLetterCode, string Symbol, ChemicalFormula Formula, double Mass,
+            ChemicalFormula nucleosideFormula);
+
+        internal static IEnumerable<NucleotideTestCase> GetNucleotideTestCases()
+        {
+            Loaders.LoadElements();
+
+            yield return new NucleotideTestCase(Nucleotide.AdenineBase, "Adenine", 'A', "Ade",
+                ChemicalFormula.ParseFormula("C5H4N5"), 329.052523, ChemicalFormula.ParseFormula("C10H13N5O4"));
+            yield return new NucleotideTestCase(Nucleotide.CytosineBase, "Cytosine", 'C',
+                "Cyt", ChemicalFormula.ParseFormula("C4H4N3O1"), 305.041290, ChemicalFormula.ParseFormula("C9H13N3O5"));
+            yield return new NucleotideTestCase(Nucleotide.GuanineBase, "Guanine", 'G',
+                "Gua", ChemicalFormula.ParseFormula("C5H4N5O1"), 345.047438, ChemicalFormula.ParseFormula("C10H13N5O5"));
+            yield return new NucleotideTestCase(Nucleotide.UracilBase, "Uracil", 'U',
+                "Ura", ChemicalFormula.ParseFormula("C4H3N2O2"), 306.025306, ChemicalFormula.ParseFormula("C9H12N2O6"));
+            yield return new NucleotideTestCase(Nucleotide.DeoxyAdenineBase, "DeoxyAdenine", 'B',
+                "dAde", ChemicalFormula.ParseFormula("C5H4N5"), 313.057607, ChemicalFormula.ParseFormula("C10H13N5O3"));
+            yield return new NucleotideTestCase(Nucleotide.DeoxyCytosineBase, "DeoxyCytosine", 'D',
+                "dCyt", ChemicalFormula.ParseFormula("C4H4N3O1"), 289.046375, ChemicalFormula.ParseFormula("C9H13N3O4"));
+            yield return new NucleotideTestCase(Nucleotide.DeoxyGuanineBase, "DeoxyGuanine", 'H',
+                "dGua", ChemicalFormula.ParseFormula("C5H4N5O1"), 329.052523, ChemicalFormula.ParseFormula("C10H13N5O4"));
+            yield return new NucleotideTestCase(Nucleotide.DeoxyThymineBase, "DeoxyThymine", 'V',
+                "dThy", ChemicalFormula.ParseFormula("C5H5N2O2"), 304.046041, ChemicalFormula.ParseFormula("C10H14N2O5"));
+            yield return new NucleotideTestCase(Nucleotide.PseudoUracilBase, "PseudoUracil", 'Y',
+                "Psu", ChemicalFormula.ParseFormula("C4H3N2O2"), 306.025306, ChemicalFormula.ParseFormula("C9H12N2O6"));
+        }
+
+        [Test]
+        [TestCaseSource(nameof(GetNucleotideTestCases))]
+        public void TestCommonNucleotides(NucleotideTestCase testCase)
+        {
+            Nucleotide nucleotide = testCase.Nucleotide;
+
+            Assert.That(nucleotide.MonoisotopicMass, Is.EqualTo(testCase.Mass).Within(0.00001));
+            Assert.That(nucleotide.Letter, Is.EqualTo(testCase.OneLetterCode));
+            Assert.That(nucleotide.Symbol, Is.EqualTo(testCase.Symbol));
+            Assert.That(nucleotide.ToString(), Is.EqualTo($"{testCase.OneLetterCode} {testCase.Symbol} ({testCase.Name})"));
+            Assert.That(nucleotide.BaseChemicalFormula, Is.EqualTo(testCase.Formula));
+            Assert.That(nucleotide.NucleosideChemicalFormula, Is.EqualTo(testCase.nucleosideFormula));
+
+            Nucleotide newNucleotide =
+                new Nucleotide(testCase.Name, testCase.OneLetterCode, testCase.Symbol, testCase.Formula);
+            Assert.That(nucleotide.Equals(nucleotide));
+            Assert.That(!nucleotide.Equals(null));
+            Assert.That(nucleotide.Equals(newNucleotide));
+            Assert.That(nucleotide.Equals((object)newNucleotide));
+            Assert.That(!nucleotide.Equals((object)null));
+        }
+
+        [Test]
+        [TestCaseSource(nameof(GetNucleotideTestCases))]
+        public void TestGetResidue(NucleotideTestCase testCase)
+        {
+            Nucleotide nucleotide = testCase.Nucleotide;
+
+            var testNucleotide = Nucleotide.GetResidue(testCase.OneLetterCode);
+            Assert.That(nucleotide.Equals(testNucleotide));
+
+            if (Nucleotide.TryGetResidue(testCase.OneLetterCode, out Nucleotide outTide))
+            {
+                Assert.That(nucleotide.Equals(outTide));
+            }
+            else
+                Assert.Fail();
+
+            testNucleotide = Nucleotide.GetResidue(testCase.Symbol);
+            Assert.That(nucleotide.Equals(testNucleotide));
+            if (Nucleotide.TryGetResidue(testCase.Symbol, out outTide))
+            {
+                Assert.That(nucleotide.Equals(outTide));
+            }
+            else
+                Assert.Fail();
+        }
+
+        [Test]
+        public static void TestCustomResidue()
+        {
+            string name = "FakeNucleotide";
+            char oneLetter = 'F';
+            string symbol = "Fke";
+            string chemicalFormula = "C5H5N2O2";
+            var fakeNucleotide = new Nucleotide(name, oneLetter, symbol, ChemicalFormula.ParseFormula(chemicalFormula));
+
+            Nucleotide.AddResidue(name, oneLetter, symbol, chemicalFormula);
+
+            // test new nucleotide is within dictionary
+            if (Nucleotide.TryGetResidue('F', out Nucleotide outTide))
+            {
+                Assert.That(fakeNucleotide.Equals(outTide));
+            }
+            else
+                Assert.Fail();
+
+            if (Nucleotide.TryGetResidue("Fke", out outTide))
+            {
+                Assert.That(fakeNucleotide.Equals(outTide));
+            }
+            else
+                Assert.Fail();
+
+            // test false result in TryGetResidue
+            if (Nucleotide.TryGetResidue('P', out outTide))
+                Assert.Fail();
+
+            if (Nucleotide.TryGetResidue("Taco", out outTide))
+                Assert.Fail();
+        }
+
+        [Test]
+        public void TestEquality()
+        {
+            Assert.That(Nucleotide.TryGetResidue('A', out Nucleotide a));
+            Assert.That(Nucleotide.TryGetResidue("Ade", out Nucleotide a2));
+            Assert.That(Nucleotide.TryGetResidue("U", out Nucleotide u));
+            Assert.That(Nucleotide.TryGetResidue("Ura", out Nucleotide u2));
+
+            Assert.That(a.Equals(a));
+            Assert.That(a.Equals(a2));
+            Assert.That(a.GetHashCode(), Is.EqualTo(a2.GetHashCode()));
+            Assert.That(u.Equals(u2));
+            Assert.That(u.GetHashCode(), Is.EqualTo(u2.GetHashCode()));
+            Assert.That(!a.Equals(u2));
+            Assert.That(a.GetHashCode(), Is.Not.EqualTo(u.GetHashCode()));
+            Assert.That(!u.Equals(a2));
+            Assert.That(u.GetHashCode(), Is.Not.EqualTo(a.GetHashCode()));
+            Assert.That(!u.Equals(null));
+            Assert.That(a.Equals((object)a2));
+            Assert.That(a.Equals((object)a));
+            Assert.That(u.Equals((object)u2));
+            Assert.That(!a.Equals((object)u2));
+            Assert.That(!u.Equals((object)a2));
+            Assert.That(!u.Equals((object)null));
+            Assert.That(!u.Equals((object)new Action(() => { })));
+        }
+    }
+}

--- a/mzLib/Test/Transcriptomics/TestNucleotide.cs
+++ b/mzLib/Test/Transcriptomics/TestNucleotide.cs
@@ -2,9 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Chemistry;
 using Transcriptomics;
 using UsefulProteomicsDatabases;

--- a/mzLib/Test/Transcriptomics/TestNucleotide.cs
+++ b/mzLib/Test/Transcriptomics/TestNucleotide.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using UsefulProteomicsDatabases;
 
 namespace Test.Transcriptomics
 {
+    [ExcludeFromCodeCoverage]
     internal class TestNucleotide
     {
         internal record NucleotideTestCase(Nucleotide Nucleotide, string Name, char OneLetterCode, string Symbol, ChemicalFormula Formula, double Mass,

--- a/mzLib/Test/Transcriptomics/TestNucleotide.cs
+++ b/mzLib/Test/Transcriptomics/TestNucleotide.cs
@@ -84,6 +84,11 @@ namespace Test.Transcriptomics
             }
             else
                 Assert.Fail();
+
+            if (Nucleotide.TryGetResidue('&', out outTide))
+                Assert.Fail();
+            else
+                Assert.Pass();
         }
 
         [Test]

--- a/mzLib/Test/Transcriptomics/TestRnase.cs
+++ b/mzLib/Test/Transcriptomics/TestRnase.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -11,6 +12,7 @@ using Transcriptomics.Digestion;
 
 namespace Test.Transcriptomics
 {
+    [ExcludeFromCodeCoverage]
     internal class TestRnase
     {
         public static string rnaseTsvpath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"Digestion\rnases.tsv");

--- a/mzLib/Test/Transcriptomics/TestRnase.cs
+++ b/mzLib/Test/Transcriptomics/TestRnase.cs
@@ -4,9 +4,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
-using System.Threading.Tasks;
 using Proteomics.ProteolyticDigestion;
 using Transcriptomics.Digestion;
 

--- a/mzLib/Test/Transcriptomics/TestRnase.cs
+++ b/mzLib/Test/Transcriptomics/TestRnase.cs
@@ -1,0 +1,47 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Proteomics.ProteolyticDigestion;
+using Transcriptomics.Digestion;
+
+namespace Test.Transcriptomics
+{
+    internal class TestRnase
+    {
+        public static string rnaseTsvpath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"Digestion\rnases.tsv");
+
+        [Test]
+        public void TestRnaseDictionaryLoading()
+        {
+            var rnaseCountFromTsv = File.ReadAllLines(rnaseTsvpath).Length - 1;
+            Assert.AreEqual(RnaseDictionary.Dictionary.Count, rnaseCountFromTsv);
+        }
+
+        [Test]
+        public void TestRnaseEqualityProperties()
+        {
+            Rnase t1 = RnaseDictionary.Dictionary["RNase T1"];
+            Rnase t1Duplicate = RnaseDictionary.Dictionary["RNase T1"];
+            Rnase t2 = RnaseDictionary.Dictionary["RNase T2"];
+
+            Assert.That(t1.ToString(), Is.EqualTo("RNase T1"));
+            Assert.That(t1.Equals(t1Duplicate));
+            Assert.That(t1.Equals(t1));
+            Assert.That(!t1.Equals(t2));
+            Assert.That(!t1.Equals(null));
+            Assert.That(t1.GetHashCode(), Is.EqualTo(t1Duplicate.GetHashCode()));
+            Assert.That(t1.GetHashCode(), Is.Not.EqualTo(t2.GetHashCode()));
+            Assert.That(t1.Equals((object)t1Duplicate));
+            Assert.That(t1.Equals((object)t1));
+            Assert.That(!t1.Equals((object)t2));
+            Assert.That(!t1.Equals((object)null));
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            Assert.That(!t1.Equals((object)ProteaseDictionary.Dictionary["top-down"]));
+        }
+    }
+}

--- a/mzLib/Transcriptomics/Digestion/Rnase.cs
+++ b/mzLib/Transcriptomics/Digestion/Rnase.cs
@@ -1,0 +1,52 @@
+﻿using Chemistry;
+using Omics.Digestion;
+using Omics.Modifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Transcriptomics.Digestion
+{
+    public class Rnase : DigestionAgent, IEquatable<Rnase>
+    {
+        public Rnase(string name, CleavageSpecificity cleaveSpecificity, List<DigestionMotif> motifList, Modification cleavageMod = null) :
+            base(name, cleaveSpecificity, motifList, cleavageMod)
+        {
+            Name = name;
+            CleavageSpecificity = cleaveSpecificity;
+            DigestionMotifs = motifList;
+        }
+
+        // TODO: Coming soon to a mzLib near you
+        // public List<NucleolyticOligo> GetUnmodifiedOligos(NucleicAcid nucleicAcid, int maxMissedCleavages, int minLength, int maxLength)
+        // private IEnumerable<NucleolyticOligo> FullDigestion(NucleicAcid nucleicAcid, int maxMissedCleavages, int minLength, int maxLength)
+        
+        public bool Equals(Rnase? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Name == other.Name;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Rnase)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return Name;
+        }
+    }
+}

--- a/mzLib/Transcriptomics/Digestion/Rnase.cs
+++ b/mzLib/Transcriptomics/Digestion/Rnase.cs
@@ -1,12 +1,5 @@
-﻿using Chemistry;
-using Omics.Digestion;
+﻿using Omics.Digestion;
 using Omics.Modifications;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Linq;
 
 namespace Transcriptomics.Digestion
 {

--- a/mzLib/Transcriptomics/Digestion/RnaseDictionary.cs
+++ b/mzLib/Transcriptomics/Digestion/RnaseDictionary.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Easy.Common.Extensions;
+﻿using Easy.Common.Extensions;
 using MzLibUtil;
 using Omics.Digestion;
 

--- a/mzLib/Transcriptomics/Digestion/RnaseDictionary.cs
+++ b/mzLib/Transcriptomics/Digestion/RnaseDictionary.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Easy.Common.Extensions;
+using MzLibUtil;
+using Omics.Digestion;
+
+namespace Transcriptomics.Digestion
+{
+    public static class RnaseDictionary
+    {
+        static RnaseDictionary()
+        {
+            // TODO: Load dictionary automatically on first call to RnaseDictioanry
+
+
+            var pathToProgramFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+            string dataDirectory = !String.IsNullOrWhiteSpace(pathToProgramFiles) &&
+                                   AppDomain.CurrentDomain.BaseDirectory.Contains(pathToProgramFiles)
+                                   && !AppDomain.CurrentDomain.BaseDirectory.Contains("Jenkins")
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "MetaMorpheus")
+                : AppDomain.CurrentDomain.BaseDirectory;
+            string path = Path.Combine(dataDirectory, "Digestion", "rnases.tsv");
+            Dictionary = LoadRnaseDictionary(path);
+        }
+
+        public static Dictionary<string, Rnase> Dictionary { get; set; }
+
+
+        public static Dictionary<string, Rnase> LoadRnaseDictionary(string path)
+        {
+            Dictionary<string, Rnase> dict = new();
+            string[] myLines = File.ReadAllLines(path).Skip(1).ToArray();
+
+            foreach (var line in File.ReadAllLines(path).Skip(1))
+            {
+                if (line.Trim() != string.Empty)
+                {
+                    string[] fields = line.Split('\t');
+                    List<DigestionMotif> motifList = DigestionMotif.ParseDigestionMotifsFromString(fields[1]);
+                    string name = fields[0];
+                    CleavageSpecificity cleavage = Enum.Parse<CleavageSpecificity>(fields[4], true);
+
+                    var rnase = new Rnase(name, cleavage, motifList);
+                    if (!dict.ContainsKey(rnase.Name))
+                    {
+                        dict.Add(rnase.Name, rnase);
+                    }
+                    else
+                    {
+                        throw new MzLibException("More than one Rnase named {rnase.Name} exits");
+                    }
+                }
+            }
+
+            if (!Dictionary.IsNotNullOrEmpty())
+                Dictionary = dict;
+
+            return dict;
+        }
+    }
+}

--- a/mzLib/Transcriptomics/Interfaces/INucleicAcid.cs
+++ b/mzLib/Transcriptomics/Interfaces/INucleicAcid.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Chemistry;
-using MassSpectrometry;
+﻿using Chemistry;
 using Omics;
 using Omics.Modifications;
 

--- a/mzLib/Transcriptomics/Interfaces/INucleicAcid.cs
+++ b/mzLib/Transcriptomics/Interfaces/INucleicAcid.cs
@@ -12,6 +12,22 @@ namespace Transcriptomics
 {
     public interface INucleicAcid : IHasChemicalFormula, IBioPolymer
     {
+        /// <summary>
+        /// The amino acid sequence
+        /// </summary>
+        string BaseSequence { get; }
+
+        /// <summary>
+        /// The length of the amino acid sequence
+        /// </summary>
+        int Length { get; }
+
+        /// <summary>
+        /// Modifications 
+        /// </summary>
+        IDictionary<int, List<Modification>> OneBasedPossibleLocalizedModifications { get; }
+
+
         IHasChemicalFormula FivePrimeTerminus { get; set; }
 
         IHasChemicalFormula ThreePrimeTerminus { get; set; }

--- a/mzLib/Transcriptomics/Interfaces/INucleotide.cs
+++ b/mzLib/Transcriptomics/Interfaces/INucleotide.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Chemistry;
+﻿using Chemistry;
 
 namespace Transcriptomics
 {

--- a/mzLib/Transcriptomics/Nucleotide.cs
+++ b/mzLib/Transcriptomics/Nucleotide.cs
@@ -1,0 +1,250 @@
+﻿using Chemistry;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Transcriptomics
+{
+    /// <summary>
+    /// Class representing nucleotides
+    /// Static members are set of for common bases that are universal and instantiated in the static constructor
+    /// Novel bases can be created trough the AddResidue() method
+    ///
+    /// Future directions could further separate out the sugar and phosphate groups to account for modifications
+    /// </summary>
+    public class Nucleotide : INucleotide, IEquatable<Nucleotide>
+    {
+        #region Common Bases
+
+        // RNA
+        public static Nucleotide AdenineBase { get; private set; }
+        public static Nucleotide CytosineBase { get; private set; }
+        public static Nucleotide GuanineBase { get; private set; }
+        public static Nucleotide UracilBase { get; private set; }
+        public static Nucleotide PseudoUracilBase { get; private set; }
+
+        // DNA
+        public static Nucleotide DeoxyAdenineBase { get; private set; }
+        public static Nucleotide DeoxyCytosineBase { get; private set; }
+        public static Nucleotide DeoxyGuanineBase { get; private set; }
+        public static Nucleotide DeoxyThymineBase { get; private set; }
+
+        #endregion
+
+        #region Static Instantiation of Common Known Bases
+
+        /// <summary>
+        /// A dictionary of all known residues, can be searched via one letter, three letter, or the name of the residue
+        /// </summary>
+        internal static readonly Dictionary<string, Nucleotide> AllKnownResidues;
+
+        internal static readonly Nucleotide[] ResiduesByLetter;
+
+        /// <summary>
+        /// Constructs all known nucleic acids
+        /// </summary>
+        static Nucleotide()
+        {
+
+            AllKnownResidues = new Dictionary<string, Nucleotide>(66);
+            ResiduesByLetter = new Nucleotide['z' + 1]; //Make it big enough for all the Upper and Lower characters
+
+            // actual base chemical formula after bonding with the sugar
+            // the sugar and phosphate has a chemical formula of C5H8O6P1
+            AdenineBase = AddResidue("Adenine", 'A', "Ade", "C5H4N5");
+            CytosineBase = AddResidue("Cytosine", 'C', "Cyt", "C4H4N3O1");
+            GuanineBase = AddResidue("Guanine", 'G', "Gua", "C5H4N5O1");
+            UracilBase = AddResidue("Uracil", 'U', "Ura", "C4H3N2O2");
+            PseudoUracilBase = AddResidue("PseudoUracil", 'Y', "Psu", "C4H3N2O2"); // Y was choosen for pseudouridine due to it commonly being represented by Psi
+
+            // DNA bases which have the same mass as the ones above
+            // however, naming to deoxy- to distinguish DNA nucleotide mass calculation from RNA
+            DeoxyAdenineBase = AddResidue("DeoxyAdenine", 'B', "dAde", "C5H4N5");
+            DeoxyCytosineBase = AddResidue("DeoxyCytosine", 'D', "dCyt", "C4H4N3O1");
+            DeoxyGuanineBase = AddResidue("DeoxyGuanine", 'H', "dGua", "C5H4N5O1");
+            DeoxyThymineBase = AddResidue("DeoxyThymine", 'V', "dThy", "C5H5N2O2");
+        }
+
+        /// <summary>
+        /// Adds residue to static internal dictionary of all known residues
+        /// </summary>
+        /// <param name="residue"></param>
+        private static void AddResidueToDictionary(Nucleotide residue)
+        {
+            AllKnownResidues.Add(residue.Letter.ToString(CultureInfo.InvariantCulture), residue);
+            AllKnownResidues.Add(residue.Name, residue);
+            AllKnownResidues.Add(residue.Symbol, residue);
+            ResiduesByLetter[residue.Letter] = residue;
+            ResiduesByLetter[Char.ToLower(residue.Letter)] = residue;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Chemical formula of the sugar less OH 
+        /// </summary>
+        private ChemicalFormula _sugarAndPhosphate;
+
+        public string Name { get; private set; }
+        public double MonoisotopicMass { get; private set; }
+        public char Letter { get; private set; }
+        public string Symbol { get; private set; }
+
+        /// <summary>
+        /// Chemical formula of the base plus the sugar and phosphate less H20
+        /// </summary>
+        public ChemicalFormula ThisChemicalFormula { get; private set; }
+
+        /// <summary>
+        /// Chemical formula of the base less one H
+        /// </summary>
+        public ChemicalFormula BaseChemicalFormula { get; private set; }
+
+        /// <summary>
+        /// Chemical formula of the base plus the sugar
+        /// Used to calculate the mass of a modification from the modomics database
+        /// </summary>
+        public ChemicalFormula NucleosideChemicalFormula { get; private set; }
+
+        #endregion
+
+        #region Constructors
+
+        internal Nucleotide(string name, char oneLetterAbbreviation, string threeLetterAbbreviation, string baseChemicalFormula)
+            : this(name, oneLetterAbbreviation, threeLetterAbbreviation, ChemicalFormula.ParseFormula(baseChemicalFormula))
+        {
+        }
+
+        public Nucleotide(string name, char oneLetterAbbreviation, string threeLetterAbbreviation,
+            ChemicalFormula baseChemicalFormula)
+        {
+            Name = name;
+            Letter = oneLetterAbbreviation;
+            Symbol = threeLetterAbbreviation;
+            ThisChemicalFormula = new ChemicalFormula(baseChemicalFormula);
+            BaseChemicalFormula = baseChemicalFormula;
+
+            // calculation for monoisoptic mass of DNA and RNA
+            if (Name.Equals("DeoxyAdenine") || Name.Equals("DeoxyCytosine") || Name.Equals("DeoxyGuanine") || Name.Equals("DeoxyThymine"))
+            {
+                // DNA sugar phosphate backbone (one less oxygen than RNA)
+                _sugarAndPhosphate = ChemicalFormula.ParseFormula("C5H8O5P1");
+            }
+            else
+            {
+                // RNA sugar phosphate backbone
+                _sugarAndPhosphate = ChemicalFormula.ParseFormula("C5H8O6P1");
+            }
+
+            ThisChemicalFormula.Add(_sugarAndPhosphate);
+            MonoisotopicMass = ThisChemicalFormula.MonoisotopicMass;
+
+            // subtracting one phospho (H03P) and adding one water (H2O) to get the nucleoside formula
+            // must add water because base and sugar are already calculated assuming loss of H20 from polymerization reaction
+            NucleosideChemicalFormula = ThisChemicalFormula - ChemicalFormula.ParseFormula("H-1O2P1");
+        }
+
+        #endregion
+
+        #region Static Methods
+
+        /// <summary>
+        /// Adds residue to AllKnownResidues Dictionary
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="oneLetterAbbreviation"></param>
+        /// <param name="threeLetterAbbreviation"></param>
+        /// <param name="chemicalFormula"></param>
+        /// <returns></returns>
+        public static Nucleotide AddResidue(string name, char oneLetterAbbreviation, string threeLetterAbbreviation, string chemicalFormula)
+        {
+            var residue = new Nucleotide(name, oneLetterAbbreviation, threeLetterAbbreviation, chemicalFormula);
+            AddResidueToDictionary(residue);
+            return residue;
+        }
+
+        /// <summary>
+        /// Get the residue based on the residues' symbol
+        /// </summary>
+        /// <param name="symbol"></param>
+        /// <returns></returns>
+        public static Nucleotide GetResidue(string symbol)
+        {
+            return symbol.Length == 1 ? ResiduesByLetter[symbol[0]] : AllKnownResidues[symbol];
+        }
+
+        /// <summary>
+        /// Gets the residue based on the residue's one-character symbol
+        /// </summary>
+        /// <param name="letter"></param>
+        /// <returns></returns>
+        public static Nucleotide GetResidue(char letter)
+        {
+            return ResiduesByLetter[letter];
+        }
+
+        /// <summary>
+        /// Try to get the residue based upon the residue's one-character symbol
+        /// </summary>
+        /// <param name="letter"></param>
+        /// <param name="residue"></param>
+        /// <returns></returns>
+        public static bool TryGetResidue(char letter, out Nucleotide residue)
+        {
+            residue = null;
+            if (letter > 'z' || letter < 0)
+                return false;
+            residue = ResiduesByLetter[letter];
+            return residue != null;
+        }
+
+        /// <summary>
+        /// Try to get the residue based upon the residues' symbol
+        /// </summary>
+        /// <param name="symbol"></param>
+        /// <param name="residue"></param>
+        /// <returns></returns>
+        public static bool TryGetResidue(string symbol, out Nucleotide residue)
+        {
+            return AllKnownResidues.TryGetValue(symbol, out residue);
+        }
+
+        #endregion
+
+        #region Interface Implementations and Overrides
+
+        public override string ToString()
+        {
+            return $"{Letter} {Symbol} ({Name})";
+        }
+
+        public bool Equals(Nucleotide? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Name == other.Name && ThisChemicalFormula.Equals(other.ThisChemicalFormula)
+                                      && Letter == other.Letter
+                                      && Symbol == other.Symbol;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Nucleotide)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Name, ThisChemicalFormula, Letter, Symbol);
+        }
+
+        #endregion
+    }
+}

--- a/mzLib/Transcriptomics/Nucleotide.cs
+++ b/mzLib/Transcriptomics/Nucleotide.cs
@@ -1,10 +1,5 @@
 ﻿using Chemistry;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Transcriptomics
 {

--- a/mzLib/mzLib.nuspec
+++ b/mzLib/mzLib.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>mzLib</id>
-    <version>5.0.543</version>
+    <version>5.0.203</version>
     <title>mzLib</title>
     <authors>Stef S.</authors>
     <owners>Stef S.</owners>
@@ -13,25 +13,25 @@
     <tags>Chemistry Spectrometry</tags>
     <dependencies>
       <group targetFramework="net6.0">
-	<!--net6.0 target-->
-	<dependency id="Easy.Common" version="4.3.0"/>
-	<dependency id="MathNet.Numerics" version="5.0.0"/>
-	<dependency id="Microsoft.Win32.Registry" version="5.0.0"/>
-	<dependency id="NetSerializer" version="4.1.1"/>
-	<dependency id="OpenMcdf" version="2.2.1.3"/>
-	<dependency id="OpenMcdf.Extensions" version="2.2.1.3"/>
-	<dependency id="SharpLearning.Optimization" version="0.28.0"/>
+        <!--net6.0 target-->
+        <dependency id="Easy.Common" version="4.3.0" />
+        <dependency id="MathNet.Numerics" version="5.0.0" />
+        <dependency id="Microsoft.Win32.Registry" version="5.0.0" />
+        <dependency id="NetSerializer" version="4.1.1" />
+        <dependency id="OpenMcdf" version="2.2.1.3" />
+        <dependency id="OpenMcdf.Extensions" version="2.2.1.3" />
+        <dependency id="SharpLearning.Optimization" version="0.28.0" />
       </group>
       <group targetFramework="net6.0-windows7.0">
-	<!--net6.0-windows7.0 target with OxyPlot-->
-	<dependency id="Easy.Common" version="4.3.0"/>
-	<dependency id="MathNet.Numerics" version="5.0.0"/>
-	<dependency id="Microsoft.Win32.Registry" version="5.0.0"/>
-	<dependency id="NetSerializer" version="4.1.1"/>
-	<dependency id="OpenMcdf" version="2.2.1.3"/>
-	<dependency id="OpenMcdf.Extensions" version="2.2.1.3"/>
-	<dependency id="SharpLearning.Optimization" version="0.28.0"/>
-        <dependency id="OxyPlot.Wpf" version="2.0.0"/>
+        <!--net6.0-windows7.0 target with OxyPlot-->
+        <dependency id="Easy.Common" version="4.3.0" />
+        <dependency id="MathNet.Numerics" version="5.0.0" />
+        <dependency id="Microsoft.Win32.Registry" version="5.0.0" />
+        <dependency id="NetSerializer" version="4.1.1" />
+        <dependency id="OpenMcdf" version="2.2.1.3" />
+        <dependency id="OpenMcdf.Extensions" version="2.2.1.3" />
+        <dependency id="SharpLearning.Optimization" version="0.28.0" />
+        <dependency id="OxyPlot.Wpf" version="2.0.0" />
       </group>
     </dependencies>
   </metadata>
@@ -41,25 +41,25 @@
     <file src="BayesianEstimation\bin\x64\Release\net6.0\BayesianEstimation.dll" target="lib\net6.0" />
     <file src="Chemistry\bin\x64\Release\net6.0\Chemistry.dll" target="lib\net6.0" />
     <file src="FlashLFQ\bin\x64\Release\net6.0\FlashLFQ.dll" target="lib\net6.0" />
-    <file src="MassSpectrometry\bin\x64\Release\net6.0\MassSpectrometry.dll" target="lib\net6.0" />	
+    <file src="MassSpectrometry\bin\x64\Release\net6.0\MassSpectrometry.dll" target="lib\net6.0" />
     <file src="MzIdentML\bin\x64\Release\net6.0\MzIdentML.dll" target="lib\net6.0" />
-    <file src="SpectralAveraging\bin\x64\Release\net6.0\SpectralAveraging.dll" target="lib\net6.0" /> 
+    <file src="SpectralAveraging\bin\x64\Release\net6.0\SpectralAveraging.dll" target="lib\net6.0" />
     <file src="MzLibUtil\bin\x64\Release\net6.0\MzLibUtil.dll" target="lib\net6.0" />
-    <file src="Omics\bin\x64\Release\net6.0\Omics.dll" target="lib\net6.0" /> 
-    <file src="PepXML\bin\x64\Release\net6.0\PepXML.dll" target="lib\net6.0" /> 
-    <file src="Proteomics\bin\x64\Release\net6.0\Proteomics.dll" target="lib\net6.0" /> 
-    <file src="Proteomics\bin\x64\Release\net6.0\ProteolyticDigestion\proteases.tsv" target="lib\net6.0\ProteolyticDigestion" /> 
-    <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UniProtKB_columnNamesForProgrammaticAccess.txt" target="lib\net6.0" /> 
-    <file src="Readers\bin\x64\Release\net6.0\Readers.dll" target="lib\net6.0" /> 
-    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.BackgroundSubtraction.dll" target="lib\net6.0" /> 
-    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.Data.dll" target="lib\net6.0" /> 
-    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.MassPrecisionEstimator.dll" target="lib\net6.0" /> 
-    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.RawFileReader.dll" target="lib\net6.0" /> 
-    <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UsefulProteomicsDatabases.dll" target="lib\net6.0" /> 
-    <file src="Transcriptomics\bin\x64\Release\net6.0\Transcriptomics.dll" target="lib\net6.0" /> 
-    <file src="Transcriptomics\bin\x64\Release\net6.0\Digestion\rnases.tsv" target="lib\net6.0" /> 
+    <file src="Omics\bin\x64\Release\net6.0\Omics.dll" target="lib\net6.0" />
+    <file src="PepXML\bin\x64\Release\net6.0\PepXML.dll" target="lib\net6.0" />
+    <file src="Proteomics\bin\x64\Release\net6.0\Proteomics.dll" target="lib\net6.0" />
+    <file src="Proteomics\bin\x64\Release\net6.0\ProteolyticDigestion\proteases.tsv" target="lib\net6.0\ProteolyticDigestion" />
+    <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UniProtKB_columnNamesForProgrammaticAccess.txt" target="lib\net6.0" />
+    <file src="Readers\bin\x64\Release\net6.0\Readers.dll" target="lib\net6.0" />
+    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.BackgroundSubtraction.dll" target="lib\net6.0" />
+    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.Data.dll" target="lib\net6.0" />
+    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.MassPrecisionEstimator.dll" target="lib\net6.0" />
+    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.RawFileReader.dll" target="lib\net6.0" />
+    <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UsefulProteomicsDatabases.dll" target="lib\net6.0" />
+    <file src="Transcriptomics\bin\x64\Release\net6.0\Transcriptomics.dll" target="lib\net6.0" />
+    <file src="Transcriptomics\bin\x64\Release\net6.0\Digestion\rnases.tsv" target="lib\net6.0" />
     <!--net6.0-windows target with mzPlot-->
-    <file src="mzPlot\bin\x64\Release\net6.0-windows\mzPlot.dll" target="lib\net6.0-windows7.0" /> 
+    <file src="mzPlot\bin\x64\Release\net6.0-windows\mzPlot.dll" target="lib\net6.0-windows7.0" />
     <file src="BayesianEstimation\bin\x64\Release\net6.0\BayesianEstimation.dll" target="lib\net6.0-windows7.0" />
     <file src="Chemistry\bin\x64\Release\net6.0\Chemistry.dll" target="lib\net6.0-windows7.0" />
     <file src="FlashLFQ\bin\x64\Release\net6.0\FlashLFQ.dll" target="lib\net6.0-windows7.0" />
@@ -67,18 +67,18 @@
     <file src="MzIdentML\bin\x64\Release\net6.0\MzIdentML.dll" target="lib\net6.0-windows7.0" />
     <file src="SpectralAveraging\bin\x64\Release\net6.0\SpectralAveraging.dll" target="lib\net6.0-windows7.0" />
     <file src="MzLibUtil\bin\x64\Release\net6.0\MzLibUtil.dll" target="lib\net6.0-windows7.0" />
-    <file src="Omics\bin\x64\Release\net6.0\Omics.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="PepXML\bin\x64\Release\net6.0\PepXML.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="Proteomics\bin\x64\Release\net6.0\Proteomics.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="Proteomics\bin\x64\Release\net6.0\ProteolyticDigestion\proteases.tsv" target="lib\net6.0-windows7.0\ProteolyticDigestion" /> 
+    <file src="Omics\bin\x64\Release\net6.0\Omics.dll" target="lib\net6.0-windows7.0" />
+    <file src="PepXML\bin\x64\Release\net6.0\PepXML.dll" target="lib\net6.0-windows7.0" />
+    <file src="Proteomics\bin\x64\Release\net6.0\Proteomics.dll" target="lib\net6.0-windows7.0" />
+    <file src="Proteomics\bin\x64\Release\net6.0\ProteolyticDigestion\proteases.tsv" target="lib\net6.0-windows7.0\ProteolyticDigestion" />
     <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UniProtKB_columnNamesForProgrammaticAccess.txt" target="lib\net6.0-windows7.0" />
-    <file src="Readers\bin\x64\Release\net6.0\Readers.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.BackgroundSubtraction.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.Data.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.MassPrecisionEstimator.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.RawFileReader.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UsefulProteomicsDatabases.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="Transcriptomics\bin\x64\Release\net6.0\Transcriptomics.dll" target="lib\net6.0-windows7.0" /> 
-    <file src="Transcriptomics\bin\x64\Release\net6.0\Digestion\rnases.tsv" target="lib\net6.0-windows7.0" /> 
+    <file src="Readers\bin\x64\Release\net6.0\Readers.dll" target="lib\net6.0-windows7.0" />
+    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.BackgroundSubtraction.dll" target="lib\net6.0-windows7.0" />
+    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.Data.dll" target="lib\net6.0-windows7.0" />
+    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.MassPrecisionEstimator.dll" target="lib\net6.0-windows7.0" />
+    <file src="Readers\bin\x64\Release\net6.0\Thermo\ThermoFisher.CommonCore.RawFileReader.dll" target="lib\net6.0-windows7.0" />
+    <file src="UsefulProteomicsDatabases\bin\x64\Release\net6.0\UsefulProteomicsDatabases.dll" target="lib\net6.0-windows7.0" />
+    <file src="Transcriptomics\bin\x64\Release\net6.0\Transcriptomics.dll" target="lib\net6.0-windows7.0" />
+    <file src="Transcriptomics\bin\x64\Release\net6.0\Digestion\rnases.tsv" target="lib\net6.0-windows7.0" />
   </files>
 </package>


### PR DESCRIPTION
Adjusted interfaces to allow for abstraction of the SpectralMatchClass in MetaMorpheus

Added Clone method to DigestionParams
  There are many many times in MetaMorpheus where we need to copy digestion parameters to file specific parameters and they are done manually each time. Once incorporated, will allow all cloning to take place in one location

Added Nucleotide class that is modeled off of the Residue Class

Added Rnase without digestion functionality. 
This will make subsequent PR's with digestion easier