### PR TITLE
Allow multiple custom fragmentations

### DIFF
--- a/mzLib/Omics/Fragmentation/Peptide/DissociationTypeCollection.cs
+++ b/mzLib/Omics/Fragmentation/Peptide/DissociationTypeCollection.cs
@@ -24,7 +24,13 @@ namespace Omics.Fragmentation.Peptide
 
         public static List<ProductType> GetTerminusSpecificProductTypesFromDissociation(DissociationType dissociationType, FragmentationTerminus fragmentationTerminus)
         {
-            if (!TerminusSpecificProductTypesFromDissociation.TryGetValue((dissociationType, fragmentationTerminus), out List<ProductType> productTypes))
+            List<ProductType> productTypes;
+            if (dissociationType == DissociationType.Custom)
+            {
+                productTypes = TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[fragmentationTerminus]
+                    .Intersect(DissociationTypeCollection.ProductsFromDissociationType[dissociationType]).ToList();
+            }
+            else if (!TerminusSpecificProductTypesFromDissociation.TryGetValue((dissociationType, fragmentationTerminus), out productTypes))
             {
                 lock (TerminusSpecificProductTypesFromDissociation)
                 {

--- a/mzLib/Test/TestFragments.cs
+++ b/mzLib/Test/TestFragments.cs
@@ -788,13 +788,40 @@ namespace Test
         {
             DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom].Add(ProductType.b);
             DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom].Add(ProductType.y);
+            DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom].Add(ProductType.c);
+            DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom].Add(ProductType.x);
             Assert.IsTrue(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom].Contains(ProductType.b));
 
-            var productCollection = TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.N].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom]);
+            var productCollection = TerminusSpecificProductTypes
+                .ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.N]
+                .Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom]);
             Assert.IsTrue(productCollection.Contains(ProductType.b));
+            Assert.IsTrue(productCollection.Contains(ProductType.c));
 
-            productCollection = TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.C].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom]);
+            productCollection = TerminusSpecificProductTypes
+                .ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.C]
+                .Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom]);
             Assert.IsTrue(productCollection.Contains(ProductType.y));
+            Assert.IsTrue(productCollection.Contains(ProductType.x));
+
+            var peptide = new PeptideWithSetModifications("PEPTIDE", new Dictionary<string, Modification>());
+            var products = new List<Product>();
+            peptide.Fragment(DissociationType.Custom, FragmentationTerminus.Both, products);
+
+            Assert.That(products.Any(p => p.ProductType == ProductType.b));
+            Assert.That(products.Any(p => p.ProductType == ProductType.y));
+            Assert.That(products.Any(p => p.ProductType == ProductType.c));
+            Assert.That(products.Any(p => p.ProductType == ProductType.x));
+
+            DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom].Clear();
+            Assert.That(!DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom].Any());
+            DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom].AddRange(new List<ProductType> { ProductType.b, ProductType.y });
+            products.Clear();
+            peptide.Fragment(DissociationType.Custom, FragmentationTerminus.Both, products);
+            Assert.That(products.Any(p => p.ProductType == ProductType.b));
+            Assert.That(products.Any(p => p.ProductType == ProductType.y));
+            Assert.That(products.All(p => p.ProductType != ProductType.c));
+            Assert.That(products.All(p => p.ProductType != ProductType.x));
         }
 
         [Test]


### PR DESCRIPTION
Mzlib was hardcoded to save the product types from the first time the DissociationType.Custom was called. This functionality will not allow for two file specific parameters to be searched with two different sets of custom ions in MetaMorpheus. This PR changes the dictionary in which those get stored to determine the product types dynamically for DissociationType.Custom but retain the static implementation for all other dissociation types. 