### PR TITLE
Changed PWSM GetHashCode and Equals methods

### DIFF
--- a/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -888,28 +888,13 @@ namespace Proteomics.ProteolyticDigestion
         {
             var q = obj as PeptideWithSetModifications;
 
-            if (Protein == null && q.Protein == null)
-            {
-                return q.FullSequence.Equals(this.FullSequence);
-            }
-
             return q != null
-                && q.FullSequence.Equals(this.FullSequence)
-                && q.OneBasedStartResidue == this.OneBasedStartResidue
-                && (q.Protein.Accession == null && this.Protein.Accession == null || q.Protein.Accession.Equals(this.Protein.Accession))
-                && q.DigestionParams.DigestionAgent.Equals(this.DigestionParams.DigestionAgent);
+                && q.FullSequence.Equals(this.FullSequence);
         }
 
         public override int GetHashCode()
         {
-            if (DigestionParams == null)
-            {
-                return FullSequence.GetHashCode();
-            }
-            else
-            {
-                return FullSequence.GetHashCode() + DigestionParams.DigestionAgent.GetHashCode();
-            }
+            return FullSequence.GetHashCode();
         }
 
         /// <summary>

--- a/mzLib/Test/TestDigestionMotif.cs
+++ b/mzLib/Test/TestDigestionMotif.cs
@@ -563,9 +563,9 @@ namespace Test
             Assert.IsTrue(pwsms.Any(x => x.OneBasedStartResidueInProtein == 57 && x.OneBasedEndResidueInProtein == 87));
             Assert.IsTrue(pwsms.Any(x => x.OneBasedStartResidueInProtein == 90 && x.OneBasedEndResidueInProtein == 110));
             //check that all the correct peptides were made
-            Assert.IsTrue(hashset.Count == 52);
-            //check that there are no duplicates
-            Assert.IsTrue(pwsms.Count == hashset.Count);
+            Assert.AreEqual(hashset.Count, 51);
+            //check that there is one duplicate peptide (duplicate full sequence)
+            Assert.AreEqual(1, pwsms.Count - hashset.Count);
             //Speedy semi specific test
             DigestionParams speedySemiN = new DigestionParams("trypsin", 10, 29, 30, 1024, InitiatorMethionineBehavior.Retain, 2, CleavageSpecificity.Semi, Omics.Fragmentation.FragmentationTerminus.N);
             DigestionParams speedySemiC = new DigestionParams("trypsin", 10, 29, 30, 1024, InitiatorMethionineBehavior.Retain, 2, CleavageSpecificity.Semi, Omics.Fragmentation.FragmentationTerminus.C);

--- a/mzLib/Test/TestPeptideWithSetMods.cs
+++ b/mzLib/Test/TestPeptideWithSetMods.cs
@@ -52,8 +52,8 @@ namespace Test
             Assert.That(pep1.FullSequence.Equals(pep2.FullSequence));
             Assert.That(pep1.Parent.Equals(pep2.Parent));
             Assert.That(!pep1.DigestionParams.DigestionAgent.Equals(pep2.DigestionParams.DigestionAgent));
-            Assert.That(!pep1.Equals(pep2));
-            Assert.That(!pep1.GetHashCode().Equals(pep2.GetHashCode()));
+            Assert.That(pep1.Equals(pep2));
+            Assert.That(pep1.GetHashCode().Equals(pep2.GetHashCode()));
         }
 
         [Test]


### PR DESCRIPTION
GetHashCode and Equals now only care about the full sequence of the PWSM. 

Previously, non-equal PWSMs could have identical hash codes. Now, any equal PWSM will have identical hash codes and vice versa.