### PR TITLE
Fixed decoy order

### DIFF
--- a/mzLib/Test/DatabaseTests/TestDatabaseLoaders.cs
+++ b/mzLib/Test/DatabaseTests/TestDatabaseLoaders.cs
@@ -110,9 +110,8 @@ namespace Test.DatabaseTests
 
             // check are equivalent lists of proteins
             Assert.AreEqual(proteins1.Count, proteins2.Count);
-            // Because decoys are written in a parallel environment, there is no guarantee that the orders will be the same
-            CollectionAssert.AreEquivalent(proteins1.Select(p => p.Accession), proteins2.Select(p => p.Accession));
-            CollectionAssert.AreEquivalent(proteins1.Select(p => p.BaseSequence), proteins2.Select(p => p.BaseSequence));
+            // Because decoys are sorted before they are returned, the order should be identical
+            Assert.AreEqual(proteins1, proteins2);
         }
 
         [Test]

--- a/mzLib/UsefulProteomicsDatabases/DecoyProteinGenerator.cs
+++ b/mzLib/UsefulProteomicsDatabases/DecoyProteinGenerator.cs
@@ -180,6 +180,7 @@ namespace UsefulProteomicsDatabases
 
                 lock (decoyProteins) { decoyProteins.Add(decoyProtein); }
             });
+            decoyProteins = decoyProteins.OrderBy(p => p.Accession).ToList();
             return decoyProteins;
         }
 
@@ -359,6 +360,7 @@ namespace UsefulProteomicsDatabases
                     protein.Name, protein.FullName, true, protein.IsContaminant, null, decoyVariationsSlide, null, protein.SampleNameForVariants, decoy_disulfides_slide, spliceSitesSlide, protein.DatabaseFilePath);
                 lock (decoyProteins) { decoyProteins.Add(decoyProteinSlide); }
             });
+            decoyProteins = decoyProteins.OrderBy(p => p.Accession).ToList();
             return decoyProteins;
         }
 


### PR DESCRIPTION
Protein decoys are generated using a parallel foreach loop. Previously, this caused the decoy proteins to be written to a list in a non-reproducible way. The order would change each time the protein database was read in.

Now, the decoys are sorted before they are returned to ensure that the list of Proteins is ordered the same way every time.