### PR TITLE
Handled edge case with digestion product having a null parent

### DIFF
--- a/mzLib/Omics/Digestion/DigestionProduct.cs
+++ b/mzLib/Omics/Digestion/DigestionProduct.cs
@@ -28,9 +28,11 @@ namespace Omics.Digestion
         public int OneBasedStartResidue { get; }// the residue number at which the peptide begins (the first residue in a protein is 1)
         public int OneBasedEndResidue { get; }// the residue number at which the peptide ends
         public int MissedCleavages { get; } // the number of missed cleavages this peptide has with respect to the digesting protease
-        public virtual char PreviousResidue => OneBasedStartResidue > 1 ? Parent[OneBasedStartResidue - 2] : '-';
 
-        public virtual char NextResidue => OneBasedEndResidue < Parent.Length ? Parent[OneBasedEndResidue] : '-';
+        public virtual char PreviousResidue => OneBasedStartResidue > 1 ? Parent?[OneBasedStartResidue - 2] ?? '-' : '-';
+
+        public virtual char NextResidue => OneBasedEndResidue < Parent?.Length ? Parent?[OneBasedEndResidue] ?? '-' : '-';
+
         public string BaseSequence =>
             _baseSequence ??= Parent.BaseSequence.Substring(OneBasedStartResidue - 1,
                 OneBasedEndResidue - OneBasedStartResidue + 1);

--- a/mzLib/Test/TestPeptideWithSetMods.cs
+++ b/mzLib/Test/TestPeptideWithSetMods.cs
@@ -1143,5 +1143,15 @@ namespace Test
             var expectedFullStringsWithMassShifts = File.ReadAllLines(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "fullSequencesWithMassShift.txt"));
             CollectionAssert.AreEquivalent(expectedFullStringsWithMassShifts, allSequences.ToArray());
         }
+
+        [Test]
+        public static void TestPeptideWithSetModsNoParentProtein()
+        {
+            DigestionParams dParams = new DigestionParams();
+            var pwsm = new PeptideWithSetModifications("P", null,
+                digestionParams: dParams, p: null);
+            Assert.AreEqual('-', pwsm.PreviousAminoAcid);
+            Assert.AreEqual('-', pwsm.NextAminoAcid);
+        }
     }
 }


### PR DESCRIPTION
This typically only occurs when we are constructing them manually for a test. 