### PR TITLE
IEquality Hotfix

### DIFF
--- a/mzLib/Omics/Digestion/DigestionAgent.cs
+++ b/mzLib/Omics/Digestion/DigestionAgent.cs
@@ -1,9 +1,4 @@
 ﻿using Omics.Modifications;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Omics.Digestion
 {
@@ -17,7 +12,7 @@ namespace Omics.Digestion
             CleavageMod = cleavageMod;
         }
 
-        public string Name { get; init; }
+        public readonly string Name;
         public CleavageSpecificity CleavageSpecificity { get; init; }
         public List<DigestionMotif> DigestionMotifs { get; init; }
         public Modification CleavageMod { get; set; }
@@ -25,6 +20,16 @@ namespace Omics.Digestion
         public override string ToString()
         {
             return Name;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is DigestionAgent agent && agent.Name == Name;
+        }
+
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode();
         }
 
         /// <summary>

--- a/mzLib/Omics/IBioPolymer.cs
+++ b/mzLib/Omics/IBioPolymer.cs
@@ -29,5 +29,14 @@ namespace Omics
 
         IEnumerable<IBioPolymerWithSetMods> Digest(IDigestionParams digestionParams, List<Modification> allKnownFixedModifications,
             List<Modification> variableModifications, List<SilacLabel> silacLabels = null, (SilacLabel startLabel, SilacLabel endLabel)? turnoverLabels = null, bool topDownTruncationSearch = false);
+
+        bool IEquatable<IBioPolymer>.Equals(IBioPolymer? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            if (other.GetType() != GetType()) return false;
+            return Accession == other.Accession
+                && BaseSequence == other.BaseSequence;
+        }
     }
 }

--- a/mzLib/Omics/IBioPolymerWithSetMods.cs
+++ b/mzLib/Omics/IBioPolymerWithSetMods.cs
@@ -59,11 +59,12 @@ namespace Omics
             if (ReferenceEquals(this, other)) return true;
             if (other.GetType() != GetType()) return false;
 
+            // for those constructed from sequence and mods only
             if (Parent is null && other.Parent is null)
                 return FullSequence.Equals(other.FullSequence);
 
             return FullSequence == other.FullSequence
-                && DigestionParams?.DigestionAgent == other.DigestionParams?.DigestionAgent;
+                && Equals(DigestionParams?.DigestionAgent, other.DigestionParams?.DigestionAgent);
         }
 
         public void Fragment(DissociationType dissociationType, FragmentationTerminus fragmentationTerminus,

--- a/mzLib/Omics/IBioPolymerWithSetMods.cs
+++ b/mzLib/Omics/IBioPolymerWithSetMods.cs
@@ -44,6 +44,28 @@ namespace Omics
         char this[int zeroBasedIndex] => BaseSequence[zeroBasedIndex];
         IBioPolymer Parent { get; }
 
+        /// <summary>
+        /// Default Equals Method for IBioPolymerWithSetMods
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Different parent but same sequence and digestion condition => are equal
+        /// Different Digestion agent but same sequence => are not equal (this is for multi-protease analysis in MetaMorpheus)
+        /// </remarks>
+        bool IEquatable<IBioPolymerWithSetMods>.Equals(IBioPolymerWithSetMods? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            if (other.GetType() != GetType()) return false;
+
+            if (Parent is null && other.Parent is null)
+                return FullSequence.Equals(other.FullSequence);
+
+            return FullSequence == other.FullSequence
+                && DigestionParams?.DigestionAgent == other.DigestionParams?.DigestionAgent;
+        }
+
         public void Fragment(DissociationType dissociationType, FragmentationTerminus fragmentationTerminus,
             List<Product> products);
 
@@ -163,10 +185,5 @@ namespace Omics
         /// <returns></returns>
         public static List<Modification> GetModificationsFromFullSequence(string fullSequence,
             Dictionary<string, Modification> allModsKnown) => [.. GetModificationDictionaryFromFullSequence(fullSequence, allModsKnown).Values];
-
-        public bool Equals(IBioPolymerWithSetMods other);
-
-        public int GetHashCode();
-
     }
 }

--- a/mzLib/Proteomics/Protein/Protein.cs
+++ b/mzLib/Proteomics/Protein/Protein.cs
@@ -12,7 +12,7 @@ using Easy.Common.Extensions;
 
 namespace Proteomics
 {
-    public class Protein : IBioPolymer
+    public class Protein : IBioPolymer, IEquatable<Protein>
     {
         private List<ProteolysisProduct> _proteolysisProducts;
 
@@ -969,16 +969,18 @@ namespace Proteomics
         //not sure if we require any additional fields for equality
         public override bool Equals(object obj)
         {
-            Protein otherProtein = (Protein)obj;
-            return otherProtein != null && otherProtein.Accession.Equals(Accession) && otherProtein.BaseSequence.Equals(BaseSequence);
+            if (obj is Protein bioPol)
+            {
+                return Equals(bioPol);
+            }
+            return false;
         }
 
-        public bool Equals(IBioPolymer other)
+        public bool Equals(Protein other)
         {
-            Protein otherProtein = (Protein)other;
-            return otherProtein != null && otherProtein.Accession.Equals(Accession) && otherProtein.BaseSequence.Equals(BaseSequence);
+            return (this as IBioPolymer).Equals(other);   
         }
-
+        
         /// <summary>
         /// The protein object uses the default hash code method for speed,
         /// but note that two protein objects with the same information will give two different hash codes.

--- a/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -14,7 +14,7 @@ using Omics.Modifications;
 namespace Proteomics.ProteolyticDigestion
 {
     [Serializable]
-    public class PeptideWithSetModifications : ProteolyticPeptide, IBioPolymerWithSetMods
+    public class PeptideWithSetModifications : ProteolyticPeptide, IBioPolymerWithSetMods, IEquatable<PeptideWithSetModifications>
     {
         public string FullSequence { get; private set; } //sequence with modifications
         public int NumFixedMods { get; }
@@ -886,18 +886,16 @@ namespace Proteomics.ProteolyticDigestion
 
         public override bool Equals(object obj)
         {
-            var q = obj as PeptideWithSetModifications;
-            if (q == null) return false;
-            return Equals(q);
+            if (obj is PeptideWithSetModifications peptide)
+            {
+                return Equals(peptide);
+            }
+            return false;
         }
 
-        public bool Equals(IBioPolymerWithSetMods other)
+        public bool Equals(PeptideWithSetModifications other)
         {
-            return FullSequence == other.FullSequence
-                && OneBasedStartResidue == other.OneBasedStartResidue
-                && ((Parent != null && Parent.Equals(other.Parent)) || (Parent == null & other.Parent == null))
-                && ((DigestionParams?.DigestionAgent != null && DigestionParams.DigestionAgent.Equals(other.DigestionParams?.DigestionAgent))
-                    || (DigestionParams?.DigestionAgent == null & other.DigestionParams?.DigestionAgent == null)); 
+            return (this as IBioPolymerWithSetMods).Equals(other);
         }
 
         public override int GetHashCode()
@@ -905,11 +903,9 @@ namespace Proteomics.ProteolyticDigestion
             var hash = new HashCode();
             hash.Add(FullSequence);
             hash.Add(OneBasedStartResidue);
-            if (Parent != null)
+            if (Parent?.Accession != null)
             {
-                hash.Add(Parent);
-                if (Parent.Accession != null)
-                    hash.Add(Parent.Accession);
+                hash.Add(Parent.Accession);
             }
             if (DigestionParams?.DigestionAgent != null)
             {

--- a/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -895,7 +895,10 @@ namespace Proteomics.ProteolyticDigestion
 
         public bool Equals(PeptideWithSetModifications other)
         {
-            return (this as IBioPolymerWithSetMods).Equals(other);
+            // interface equals first because it does null and reference checks
+            return (this as IBioPolymerWithSetMods).Equals(other)
+                   && OneBasedStartResidue == other!.OneBasedStartResidue
+                   && Equals(Parent, other.Parent);
         }
 
         public override int GetHashCode()

--- a/mzLib/Proteomics/ProteolyticDigestion/Protease.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/Protease.cs
@@ -24,17 +24,6 @@ namespace Proteomics.ProteolyticDigestion
             return Name;
         }
 
-        public override bool Equals(object obj)
-        {
-            return obj is Protease a
-                && (a.Name == null && Name == null || a.Name.Equals(Name));
-        }
-
-        public override int GetHashCode()
-        {
-            return (Name ?? "").GetHashCode();
-        }
-
         /// <summary>
         /// This method is used to determine cleavage specificity if the cleavage specificity is unknown
         /// This occurs in the speedy nonspecific/semispecific searches when digesting post-search

--- a/mzLib/Test/DigestionAgentTests.cs
+++ b/mzLib/Test/DigestionAgentTests.cs
@@ -1,0 +1,13 @@
+using Omics.Digestion;
+using Omics.Modifications;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Test
+{
+    public class DigestionAgentTests
+    {
+        
+        
+    }
+}

--- a/mzLib/Test/TestDigestionMotif.cs
+++ b/mzLib/Test/TestDigestionMotif.cs
@@ -595,5 +595,49 @@ namespace Test
             digestionParams.MaxModsForPeptide = 3;
             Assert.That(digestionParams.MaxMods, Is.EqualTo(digestionParams.MaxModsForPeptide));
         }
+
+        private class TestDigestionAgent : DigestionAgent
+        {
+            public TestDigestionAgent(string name, CleavageSpecificity cleavageSpecificity, List<DigestionMotif> motifList, Modification cleavageMod)
+                : base(name, cleavageSpecificity, motifList, cleavageMod)
+            {
+            }
+        }
+
+        [Test]
+        public void Equals_SameName_ReturnsTrue()
+        {
+            var agent1 = ProteaseDictionary.Dictionary["trypsin"];
+            var agent2 = ProteaseDictionary.Dictionary["trypsin"];
+
+            Assert.That(agent1.Equals(agent2), Is.True);
+        }
+
+        [Test]
+        public void Equals_DifferentName_ReturnsFalse()
+        {
+            var agent1 = ProteaseDictionary.Dictionary["trypsin"];
+            var agent2 = ProteaseDictionary.Dictionary["Arg-C"];
+
+            Assert.That(agent1.Equals(agent2), Is.False);
+        }
+
+        [Test]
+        public void GetHashCode_SameName_ReturnsSameHashCode()
+        {
+            var agent1 = ProteaseDictionary.Dictionary["trypsin"];
+            var agent2 = ProteaseDictionary.Dictionary["trypsin"];
+
+            Assert.That(agent1.GetHashCode(), Is.EqualTo(agent2.GetHashCode()));
+        }
+
+        [Test]
+        public void GetHashCode_DifferentName_ReturnsDifferentHashCode()
+        {
+            var agent1 = ProteaseDictionary.Dictionary["trypsin"];
+            var agent2 = ProteaseDictionary.Dictionary["Arg-C"];
+
+            Assert.That(agent1.GetHashCode(), Is.Not.EqualTo(agent2.GetHashCode()));
+        }
     }
 }

--- a/mzLib/Test/TestPeptideWithSetMods.cs
+++ b/mzLib/Test/TestPeptideWithSetMods.cs
@@ -69,6 +69,8 @@ namespace Test
 
             Assert.That(!oligo.Equals(peptide));
             Assert.That(!peptide.Equals(oligo));
+            Assert.That(!((IBioPolymerWithSetMods)oligo).Equals(peptide));
+            Assert.That(!((IBioPolymerWithSetMods)peptide).Equals(oligo));
         }
 
         [Test]

--- a/mzLib/Test/TestPeptideWithSetMods.cs
+++ b/mzLib/Test/TestPeptideWithSetMods.cs
@@ -13,6 +13,7 @@ using Omics;
 using Omics.Digestion;
 using Omics.Fragmentation;
 using Omics.Modifications;
+using Transcriptomics.Digestion;
 using UsefulProteomicsDatabases;
 using Stopwatch = System.Diagnostics.Stopwatch;
 
@@ -58,6 +59,16 @@ namespace Test
             Assert.That(!pep1.Equals(pep2));
             Assert.That(!pep1.Equals((object)pep2));
             Assert.That(!pep1.GetHashCode().Equals(pep2.GetHashCode()));
+        }
+
+        [Test]
+        public static void TestPeptideOligoEquality()
+        {
+            var oligo = new OligoWithSetMods("GUACUG", []);
+            var peptide = new PeptideWithSetModifications("PEPTIDE", []);
+
+            Assert.That(oligo, Is.Not.EqualTo(peptide));
+            Assert.That(peptide, Is.Not.EqualTo(oligo));
         }
 
         [Test]

--- a/mzLib/Test/TestPeptideWithSetMods.cs
+++ b/mzLib/Test/TestPeptideWithSetMods.cs
@@ -67,8 +67,8 @@ namespace Test
             var oligo = new OligoWithSetMods("GUACUG", []);
             var peptide = new PeptideWithSetModifications("PEPTIDE", []);
 
-            Assert.That(oligo, Is.Not.EqualTo(peptide));
-            Assert.That(peptide, Is.Not.EqualTo(oligo));
+            Assert.That(!oligo.Equals(peptide));
+            Assert.That(!peptide.Equals(oligo));
         }
 
         [Test]

--- a/mzLib/Test/TestProteinProperties.cs
+++ b/mzLib/Test/TestProteinProperties.cs
@@ -295,8 +295,8 @@ namespace Test
             RNA rna = new RNA("GUACUG");
 
 
-            Assert.That(rna, Is.Not.EqualTo(protein1));
-            Assert.That(protein1, Is.Not.EqualTo(rna));
+            Assert.That(!rna.Equals(protein1));
+            Assert.That(!protein1.Equals(rna));
         }
     }
 }

--- a/mzLib/Test/TestProteinProperties.cs
+++ b/mzLib/Test/TestProteinProperties.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Omics;
 using Omics.Modifications;
 using Stopwatch = System.Diagnostics.Stopwatch;
 using Transcriptomics;
@@ -297,6 +298,8 @@ namespace Test
 
             Assert.That(!rna.Equals(protein1));
             Assert.That(!protein1.Equals(rna));
+            Assert.That(!((IBioPolymer)rna).Equals(protein1));
+            Assert.That(!((IBioPolymer)protein1).Equals(rna));
         }
     }
 }

--- a/mzLib/Test/TestProteinProperties.cs
+++ b/mzLib/Test/TestProteinProperties.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using Omics.Modifications;
 using Stopwatch = System.Diagnostics.Stopwatch;
+using Transcriptomics;
 
 namespace Test
 {
@@ -260,6 +261,42 @@ namespace Test
 
             ///Test case 3 is 2B (not level 3) because you've localized the mod, you just aren't sure what mod it is.
             ///In test case 1, you know what the mods are, but you're not sure where they belong.
+        }
+
+        [Test]
+        public void TestProteinEquals()
+        {
+            string sequence = "MKWVTFISLLFLFSSAYSRGVFRRDTHKSEIAHRFKDLGEEHFKGLVLIAFSQYLQQCPFDEHVKLVNEVTEFAKTCVADESAENCDKSLHTLFGDELCKVASLRETYGDMADCCEKQEPERNECFLSHKDDSPDLPKLKPDPNTLCDEFKADEKKFWGKYLYEIARRHPYFYAPELLFFAKRYKAAFTECCQAADKAACLLPKLDELRDEGKASSAKQR";
+            string accession = "P02768";
+            Protein protein1 = new Protein(sequence, accession);
+            Protein protein2 = new Protein(sequence, accession);
+            
+            NUnit.Framework.Assert.That(protein1.Equals(protein2), Is.True);
+            NUnit.Framework.Assert.That(protein1.Equals((object)protein2), Is.True);
+            NUnit.Framework.Assert.That(protein1.Equals(null), Is.False);
+        }
+
+        [Test]
+        public void TestProteinGetHashCode()
+        {
+            string sequence = "MKWVTFISLLFLFSSAYSRGVFRRDTHKSEIAHRFKDLGEEHFKGLVLIAFSQYLQQCPFDEHVKLVNEVTEFAKTCVADESAENCDKSLHTLFGDELCKVASLRETYGDMADCCEKQEPERNECFLSHKDDSPDLPKLKPDPNTLCDEFKADEKKFWGKYLYEIARRHPYFYAPELLFFAKRYKAAFTECCQAADKAACLLPKLDELRDEGKASSAKQR";
+            string accession = "P02768";
+            Protein protein = new Protein(sequence, accession);
+
+            NUnit.Framework.Assert.That(protein.GetHashCode(), Is.EqualTo(sequence.GetHashCode()));
+        }
+
+        [Test]
+        public void TestProteinRnaEquality()
+        {
+            string sequence = "MKWVTFISLLFLFSSAYSRGVFRRDTHKSEIAHRFKDLGEEHFKGLVLIAFSQYLQQCPFDEHVKLVNEVTEFAKTCVADESAENCDKSLHTLFGDELCKVASLRETYGDMADCCEKQEPERNECFLSHKDDSPDLPKLKPDPNTLCDEFKADEKKFWGKYLYEIARRHPYFYAPELLFFAKRYKAAFTECCQAADKAACLLPKLDELRDEGKASSAKQR";
+            string accession = "P02768";
+            Protein protein1 = new Protein(sequence, accession);
+            RNA rna = new RNA("GUACUG");
+
+
+            Assert.That(rna, Is.Not.EqualTo(protein1));
+            Assert.That(protein1, Is.Not.EqualTo(rna));
         }
     }
 }

--- a/mzLib/Test/Transcriptomics/TestOligoWithSetMods.cs
+++ b/mzLib/Test/Transcriptomics/TestOligoWithSetMods.cs
@@ -96,11 +96,17 @@ namespace Test.Transcriptomics
             Assert.That(oligoWithSetMods.Equals((object)oligoWithSetMods2)); // Test the Equals(Object obj) method
             Assert.That(!oligoWithSetMods2.Equals(null));
 
+            // Null parent checks
             oligoWithSetMods = new(oligoWithSetMods.FullSequence, modDict.ToDictionary(p => p.Value.First().IdWithMotif, p => p.Value.First()));
             oligoWithSetMods2 = new OligoWithSetMods(oligoWithSetMods.FullSequence, modDict.ToDictionary(p => p.Value.First().IdWithMotif, p => p.Value.First()));
+            var oligoWithSetMods3 = new OligoWithSetMods(oligoWithSetMods.FullSequence + "AGAUA", modDict.ToDictionary(p => p.Value.First().IdWithMotif, p => p.Value.First()));
 
             Assert.That(oligoWithSetMods, Is.EqualTo(oligoWithSetMods2));
             Assert.That(oligoWithSetMods, Is.EqualTo((object)oligoWithSetMods2));
+            Assert.That(oligoWithSetMods, Is.EqualTo((OligoWithSetMods)oligoWithSetMods2));
+            Assert.That(oligoWithSetMods, Is.Not.EqualTo(oligoWithSetMods3));
+            Assert.That(oligoWithSetMods, Is.Not.EqualTo((object)oligoWithSetMods3));
+            Assert.That(oligoWithSetMods, Is.Not.EqualTo((IBioPolymerWithSetMods)oligoWithSetMods3));
         }
 
         [Test]

--- a/mzLib/Test/Transcriptomics/TestOligoWithSetMods.cs
+++ b/mzLib/Test/Transcriptomics/TestOligoWithSetMods.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using Omics.Modifications;
 using Transcriptomics.Digestion;
 using Transcriptomics;
+using Omics;
 
 namespace Test.Transcriptomics
 {
@@ -79,20 +80,27 @@ namespace Test.Transcriptomics
         [Test]
         public static void TestEquality()
         {
+            var modDict = new Dictionary<int, List<Modification>> { { 4, [TestDigestion.PotassiumAdducts[1]] } };
             var oligoWithSetMods = new RNA("GUACUG",
-                    oneBasedPossibleLocalizedModifications: new Dictionary<int, List<Modification>> { { 4, [TestDigestion.PotassiumAdducts[1]] } })
+                    oneBasedPossibleLocalizedModifications: modDict)
                 .Digest(new RnaDigestionParams(), [], [])
                 .ElementAt(1);
 
-            var oligoWithSetMods2 = new RNA("GUACUG",
-                    oneBasedPossibleLocalizedModifications: new Dictionary<int, List<Modification>> { { 4, [TestDigestion.PotassiumAdducts[1]] } })
+            IBioPolymerWithSetMods oligoWithSetMods2 = new RNA("GUACUG",
+                    oneBasedPossibleLocalizedModifications: modDict)
                 .Digest(new RnaDigestionParams(), [], [])
                 .ElementAt(1);
 
             Assert.That(oligoWithSetMods, Is.EqualTo(oligoWithSetMods2));
             Assert.That(oligoWithSetMods.GetHashCode(), Is.EqualTo(oligoWithSetMods2.GetHashCode()));
-
             Assert.That(oligoWithSetMods.Equals((object)oligoWithSetMods2)); // Test the Equals(Object obj) method
+            Assert.That(!oligoWithSetMods2.Equals(null));
+
+            oligoWithSetMods = new(oligoWithSetMods.FullSequence, modDict.ToDictionary(p => p.Value.First().IdWithMotif, p => p.Value.First()));
+            var oligoWithSetMods3 = new OligoWithSetMods(oligoWithSetMods.FullSequence, modDict.ToDictionary(p => p.Value.First().IdWithMotif, p => p.Value.First()));
+
+            Assert.That(oligoWithSetMods, Is.EqualTo(oligoWithSetMods3));
+            Assert.That(oligoWithSetMods, Is.EqualTo((object)oligoWithSetMods3));
         }
 
         [Test]
@@ -111,6 +119,7 @@ namespace Test.Transcriptomics
                 .First();
 
             Assert.That(oligo1, Is.EqualTo(oligo2));
+            Assert.That(oligo1.Equals(oligo1));
             Assert.That(oligo1, Is.EqualTo((object)oligo2));
             Assert.That(oligo1.GetHashCode(), Is.EqualTo(oligo2.GetHashCode()));
         }

--- a/mzLib/Test/Transcriptomics/TestOligoWithSetMods.cs
+++ b/mzLib/Test/Transcriptomics/TestOligoWithSetMods.cs
@@ -97,10 +97,10 @@ namespace Test.Transcriptomics
             Assert.That(!oligoWithSetMods2.Equals(null));
 
             oligoWithSetMods = new(oligoWithSetMods.FullSequence, modDict.ToDictionary(p => p.Value.First().IdWithMotif, p => p.Value.First()));
-            var oligoWithSetMods3 = new OligoWithSetMods(oligoWithSetMods.FullSequence, modDict.ToDictionary(p => p.Value.First().IdWithMotif, p => p.Value.First()));
+            oligoWithSetMods2 = new OligoWithSetMods(oligoWithSetMods.FullSequence, modDict.ToDictionary(p => p.Value.First().IdWithMotif, p => p.Value.First()));
 
-            Assert.That(oligoWithSetMods, Is.EqualTo(oligoWithSetMods3));
-            Assert.That(oligoWithSetMods, Is.EqualTo((object)oligoWithSetMods3));
+            Assert.That(oligoWithSetMods, Is.EqualTo(oligoWithSetMods2));
+            Assert.That(oligoWithSetMods, Is.EqualTo((object)oligoWithSetMods2));
         }
 
         [Test]

--- a/mzLib/Transcriptomics/Digestion/OligoWithSetMods.cs
+++ b/mzLib/Transcriptomics/Digestion/OligoWithSetMods.cs
@@ -20,7 +20,7 @@ namespace Transcriptomics.Digestion
     /// always available based on the current state of the oligonucleotide and its modifications. Therefor, it is important to set those
     /// properties to null whenever a termini or modification is changed.
     /// </remarks>
-    public class OligoWithSetMods : NucleolyticOligo, IBioPolymerWithSetMods, INucleicAcid
+    public class OligoWithSetMods : NucleolyticOligo, IBioPolymerWithSetMods, INucleicAcid, IEquatable<OligoWithSetMods>
     {
         public OligoWithSetMods(NucleicAcid nucleicAcid, RnaDigestionParams digestionParams, int oneBaseStartResidue,
             int oneBasedEndResidue, int missedCleavages, CleavageSpecificity cleavageSpecificity,
@@ -215,20 +215,18 @@ namespace Transcriptomics.Digestion
                     products.AddRange(GetNeutralFragments(type, sequence));
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            var q = obj as OligoWithSetMods;
-            if (q == null) return false;
-            return Equals(q);
+            if (obj is OligoWithSetMods oligo)
+            {
+                return Equals(oligo);
+            }
+            return false;
         }
 
-        public bool Equals(IBioPolymerWithSetMods other)
+        public bool Equals(OligoWithSetMods? other)
         {
-            return FullSequence == other.FullSequence
-                && OneBasedStartResidue == other.OneBasedStartResidue
-                && ((Parent != null && Parent.Equals(other.Parent)) || (Parent == null & other.Parent == null))
-                && ((DigestionParams?.DigestionAgent != null && DigestionParams.DigestionAgent.Equals(other.DigestionParams?.DigestionAgent))
-                    || (DigestionParams?.DigestionAgent == null & other.DigestionParams?.DigestionAgent == null));
+            return (this as IBioPolymerWithSetMods).Equals(other);
         }
 
         public override int GetHashCode()
@@ -236,11 +234,9 @@ namespace Transcriptomics.Digestion
             var hash = new HashCode();
             hash.Add(FullSequence);
             hash.Add(OneBasedStartResidue);
-            if (Parent != null)
+            if (Parent?.Accession != null)
             {
-                hash.Add(Parent);
-                if (Parent.Accession != null)
-                    hash.Add(Parent.Accession);
+                hash.Add(Parent.Accession);
             }
             if (DigestionParams?.DigestionAgent != null)
             {

--- a/mzLib/Transcriptomics/Digestion/Rnase.cs
+++ b/mzLib/Transcriptomics/Digestion/Rnase.cs
@@ -9,7 +9,6 @@ namespace Transcriptomics.Digestion
         public Rnase(string name, CleavageSpecificity cleaveSpecificity, List<DigestionMotif> motifList, Modification cleavageMod = null) :
             base(name, cleaveSpecificity, motifList, cleavageMod)
         {
-            Name = name;
             CleavageSpecificity = cleaveSpecificity;
             DigestionMotifs = motifList;
         }

--- a/mzLib/Transcriptomics/NucleicAcid.cs
+++ b/mzLib/Transcriptomics/NucleicAcid.cs
@@ -324,6 +324,7 @@ namespace Transcriptomics
 
         public bool Equals(NucleicAcid? other)
         {
+            // interface equals first because it does null and reference checks
             return (this as IBioPolymer).Equals(other)
                    && _5PrimeTerminus.Equals(other._5PrimeTerminus)
                    && _3PrimeTerminus.Equals(other._3PrimeTerminus);

--- a/mzLib/Transcriptomics/NucleicAcid.cs
+++ b/mzLib/Transcriptomics/NucleicAcid.cs
@@ -324,25 +324,18 @@ namespace Transcriptomics
 
         public bool Equals(NucleicAcid? other)
         {
-            if (ReferenceEquals(null, other)) return false;
-            if (ReferenceEquals(this, other)) return true;
-            return _sequence == other._sequence
+            return (this as IBioPolymer).Equals(other)
                    && _5PrimeTerminus.Equals(other._5PrimeTerminus)
                    && _3PrimeTerminus.Equals(other._3PrimeTerminus);
         }
 
         public override bool Equals(object? obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((NucleicAcid)obj);
-        }
-
-        public bool Equals(IBioPolymer other)
-        {
-            var castedOther = other as NucleicAcid;
-            return(Equals(castedOther));
+            if (obj is NucleicAcid oligo)
+            {
+                return Equals(oligo);
+            }
+            return false;
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
Last IEquality adjustment broke a few things in MetaMorpheus. This PR rectifies that and adds default interface implementations, pointing the derived classes at that default. 

- Added `IEquatable<IBioPolymer>` and `IEquatable<IBioPolymerWithSetMods>` implementations in `IBioPolymer.cs` and `IBioPolymerWithSetMods.cs`.
- Updated `Equals` and `GetHashCode` methods in `Protein.cs` and `PeptideWithSetModifications.cs` to use the new interface.
- Added new test cases in `TestOligoWithSetMods.cs` to verify equality and inequality.
- Updated `Equals` and `GetHashCode` methods in `OligoWithSetMods.cs` and `NucleicAcid.cs` to use the new interface.