### PR TITLE
Allow SSRCalc to be called from just base sequence without constructing PeptideWithSetModifications

### DIFF
--- a/mzLib/Proteomics/RetentionTimePrediction/SSRCalc3.cs
+++ b/mzLib/Proteomics/RetentionTimePrediction/SSRCalc3.cs
@@ -568,9 +568,11 @@ namespace Proteomics.RetentionTimePrediction
             get { return 0; }
         }
 
-        public double ScoreSequence(PeptideWithSetModifications item)
+        public double ScoreSequence(PeptideWithSetModifications item) => ScoreSequence(item.BaseSequence);
+
+        public double ScoreSequence(string baseSequence)
         {
-            var seq = item.BaseSequence; //PTMs are not yet implemented
+            var seq = baseSequence; //PTMs are not yet implemented
             double tsum3 = 0.0;
             int i;
 

--- a/mzLib/Test/TestRetentionTimePrediction.cs
+++ b/mzLib/Test/TestRetentionTimePrediction.cs
@@ -657,6 +657,7 @@ namespace Test
                 object obj = _peptides100A[i, 1];
                 double expected = (double)_peptides100A[i, 1];
                 double actual = calc.ScoreSequence(peptide);
+                double actualString = calc.ScoreSequence(peptide.BaseSequence);
 
                 // Round the returned value to match the values presented
                 // in the supporting information of the SSRCalc 3 publication.
@@ -665,11 +666,13 @@ namespace Test
                 // instead of 12.81.  When diffed with 12.81 the result was
                 // 0.005000000000002558.
                 double actualRound = Math.Round((float)actual, 2);
+                double actualStringRound = Math.Round((float)actualString, 2);
 
                 // Extra conditional added to improve debugging of issues.
                 if (Math.Abs(expected - actual) > 0.005)
                 {
                     Assert.AreEqual(expected, actualRound, "Peptide {0}", peptide);
+                    Assert.AreEqual(expected, actualStringRound, "Peptide {0}", peptide);
                 }
             }
         }


### PR DESCRIPTION
Allow SSRCalc to be called from just base sequence without constructing PeptideWithSetModifications