### PR TITLE
Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,9 +25,9 @@ jobs:
     - name: Build (TestFlashLFQ)
       run: cd mzLib && dotnet build --no-restore ./TestFlashLFQ/TestFlashLFQ.csproj
     - name: Add coverlet collector (Test)
-      run: cd mzLib && dotnet add Test/Test.csproj package coverlet.collector && dotnet add Test/Test.csproj package System.Text.Json -v 8.0.0
+      run: cd mzLib && dotnet add Test/Test.csproj package coverlet.collector -v 6.0.0
     - name: Add coverlet collector (TestFlashLFQ)
-      run: cd mzLib && dotnet add TestFlashLFQ/TestFlashLFQ.csproj package coverlet.collector && dotnet add Test/Test.csproj package System.Text.Json -v 8.0.0
+      run: cd mzLib && dotnet add TestFlashLFQ/TestFlashLFQ.csproj package coverlet.collector -v 6.0.0
     - name: Test
       run: cd mzLib && dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura ./Test/Test.csproj
     - name: TestFlashLFQ

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,9 +25,9 @@ jobs:
     - name: Build (TestFlashLFQ)
       run: cd mzLib && dotnet build --no-restore ./TestFlashLFQ/TestFlashLFQ.csproj
     - name: Add coverlet collector (Test)
-      run: cd mzLib && dotnet add Test/Test.csproj package coverlet.collector
+      run: cd mzLib && dotnet add Test/Test.csproj package coverlet.collector && dotnet add Test/Test.csproj package System.Text.Json
     - name: Add coverlet collector (TestFlashLFQ)
-      run: cd mzLib && dotnet add TestFlashLFQ/TestFlashLFQ.csproj package coverlet.collector
+      run: cd mzLib && dotnet add TestFlashLFQ/TestFlashLFQ.csproj package coverlet.collector && dotnet add Test/Test.csproj package System.Text.Json
     - name: Test
       run: cd mzLib && dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura ./Test/Test.csproj
     - name: TestFlashLFQ

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,9 +25,9 @@ jobs:
     - name: Build (TestFlashLFQ)
       run: cd mzLib && dotnet build --no-restore ./TestFlashLFQ/TestFlashLFQ.csproj
     - name: Add coverlet collector (Test)
-      run: cd mzLib && dotnet add Test/Test.csproj package coverlet.collector && dotnet add Test/Test.csproj package System.Text.Json
+      run: cd mzLib && dotnet add Test/Test.csproj package coverlet.collector && dotnet add Test/Test.csproj package System.Text.Json -v 8.0.0
     - name: Add coverlet collector (TestFlashLFQ)
-      run: cd mzLib && dotnet add TestFlashLFQ/TestFlashLFQ.csproj package coverlet.collector && dotnet add Test/Test.csproj package System.Text.Json
+      run: cd mzLib && dotnet add TestFlashLFQ/TestFlashLFQ.csproj package coverlet.collector && dotnet add Test/Test.csproj package System.Text.Json -v 8.0.0
     - name: Test
       run: cd mzLib && dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura ./Test/Test.csproj
     - name: TestFlashLFQ


### PR DESCRIPTION
The coverlet nuget package, which we use for analyzing code coverage, released an update about a week ago. The updated version is broken.

This PR uses the previous version of coverlet, v6.0.0, to avoid the problem that was introduced in v6.0.1