### PR TITLE
DecoyScrambler now accounts for modifications

### DIFF
--- a/mzLib/MzLibUtil/ClassExtensions.cs
+++ b/mzLib/MzLibUtil/ClassExtensions.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace MzLibUtil
 {
@@ -99,6 +100,17 @@ namespace MzLibUtil
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Finds the index of all instances of a specified substring within the source string.
+        /// The index returned is the position of the first character of the substring within the source tring
+        /// </summary>
+        /// <param name="sourceString">Haystack: string to be searched</param>
+        /// <param name="subString">Needle: substring to be located</param>
+        public static IEnumerable<int> IndexOfAll(this string sourceString, string subString)
+        {
+            return Regex.Matches(sourceString, subString).Cast<Match>().Select(m => m.Index);
         }
 
         /// <summary>

--- a/mzLib/Proteomics/Protein/Protein.cs
+++ b/mzLib/Proteomics/Protein/Protein.cs
@@ -857,7 +857,7 @@ namespace Proteomics
 
                     scrambledProteinSequence = scrambledProteinSequence.Replace(peptideSequence, scrambledPeptideSequence);
 
-                    if (!scrambledModificationDictionary.IsNotNullOrEmpty()) continue;
+                    if (!scrambledModificationDictionary.Any()) continue;
 
                     // rearrange the modifications 
                     foreach (int index in scrambledProteinSequence.IndexOfAll(scrambledPeptideSequence))

--- a/mzLib/Proteomics/Protein/Protein.cs
+++ b/mzLib/Proteomics/Protein/Protein.cs
@@ -869,7 +869,6 @@ namespace Proteomics
                         // Modify the dictionary to reflect the new positions of the modifications
                         foreach (var kvp in relevantMods)
                         {
-                            int idxInSwappedArray = kvp.Key - index - 1;
                             int newKey = swappedArray[kvp.Key - 1 - index] + 1 + index;
                             // To prevent collisions, we have to check if mods already exist at the new idx.
                             if(scrambledModificationDictionary.TryGetValue(newKey, out var modsToSwap))

--- a/mzLib/Proteomics/Protein/Protein.cs
+++ b/mzLib/Proteomics/Protein/Protein.cs
@@ -901,6 +901,7 @@ namespace Proteomics
         /// <summary>
         /// Scrambles a peptide sequence, preserving the position of any cleavage sites.
         /// </summary>
+        /// <param name="swappedPositionArray">An array that maps the previous position (index) to the new position (value)</param>
         public static string ScrambleSequence(string sequence, List<DigestionMotif> motifs, out int[] swappedPositionArray)
         {
             // First, find the location of every cleavage motif. These sites shouldn't be scrambled.

--- a/mzLib/Proteomics/Protein/Protein.cs
+++ b/mzLib/Proteomics/Protein/Protein.cs
@@ -7,6 +7,8 @@ using Omics;
 using Omics.Digestion;
 using Omics.Fragmentation;
 using Omics.Modifications;
+using MzLibUtil;
+using Easy.Common.Extensions;
 
 namespace Proteomics
 {
@@ -832,25 +834,67 @@ namespace Proteomics
             }
 
             string scrambledProteinSequence = originalDecoyProtein.BaseSequence;
+            // Clone the original protein's modifications
+            var scrambledModificationDictionary = originalDecoyProtein.OriginalNonVariantModifications.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
             // Start small and then go big. If we scramble a zero-missed cleavage peptide, but the missed cleavage peptide contains the previously scrambled peptide
             // Then we can avoid unnecessary operations as the scrambledProteinSequence will no longer contain the longer sequence of the missed cleavage peptide
             foreach(string peptideSequence in sequencesToScramble.OrderBy(seq => seq.Length))
             {
                 if(scrambledProteinSequence.Contains(peptideSequence))
                 {
-                    string scrambledPeptideSequence = ScrambleSequence(peptideSequence, digestionParams.DigestionAgent.DigestionMotifs);
+                    string scrambledPeptideSequence = ScrambleSequence(peptideSequence, digestionParams.DigestionAgent.DigestionMotifs, 
+                        out var swappedArray);
                     int scrambleAttempts = 1;
+
                     // Try five times to scramble the peptide sequence without creating a forbidden sequence
                     while(forbiddenSequences.Contains(scrambledPeptideSequence) & scrambleAttempts <= 5)
                     {
-                        scrambledPeptideSequence = ScrambleSequence(peptideSequence, digestionParams.DigestionAgent.DigestionMotifs);
+                        scrambledPeptideSequence = ScrambleSequence(peptideSequence, digestionParams.DigestionAgent.DigestionMotifs,
+                            out swappedArray);
                         scrambleAttempts++;
                     }
+
                     scrambledProteinSequence = scrambledProteinSequence.Replace(peptideSequence, scrambledPeptideSequence);
+
+                    if (!scrambledModificationDictionary.IsNotNullOrEmpty()) continue;
+
+                    // rearrange the modifications 
+                    foreach (int index in scrambledProteinSequence.IndexOfAll(scrambledPeptideSequence))
+                    {
+                        // Get mods that were affected by the scramble
+                        var relevantMods = scrambledModificationDictionary.Where(kvp => 
+                            kvp.Key >= index + 1 && kvp.Key < index + peptideSequence.Length + 1).ToList();
+
+                        // Modify the dictionary to reflect the new positions of the modifications
+                        foreach (var kvp in relevantMods)
+                        {
+                            int idxInSwappedArray = kvp.Key - index - 1;
+                            int newKey = swappedArray[kvp.Key - 1 - index] + 1 + index;
+                            // To prevent collisions, we have to check if mods already exist at the new idx.
+                            if(scrambledModificationDictionary.TryGetValue(newKey, out var modsToSwap))
+                            {
+                                // If there are mods at the new idx, we swap the mods
+                                scrambledModificationDictionary[newKey] = kvp.Value;
+                                scrambledModificationDictionary[kvp.Key] = modsToSwap;
+                            }
+                            else
+                            {
+                                scrambledModificationDictionary.Add(newKey, kvp.Value);
+                                scrambledModificationDictionary.Remove(kvp.Key);
+                            }
+                        }
+                    }
                 }
             }
 
-            return new Protein(originalDecoyProtein, scrambledProteinSequence);
+            Protein newProtein = new Protein(originalDecoyProtein, scrambledProteinSequence);
+
+            // Update the modifications using the scrambledModificationDictionary
+            newProtein.OriginalNonVariantModifications = scrambledModificationDictionary;
+            newProtein.OneBasedPossibleLocalizedModifications = newProtein.SelectValidOneBaseMods(scrambledModificationDictionary);
+            
+            return newProtein;
         }
 
         private static Random rng = new Random(42);
@@ -858,7 +902,7 @@ namespace Proteomics
         /// <summary>
         /// Scrambles a peptide sequence, preserving the position of any cleavage sites.
         /// </summary>
-        public static string ScrambleSequence(string sequence, List<DigestionMotif> motifs)
+        public static string ScrambleSequence(string sequence, List<DigestionMotif> motifs, out int[] swappedPositionArray)
         {
             // First, find the location of every cleavage motif. These sites shouldn't be scrambled.
             HashSet<int> zeroBasedCleavageSitesLocations = new();
@@ -876,6 +920,10 @@ namespace Proteomics
 
             // Next, scramble the sequence using the Fisher-Yates shuffle algorithm.
             char[] sequenceArray = sequence.ToCharArray();
+            // We're going to keep track of the positions of the characters in the original sequence,
+            // This will enable us to adjust the location of modifications that are present in the original sequence
+            // to the new scrambled sequence.
+            int[] tempPositionArray = Enumerable.Range(0, sequenceArray.Length).ToArray();
             int n = sequenceArray.Length;
             while(n > 1)
             {
@@ -891,9 +939,23 @@ namespace Proteomics
                 {
                     k = rng.Next(n + 1);
                 }
-                char temp = sequenceArray[k];
+
+                // rearrange the sequence array
+                char tempResidue = sequenceArray[k];
                 sequenceArray[k] = sequenceArray[n];
-                sequenceArray[n] = temp;
+                sequenceArray[n] = tempResidue;
+
+                // update the position array to represent the swaps
+                int tempPosition = tempPositionArray[k];
+                tempPositionArray[k] = tempPositionArray[n];
+                tempPositionArray[n] = tempPosition;
+            }
+
+            // This maps the previous position (index) to the new position (value)
+            swappedPositionArray = new int[tempPositionArray.Length];
+            for (int i = 0; i < tempPositionArray.Length; i++)
+            {
+                swappedPositionArray[tempPositionArray[i]] = i;
             }
 
             return new string(sequenceArray);

--- a/mzLib/Test/DatabaseTests/TestProteomicsReadWrite.cs
+++ b/mzLib/Test/DatabaseTests/TestProteomicsReadWrite.cs
@@ -41,6 +41,20 @@ namespace Test.DatabaseTests
         }
 
         [Test]
+        public void xyz()
+        {
+            var psiModDeserialized = Loaders.LoadPsiMod(Path.Combine(TestContext.CurrentContext.TestDirectory, "PSI-MOD.obo2.xml"));
+            Dictionary<string, int> formalChargesDictionary = Loaders.GetFormalChargesDictionary(psiModDeserialized);
+            var uniprotPtms = Loaders.LoadUniprot(Path.Combine(TestContext.CurrentContext.TestDirectory, "ptmlist2.txt"), formalChargesDictionary).ToList();
+
+            List<Protein> x = ProteinDbLoader.LoadProteinXML(@"C:\Users\Alex\Documents\Proteomes\MBR_Proteomes_March_2024\MetaMorpheusContaminants.xml", true, DecoyType.None, uniprotPtms, false, null, out Dictionary<string, Modification> un);
+
+            Protein gtpase = x.First(p => p.Accession.Contains("P01112"));
+
+            int placeholder = 0;
+        }
+
+        [Test]
         public void Test_readUniProtXML_writeProteinXml()
         {
             ModificationMotif.TryGetMotif("X", out ModificationMotif motif);

--- a/mzLib/Test/DatabaseTests/TestProteomicsReadWrite.cs
+++ b/mzLib/Test/DatabaseTests/TestProteomicsReadWrite.cs
@@ -41,20 +41,6 @@ namespace Test.DatabaseTests
         }
 
         [Test]
-        public void xyz()
-        {
-            var psiModDeserialized = Loaders.LoadPsiMod(Path.Combine(TestContext.CurrentContext.TestDirectory, "PSI-MOD.obo2.xml"));
-            Dictionary<string, int> formalChargesDictionary = Loaders.GetFormalChargesDictionary(psiModDeserialized);
-            var uniprotPtms = Loaders.LoadUniprot(Path.Combine(TestContext.CurrentContext.TestDirectory, "ptmlist2.txt"), formalChargesDictionary).ToList();
-
-            List<Protein> x = ProteinDbLoader.LoadProteinXML(@"C:\Users\Alex\Documents\Proteomes\MBR_Proteomes_March_2024\MetaMorpheusContaminants.xml", true, DecoyType.None, uniprotPtms, false, null, out Dictionary<string, Modification> un);
-
-            Protein gtpase = x.First(p => p.Accession.Contains("P01112"));
-
-            int placeholder = 0;
-        }
-
-        [Test]
         public void Test_readUniProtXML_writeProteinXml()
         {
             ModificationMotif.TryGetMotif("X", out ModificationMotif motif);

--- a/mzLib/Test/TestProteinDigestion.cs
+++ b/mzLib/Test/TestProteinDigestion.cs
@@ -16,6 +16,7 @@ using Omics.Modifications;
 using UsefulProteomicsDatabases;
 using static Chemistry.PeriodicTable;
 using Stopwatch = System.Diagnostics.Stopwatch;
+using MzLibUtil;
 using System.Runtime.CompilerServices;
 
 namespace Test
@@ -393,6 +394,61 @@ namespace Test
             Assert.IsFalse(scrambledPep.Any(p => offendingDecoys.Contains(p.FullSequence)));
         }
 
+        [Test]
+        public static void TestDecoyScramblerModificationHandling()
+        {
+            DigestionParams d = new DigestionParams(
+                        maxMissedCleavages: 1,
+                        minPeptideLength: 5,
+                        initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+
+            ModificationMotif.TryGetMotif("G", out ModificationMotif motifG);
+            ModificationMotif.TryGetMotif("F", out ModificationMotif motifF);
+            Modification modG = new Modification("myMod", null, "myModType", null, motifG, "Anywhere.", null, 10, null, null, null, null, null, null);
+            Modification modF = new Modification("myMod", null, "myModType", null, motifF, "Anywhere.", null, 10, null, null, null, null, null, null);
+
+            //IDictionary<int, List<Modification>> modDictTarget = new Dictionary<int, List<Modification>>
+            //{
+            //    {9, new List<Modification> { modG } },
+            //    {7, new List<Modification> { modF } }
+            //};
+
+            IDictionary<int, List<Modification>> modDictDecoy = new Dictionary<int, List<Modification>>
+            {
+                {8, new List<Modification> { modG } },
+                {10, new List<Modification> { modF } }
+            };
+
+            Protein target = new Protein("MEDEEKFVGYKYGVFK", "target"); //, oneBasedModifications: modDictTarget);
+            Protein decoy = new Protein("EEDEMKYGVFKFVGYK", "decoy", oneBasedModifications: modDictDecoy);
+
+            var targetPep = target.Digest(d, new List<Modification>(), new List<Modification>());
+            var decoyPep = decoy.Digest(d, new List<Modification>(), new List<Modification>());
+
+            HashSet<string> targetPepSeqs = targetPep.Select(p => p.FullSequence).ToHashSet();
+            var offendingDecoys = decoyPep.Where(p => targetPepSeqs.Contains(p.FullSequence)).Select(d => d.FullSequence).ToList();
+            Protein scrambledDecoy = Protein.ScrambleDecoyProteinSequence(decoy, d, targetPepSeqs, offendingDecoys);
+
+            var fIndex = scrambledDecoy.BaseSequence.IndexOf("F");
+            var gIndex = scrambledDecoy.BaseSequence.IndexOf("G"); // We modified the first residue, so we don't need all locations, just the first
+            var fIndices = scrambledDecoy.BaseSequence.IndexOfAll("F");
+            var gIndices = scrambledDecoy.BaseSequence.IndexOfAll("G");
+
+            Assert.AreEqual(2, gIndices.Count());
+            Assert.AreEqual(2, fIndices.Count());
+            Assert.AreEqual(fIndices.First(), fIndex);
+
+            Assert.True(scrambledDecoy.OneBasedPossibleLocalizedModifications.ContainsKey(fIndex + 1));
+            Assert.True(scrambledDecoy.OneBasedPossibleLocalizedModifications[fIndex+1].Contains(modF));
+
+            Assert.True(scrambledDecoy.OneBasedPossibleLocalizedModifications.ContainsKey(gIndex + 1));
+            Assert.True(scrambledDecoy.OneBasedPossibleLocalizedModifications[gIndex + 1].Contains(modG));
+
+            Assert.AreEqual(scrambledDecoy.OneBasedPossibleLocalizedModifications.Count, 2);
+        }
+
+        
+
         [Test, Timeout(5000)]
         public static void TestDecoyScramblerNoInfiniteLoops()
         {
@@ -429,7 +485,6 @@ namespace Test
             scrambledDecoy = Protein.ScrambleDecoyProteinSequence(impossibleDecoy, d, offendingDecoys, offendingDecoys);
 
             Assert.AreEqual("KEK", scrambledDecoy.BaseSequence);
-            
         }
 
         [Test]

--- a/mzLib/Test/TestProteinDigestion.cs
+++ b/mzLib/Test/TestProteinDigestion.cs
@@ -407,12 +407,6 @@ namespace Test
             Modification modG = new Modification("myMod", null, "myModType", null, motifG, "Anywhere.", null, 10, null, null, null, null, null, null);
             Modification modF = new Modification("myMod", null, "myModType", null, motifF, "Anywhere.", null, 10, null, null, null, null, null, null);
 
-            //IDictionary<int, List<Modification>> modDictTarget = new Dictionary<int, List<Modification>>
-            //{
-            //    {9, new List<Modification> { modG } },
-            //    {7, new List<Modification> { modF } }
-            //};
-
             IDictionary<int, List<Modification>> modDictDecoy = new Dictionary<int, List<Modification>>
             {
                 {8, new List<Modification> { modG } },


### PR DESCRIPTION
Now, when creating scrambled decoy proteins, modifications come along for the ride. 

Rearranges the OneBasedPossibleLocalizedModifications dictionary to correspond to the new scrambled protein sequenc