### PR TITLE
Changed Deconvoluter to have a static call

### DIFF
--- a/mzLib/Development/Deconvolution/StandardDeconvolutionTest.cs
+++ b/mzLib/Development/Deconvolution/StandardDeconvolutionTest.cs
@@ -46,85 +46,83 @@ namespace Development.Deconvolution
                 "Averaged_221110_CytoOnly.mzML");
 
             // set up deconvoluters to be utilized by test cases
-            Deconvoluter classicTopDownDeconvoluter = new Deconvoluter(DeconvolutionType.ClassicDeconvolution,
-                new ClassicDeconvolutionParameters(1, 60, 4, 3));
-            Deconvoluter classicBottomUpDeconvoluter = new Deconvoluter(DeconvolutionType.ClassicDeconvolution,
-                new ClassicDeconvolutionParameters(1, 12, 4, 3));
+            DeconvolutionParameters classicTopDownDeconvolutionParams = new ClassicDeconvolutionParameters(1, 60, 4, 3);
+            DeconvolutionParameters classicBottomUpDeconvolutionParams = new ClassicDeconvolutionParameters(1, 12, 4, 3);
 
             // Add Individual peak test cases
             List<SinglePeakDeconvolutionTestCase> singlePeakDeconvolutionTestCases = new()
             {
                 // uniquitin, direct injection
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection PolyUbiquitin, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection PolyUbiquitin, Averaged",
                     ubiquitinPath, 1, 10038.4, 8, 1254.8, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection PolyUbiquitin, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection PolyUbiquitin, Averaged",
                     ubiquitinPath, 1, 10039.41, 9, 1115.49, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection PolyUbiquitin, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection PolyUbiquitin, Averaged",
                     ubiquitinPath, 1, 10041.4, 10, 1004.14, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection PolyUbiquitin, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection PolyUbiquitin, Averaged",
                     ubiquitinPath, 1, 10041.46, 11, 912.86, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection PolyUbiquitin, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection PolyUbiquitin, Averaged",
                     ubiquitinPath, 1, 10043.4, 12, 836.95, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection PolyUbiquitin, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection PolyUbiquitin, Averaged",
                     ubiquitinPath, 1, 10043.41, 13, 772.57, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection PolyUbiquitin, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection PolyUbiquitin, Averaged",
                     ubiquitinPath, 1, 10044.44, 14, 717.46, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection PolyUbiquitin, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection PolyUbiquitin, Averaged",
                     ubiquitinPath, 1, 10045.5, 15, 669.70, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection PolyUbiquitin, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection PolyUbiquitin, Averaged",
                     ubiquitinPath, 1, 10045.44, 16, 627.84, 20),
 
                 // hgh, direct injection
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter,
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams,
                     "Direct Injection Human Growth Hormone, Averaged",
                     hghPath, 1, 22139.41, 11, 2012.29, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter,
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams,
                     "Direct Injection Human Growth Hormone, Averaged",
                     hghPath, 1, 22136.28, 12, 1844.69, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter,
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams,
                     "Direct Injection Human Growth Hormone, Averaged",
                     hghPath, 1, 22137.31, 13, 1702.87, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter,
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams,
                     "Direct Injection Human Growth Hormone, Averaged",
                     hghPath, 1, 22139.32, 14, 1581.38, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter,
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams,
                     "Direct Injection Human Growth Hormone, Averaged",
                     hghPath, 1, 22139.25, 15, 1475.95, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter,
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams,
                     "Direct Injectio Human Growth Hormone, Averaged",
                     hghPath, 1, 22140.32, 16, 1383.77, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter,
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams,
                     "Direct Injection Human Growth Hormone, Averaged",
                     hghPath, 1, 22141.31, 17, 1302.43, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter,
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams,
                     "Direct Injection Human Growth Hormone, Averaged",
                     hghPath, 1, 22142.34, 18, 1230.13, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter,
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams,
                     "Direct Injection Human Growth Hormone, Averaged",
                     hghPath, 1, 22143.36, 19, 1165.44, 20),
 
                 // cytochrome c, direct injection 
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection Cytochrome C, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection Cytochrome C, Averaged",
                     cytoPath, 1, 12367.44, 9, 1374.16, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection Cytochrome C, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection Cytochrome C, Averaged",
                     cytoPath, 1, 12367.4, 10, 1236.74, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection Cytochrome C, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection Cytochrome C, Averaged",
                     cytoPath, 1, 12368.4, 11, 1124.40, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection Cytochrome C, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection Cytochrome C, Averaged",
                     cytoPath, 1, 12370.44, 12, 1030.87, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection Cytochrome C, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection Cytochrome C, Averaged",
                     cytoPath, 1, 12371.45, 13, 951.65, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection Cytochrome C, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection Cytochrome C, Averaged",
                     cytoPath, 1, 12373.48, 14, 883.82, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection Cytochrome C, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection Cytochrome C, Averaged",
                     cytoPath, 1, 12373.5, 15, 824.90, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection Cytochrome C, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection Cytochrome C, Averaged",
                     cytoPath, 1, 12374.56, 16, 773.41, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection Cytochrome C, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection Cytochrome C, Averaged",
                     cytoPath, 1, 12374.47, 17, 727.91, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection Cytochrome C, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection Cytochrome C, Averaged",
                     cytoPath, 1, 12376.44, 18, 687.58, 20),
-                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection Cytochrome C, Averaged",
+                new SinglePeakDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection Cytochrome C, Averaged",
                     cytoPath, 1, 12360.6, 20, 619.03, 20)
             };
             _singlePeakTestCases = singlePeakDeconvolutionTestCases;
@@ -132,19 +130,19 @@ namespace Development.Deconvolution
             // Add whole spectrum test cases
             List<WholeSpectrumDeconvolutionTestCase> wholeSpectrumDeconvolutionTestCases = new()
             {
-                new WholeSpectrumDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection PolyUbiquitin, Averaged",
+                new WholeSpectrumDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection PolyUbiquitin, Averaged",
                     ubiquitinPath, 1, 20,
                     new[] { 10038.4, 10039.41, 10041.4, 10041.46, 10043.4, 10043.41, 10044.44, 10045.5, 10045.44, },
                     new[] { 8, 9, 10, 11, 12, 13, 14, 15, 16 },
                     new[] { 1254.8, 1115.49, 1004.14, 912.86, 836.95, 772.57, 717.46, 669.70, 627.84 }),
 
-                new WholeSpectrumDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection Human Growth Hormone, Averaged",
+                new WholeSpectrumDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection Human Growth Hormone, Averaged",
                     hghPath, 1, 20,
                     new []{22139.41, 22136.28, 22137.31, 22139.32, 22139.25, 22140.32, 22141.31, 22142.34, 22143.36},
                     new []{11, 12, 13, 14, 15, 16, 17, 18, 19},
                     new []{2012.29, 1844.69, 1702.87, 1581.38, 1475.95, 1383.77, 1302.43, 1230.13, 1165.44}),
 
-                new WholeSpectrumDeconvolutionTestCase(classicTopDownDeconvoluter, "Direct Injection Cytochrome C, Averaged",
+                new WholeSpectrumDeconvolutionTestCase(classicTopDownDeconvolutionParams, "Direct Injection Cytochrome C, Averaged",
                     cytoPath, 1, 20,
                     new []{12367.44, 12367.4, 12368.4, 12370.44, 12371.45, 12373.48, 12373.5, 12374.56, 12374.47, 12376.44, 12360.6},
                     new []{9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20},
@@ -164,8 +162,8 @@ namespace Development.Deconvolution
         public static void SinglePeak_TopScoringResult_IsCorrectWithinTolerance(SinglePeakDeconvolutionTestCase testCase)
         {
             // deconvolution
-            List<IsotopicEnvelope> allResults = testCase.Deconvoluter
-                .Deconvolute(testCase.SpectrumToDeconvolute, testCase.RangeToDeconvolute).ToList();
+            List<IsotopicEnvelope> allResults = Deconvoluter
+                .Deconvolute(testCase.SpectrumToDeconvolute, testCase.DeconvolutionParameters, testCase.RangeToDeconvolute).ToList();
 
             // get top scoring result
             var topScoringResult = allResults.First();
@@ -196,8 +194,8 @@ namespace Development.Deconvolution
         public static void SinglePeak_AnyResult_IsCorrectWithinTolerance(SinglePeakDeconvolutionTestCase testCase)
         {
             // deconvolution
-            List<IsotopicEnvelope> allResults = testCase.Deconvoluter
-                .Deconvolute(testCase.SpectrumToDeconvolute, testCase.RangeToDeconvolute).ToList();
+            List<IsotopicEnvelope> allResults = Deconvoluter
+                .Deconvolute(testCase.SpectrumToDeconvolute, testCase.DeconvolutionParameters, testCase.RangeToDeconvolute).ToList();
 
             // extract tested properties from IsotopicEnvelopeResults
             var resultChargeStates = allResults.Select(p => p.Charge);
@@ -231,8 +229,8 @@ namespace Development.Deconvolution
         public static void WholeSpectrum_ResultContainsAllExpected(WholeSpectrumDeconvolutionTestCase testCase)
         {
             // deconvolution
-            List<IsotopicEnvelope> allResults = testCase.Deconvoluter
-                .Deconvolute(testCase.SpectrumToDeconvolute).ToList();
+            List<IsotopicEnvelope> allResults = Deconvoluter
+                .Deconvolute(testCase.SpectrumToDeconvolute, testCase.DeconvolutionParameters).ToList();
 
             // extract tested properties from IsotopicEnvelopeResults
             var resultChargeStates = allResults.Select(p => p.Charge);

--- a/mzLib/Development/Deconvolution/TestCases/SinglePeakDeconvolutionTestCase.cs
+++ b/mzLib/Development/Deconvolution/TestCases/SinglePeakDeconvolutionTestCase.cs
@@ -20,10 +20,10 @@ namespace Development.Deconvolution
         /// <param name="expectedIonChargeState">Expected charge state from deconvolution result</param>
         /// <param name="selectedIonMz">M/z of peak to deconvolute from spectrum</param>
         /// <param name="precursorPpmMassTolerance">Tolerance which deconvolution results must match expected value</param>
-        public SinglePeakDeconvolutionTestCase(Deconvoluter deconvoluter, string sampleInformation, string spectrumPath, int scanNumber,
+        public SinglePeakDeconvolutionTestCase(DeconvolutionParameters deconParameters, string sampleInformation, string spectrumPath, int scanNumber,
             double expectedMostAbundantObservedIsotopicMass, int expectedIonChargeState, double selectedIonMz, double precursorPpmMassTolerance)
         {
-            Deconvoluter = deconvoluter;
+            
             SampleInformation = sampleInformation;
             ExpectedMostAbundantObservedIsotopicMass = expectedMostAbundantObservedIsotopicMass;
             ExpectedIonChargeState = expectedIonChargeState;
@@ -41,7 +41,7 @@ namespace Development.Deconvolution
         /// <summary>
         /// The object which will be performing the deconvolution when tested
         /// </summary>
-        public Deconvoluter Deconvoluter { get; set; }
+        public DeconvolutionParameters DeconvolutionParameters { get; set; }
 
         /// <summary>
         /// Quick information relevant to the sample, will be visible on test failing
@@ -82,7 +82,7 @@ namespace Development.Deconvolution
 
         public override string ToString()
         {
-            return $"{Deconvoluter.DeconvolutionType}: {SampleInformation} Charge: {ExpectedIonChargeState}";
+            return $"{DeconvolutionParameters.DeconvolutionType}: {SampleInformation} Charge: {ExpectedIonChargeState}";
         }
     }
 }

--- a/mzLib/Development/Deconvolution/TestCases/TestDevelopmentTestCases.cs
+++ b/mzLib/Development/Deconvolution/TestCases/TestDevelopmentTestCases.cs
@@ -15,8 +15,7 @@ namespace Development.Deconvolution
         [Test]
         public static void TestSinglePeakDeconvolutionTestCase()
         {
-            Deconvoluter classicTopDownDeconvoluter = new Deconvoluter(DeconvolutionType.ClassicDeconvolution,
-                new ClassicDeconvolutionParameters(1, 60, 4, 3));
+            DeconvolutionParameters classicTopDownDeconvoluter = new ClassicDeconvolutionParameters(1, 60, 4, 3);
             const string sampleInformation = "Direct Injection Cytochrome C, Averaged";
             var pathToDataFile = Path.Combine(TestContext.CurrentContext.TestDirectory, "Deconvolution", "TestData",
                 "Averaged_221110_CytoOnly.mzML");
@@ -51,8 +50,7 @@ namespace Development.Deconvolution
         [Test]
         public static void TestWholeSpectrumDeconvolutionTestCase()
         {
-            Deconvoluter classicTopDownDeconvoluter = new Deconvoluter(DeconvolutionType.ClassicDeconvolution,
-                new ClassicDeconvolutionParameters(1, 60, 4, 3));
+            DeconvolutionParameters classicTopDownDeconvoluter = new ClassicDeconvolutionParameters(1, 60, 4, 3);
             const string sampleInformation = "Direct Injection Cytochrome C, Averaged";
             var pathToDataFile = Path.Combine(TestContext.CurrentContext.TestDirectory, "Deconvolution", "TestData",
                 "Averaged_221110_CytoOnly.mzML");

--- a/mzLib/Development/Deconvolution/TestCases/WholeSpectrumDeconvolutionTestCase.cs
+++ b/mzLib/Development/Deconvolution/TestCases/WholeSpectrumDeconvolutionTestCase.cs
@@ -20,13 +20,13 @@ namespace Development.Deconvolution
         /// <param name="expectedMostAbundantObservedIsotopicMasses">Expected masses from deconvolution result</param>
         /// <param name="expectedIonChargeStates">Expected charge states from deconvolution result</param>
         /// <param name="selectedIonMzs">M/z of peaks to deconvolute from spectrum</param>
-        public WholeSpectrumDeconvolutionTestCase(Deconvoluter deconvoluter, string sampleInformation, string spectrumPath, int scanNumber,
+        public WholeSpectrumDeconvolutionTestCase(DeconvolutionParameters deconvolutionParameters, string sampleInformation, string spectrumPath, int scanNumber,
             double precursorPpmMassTolerance, double[] expectedMostAbundantObservedIsotopicMasses, int[] expectedIonChargeStates, double[] selectedIonMzs)
         {
             if (!new[] { expectedMostAbundantObservedIsotopicMasses.Length, expectedIonChargeStates.Length, selectedIonMzs.Length }.AllSame())
                 throw new MzLibException("Must have same number of masses, charges, and mzs");
 
-            Deconvoluter = deconvoluter;
+            DeconvolutionParameters = deconvolutionParameters;
             SampleInformation = sampleInformation;
             ExpectedMostAbundantObservedIsotopicMasses = expectedMostAbundantObservedIsotopicMasses;
             ExpectedIonChargeStates = expectedIonChargeStates;
@@ -42,7 +42,7 @@ namespace Development.Deconvolution
         /// <summary>
         /// The object which will be performing the deconvolution when tested
         /// </summary>
-        public Deconvoluter Deconvoluter { get; set; }
+        public DeconvolutionParameters DeconvolutionParameters { get; set; }
 
         /// <summary>
         /// Quick information relevant to the sample, will be visible on test failing
@@ -82,7 +82,7 @@ namespace Development.Deconvolution
 
         public override string ToString()
         {
-            return $"{Deconvoluter.DeconvolutionType}: {SampleInformation}";
+            return $"{DeconvolutionParameters.DeconvolutionType}: {SampleInformation}";
         }
     }
 }

--- a/mzLib/MassSpectrometry/Deconvolution/DeconvoluterExtensions.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/DeconvoluterExtensions.cs
@@ -13,19 +13,19 @@ namespace MassSpectrometry
     /// </summary>
     public static class DeconvoluterExtensions
     {
-        /// <summary>
-        /// Deconvolutes a MzSpectrum object
-        /// </summary>
-        /// <param name="deconvoluter">performs deconvolution</param>
-        /// <param name="spectrum">spectrum to deconvolute</param>
-        /// <param name="range">mz range of returned peaks, if null will deconvolute entire spectrum</param>
-        /// <returns></returns>
-        /// <exception cref="MzLibException"></exception>
-        public static IEnumerable<IsotopicEnvelope> Deconvolute(this Deconvoluter deconvoluter,
-            MzSpectrum spectrum, MzRange range = null)
-        {
-            range ??= spectrum.Range;
-            return deconvoluter.DeconvolutionAlgorithm.Deconvolute(spectrum, range);
-        }
+        ///// <summary>
+        ///// Deconvolutes a MzSpectrum object
+        ///// </summary>
+        ///// <param name="deconvoluter">performs deconvolution</param>
+        ///// <param name="spectrum">spectrum to deconvolute</param>
+        ///// <param name="range">mz range of returned peaks, if null will deconvolute entire spectrum</param>
+        ///// <returns></returns>
+        ///// <exception cref="MzLibException"></exception>
+        //public static IEnumerable<IsotopicEnvelope> Deconvolute(this Deconvoluter deconvoluter,
+        //    MzSpectrum spectrum, MzRange range = null)
+        //{
+        //    range ??= spectrum.Range;
+        //    return deconvoluter.DeconvolutionAlgorithm.Deconvolute(spectrum, range);
+        //}
     }
 }

--- a/mzLib/MassSpectrometry/Deconvolution/Parameters/ClassicDeconvolutionParameters.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Parameters/ClassicDeconvolutionParameters.cs
@@ -12,6 +12,7 @@ namespace MassSpectrometry
     /// </summary>
     public class ClassicDeconvolutionParameters : DeconvolutionParameters
     {
+        public override DeconvolutionType DeconvolutionType => DeconvolutionType.ClassicDeconvolution;
         public double DeconvolutionTolerancePpm { get; set; }
         public double IntensityRatioLimit { get; set; }
 

--- a/mzLib/MassSpectrometry/Deconvolution/Parameters/DeconvolutionParameters.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Parameters/DeconvolutionParameters.cs
@@ -12,6 +12,7 @@ namespace MassSpectrometry
     /// </summary>
     public abstract class DeconvolutionParameters
     {
+        public abstract DeconvolutionType DeconvolutionType { get; }
         public int MinAssumedChargeState { get; set; }
         public int MaxAssumedChargeState { get; set; }
         public Polarity Polarity { get; set; }

--- a/mzLib/MassSpectrometry/Deconvolution/Parameters/ExampleNewDeconvolutionParametersTemplate.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Parameters/ExampleNewDeconvolutionParametersTemplate.cs
@@ -10,6 +10,7 @@ namespace MassSpectrometry
     [ExcludeFromCodeCoverage]
     public class ExampleNewDeconvolutionParametersTemplate : DeconvolutionParameters
     {
+        public override DeconvolutionType DeconvolutionType => DeconvolutionType.ExampleNewDeconvolutionTemplate;
         public ExampleNewDeconvolutionParametersTemplate(int minCharge, int maxCharge, Polarity polarity = Polarity.Positive)
             : base(minCharge, maxCharge, polarity)
         {

--- a/mzLib/MassSpectrometry/MsDataScan.cs
+++ b/mzLib/MassSpectrometry/MsDataScan.cs
@@ -126,32 +126,47 @@ namespace MassSpectrometry
             return MzSpectrum.Get64Bitarray(GetNoiseDataBaseline(NoiseData));
         }
 
+
         /// <summary>
-        /// Get deconvoluted isotopic envelopes with peaks within isolation range
+        /// Get deconvoluted isotopic envelopes with peaks within the isolation range
         /// </summary>
-        /// <param name="deconvoluter">Deconvoluter with formatted params</param>
+        /// <param name="precursorSpectrum"> precursor spectrum</param>
+        /// <param name="deconParameters">deconvolution parameters</param>
+        /// <remarks>
+        /// +- 8.5 are magic numbers from the original implementation of Classic Deconvolution
+        /// it is believe that they represent the maximum mz space an isotopic envelopes can exist within
+        /// This ensure that a peak is not cut in half by the mz isolation range
+        /// </remarks>
         /// <returns></returns>
-        public IEnumerable<IsotopicEnvelope> GetIsolatedMassesAndCharges(Deconvoluter deconvoluter)
+        public IEnumerable<IsotopicEnvelope> GetIsolatedMassesAndCharges(MzSpectrum precursorSpectrum,
+            DeconvolutionParameters deconParameters)
         {
-            // +- 8.5 are magic numbers from the original implementation of Classic Deconvolution
-            // it is believe that they represent the maximum mz space an isotopic envelopes can exist within
-            // This ensure that a peak is not cut in half by the mz isolation range
-            return deconvoluter.Deconvolute(this, new MzRange(IsolationRange.Minimum - 8.5, IsolationRange.Maximum + 8.5));
+            return IsolationRange == null
+                ? new List<IsotopicEnvelope>()
+                : Deconvoluter.Deconvolute(precursorSpectrum, deconParameters,
+                    new MzRange(IsolationRange.Minimum - 8.5, IsolationRange.Maximum + 8.5));
         }
 
         /// <summary>
         /// Get deconvoluted isotopic envelopes with peaks within the isolation range
         /// </summary>
-        /// <param name="type">deconvolution type to be performed</param>
+        /// <param name="precursorScan"> precursor scan</param>
         /// <param name="deconParameters">deconvolution parameters</param>
+        /// <remarks>
+        /// +- 8.5 are magic numbers from the original implementation of Classic Deconvolution
+        /// it is believe that they represent the maximum mz space an isotopic envelopes can exist within
+        /// This ensure that a peak is not cut in half by the mz isolation range
+        /// </remarks>
         /// <returns></returns>
-        public IEnumerable<IsotopicEnvelope> GetIsolatedMassesAndCharges(DeconvolutionType type,
+        public IEnumerable<IsotopicEnvelope> GetIsolatedMassesAndCharges(MsDataScan precursorScan,
             DeconvolutionParameters deconParameters)
         {
-            Deconvoluter deconvoluter = new Deconvoluter(type, deconParameters);
-            return GetIsolatedMassesAndCharges(deconvoluter);
+            return IsolationRange == null
+                ? new List<IsotopicEnvelope>()
+                : Deconvoluter.Deconvolute(precursorScan, deconParameters,
+                    new MzRange(IsolationRange.Minimum - 8.5, IsolationRange.Maximum + 8.5));
         }
-
+        
 
         [Obsolete]
         public IEnumerable<IsotopicEnvelope> GetIsolatedMassesAndCharges(MzSpectrum precursorSpectrum, int minAssumedChargeState,

--- a/mzLib/Test/TestDeconvolution.cs
+++ b/mzLib/Test/TestDeconvolution.cs
@@ -139,10 +139,9 @@ namespace Test
             // The ones marked 2 are for checking an overload method
 
             DeconvolutionParameters deconParameters = new ClassicDeconvolutionParameters(1, 60, 4, 3);
-            Deconvoluter deconvoluter = new Deconvoluter(DeconvolutionType.ClassicDeconvolution, deconParameters);
 
-            List<IsotopicEnvelope> isolatedMasses = scan.GetIsolatedMassesAndCharges(DeconvolutionType.ClassicDeconvolution, deconParameters).ToList();
-            List<IsotopicEnvelope> isolatedMasses2 = scan.GetIsolatedMassesAndCharges(deconvoluter).ToList();
+            List<IsotopicEnvelope> isolatedMasses = scan.GetIsolatedMassesAndCharges(scan, deconParameters).ToList();
+            List<IsotopicEnvelope> isolatedMasses2 = scan.GetIsolatedMassesAndCharges(scan.MassSpectrum, deconParameters).ToList();
 
             List<double> monoIsotopicMasses = isolatedMasses.Select(m => m.MonoisotopicMass).ToList();
             List<double> monoIsotopicMasses2 = isolatedMasses2.Select(m => m.MonoisotopicMass).ToList();
@@ -179,16 +178,15 @@ namespace Test
             DeconvolutionParameters deconParameters =
                 new ClassicDeconvolutionParameters(minAssumedChargeState, maxAssumedChargeState, deconvolutionTolerancePpm,
                     intensityRatioLimit);
-            Deconvoluter deconvoluter = new Deconvoluter(DeconvolutionType.ClassicDeconvolution, deconParameters);
 
             //check assigned correctly
 
-            List<IsotopicEnvelope> lie2 = deconvoluter.Deconvolute(singlespec, singleRange).ToList();
+            List<IsotopicEnvelope> lie2 = Deconvoluter.Deconvolute(singlespec, deconParameters, singleRange).ToList();
             List<IsotopicEnvelope> lie2_charge = lie2.Where(p => p.Charge == charge).ToList();
             Assert.That(lie2_charge[0].MostAbundantObservedIsotopicMass / charge, Is.EqualTo(m).Within(0.1));
 
             //check that if already assigned, skips assignment and just recalls same value
-            List<IsotopicEnvelope> lie3 = deconvoluter.Deconvolute(singlespec, singleRange).ToList();
+            List<IsotopicEnvelope> lie3 = Deconvoluter.Deconvolute(singlespec, deconParameters, singleRange).ToList();
             Assert.AreEqual(lie2.Select(p => p.MostAbundantObservedIsotopicMass), lie3.Select(p => p.MostAbundantObservedIsotopicMass));
         }
 
@@ -212,9 +210,8 @@ namespace Test
 
             // set up deconvolution
             DeconvolutionParameters deconParams = new ClassicDeconvolutionParameters(-10, -1, 20, 3, Polarity.Negative);
-            Deconvoluter deconvoluter = new(DeconvolutionType.ClassicDeconvolution, deconParams);
 
-            List<IsotopicEnvelope> deconvolutionResults = deconvoluter.Deconvolute(scan).ToList();
+            List<IsotopicEnvelope> deconvolutionResults = Deconvoluter.Deconvolute(scan, deconParams).ToList();
             // ensure each expected result is found, with correct mz, charge, and monoisotopic mass
             var resultsWithPeakOfInterest = deconvolutionResults.FirstOrDefault(envelope =>
                 envelope.Peaks.Any(peak => tolerance.Within(peak.mz, expectedMz)));


### PR DESCRIPTION
The Deconvoluter class was altered to have a static call instead of an instance. 
This enables MM to parallelize deconvolution as each call is through a static method. 

An error in the MsDataScan.GetIsolatedMassesAndCharges() was corrected. A precursor spectrum must now be passed in. 