### PR TITLE
Scan Filter in Averaged Spectra

### DIFF
--- a/mzLib/SpectralAveraging/Algorithms/SpectraFileAveraging.cs
+++ b/mzLib/SpectralAveraging/Algorithms/SpectraFileAveraging.cs
@@ -54,7 +54,7 @@ public static class SpectraFileAveraging
         // create output
         MsDataScan averagedScan = new(averagedSpectrum, 1, representativeScan.OneBasedScanNumber,
             representativeScan.IsCentroid, representativeScan.Polarity, scans.Select(p => p.RetentionTime).Average(),
-            averagedSpectrum.Range, null, representativeScan.MzAnalyzer, scans.Select(p => p.TotalIonCurrent).Average(),
+            averagedSpectrum.Range, representativeScan.ScanFilter, representativeScan.MzAnalyzer, scans.Select(p => p.TotalIonCurrent).Average(),
             representativeScan.InjectionTime, null, representativeScan.NativeId);
         MsDataScan[] msDataScans = { averagedScan };
         return msDataScans;
@@ -129,7 +129,8 @@ public static class SpectraFileAveraging
             centralScan.IsCentroid,
             centralScan.Polarity,
             centralScan.RetentionTime,
-            averagedSpectrum.Range, null,
+            averagedSpectrum.Range,
+            centralScan.ScanFilter,
             centralScan.MzAnalyzer,
             averagedSpectrum.SumOfAllY,
             centralScan.InjectionTime,


### PR DESCRIPTION
Updated SpectraFileAveraging.cs to include the ScanFilter parameter in the MsDataScan constructor, replacing null values. This change ensures that the ScanFilter property is properly set, improving the accuracy and completeness of the scan data.