### PR TITLE
Changing the github actions workflow to test integration with MetaMorpheus

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,6 +20,10 @@ jobs:
       run: cd mzLib && dotnet restore
     - name: Build
       run: cd mzLib && dotnet build --no-restore
+    - name: Build (Test)
+      run: cd mzLib && dotnet build --no-restore ./Test/Test.csproj
+    - name: Build (TestFlashLFQ)
+      run: cd mzLib && dotnet build --no-restore ./TestFlashLFQ/TestFlashLFQ.csproj
     - name: Add coverlet collector (Test)
       run: cd mzLib && dotnet add Test/Test.csproj package coverlet.collector -v 6.0.2
     - name: Add coverlet collector (TestFlashLFQ)

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Build
       run: cd mzLib && dotnet build --no-restore
     - name: Pack
-      run: dotnet pack --no-build --no-restore -c Debug
+      run: cd mzLib && nuget pack mzLib.nuspec -Prop Configuration=Debug
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -59,10 +59,21 @@ jobs:
         path: ./MetaMorpheus
         repository: smith-chem-wisc/MetaMorpheus 
         ref: master
-    - name: Restore MetaMorpheus
-      run: cd ./MetaMorpheus/MetaMorpheus && dotnet restore
-    - name: 
-      run: dotnet nuget locals all -l
+    - name: Delete mzLib and restore MetaMorpheus dependencies
+      run: |
+        cd ./MetaMorpheus/MetaMorpheus;
+        dotnet remove CMD package mzLib;
+        dotnet remove GUI package mzLib;
+        dotnet remove GuiFunctions package mzLib;
+        dotnet remove EngineLayer package mzLib;
+        dotnet remove Test package mzLib;
+        dotnet remove TaskLayer package mzLib;
+        dotnet restore
+    - name: Delete mzLib, replace with local
+      run: |
+        $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
+        $mzlibVersion = $mzlibMatch.Matches[0].Value;
+        echo "mzLib version: $mzlibVersion";
     - name: Build MetaMorpheus
       run: cd ./MetaMorpheus/MetaMorpheus && dotnet build --no-restore
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -47,16 +47,16 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 8.0.x
-    - name: Restore dependencies
-      run: cd mzLib && dotnet restore
-    - name: Build
-      run: cd mzLib && dotnet build --no-restore --configuration Release
-    - name: Pack
-      run: cd mzLib && nuget pack mzLib.nuspec
+    # - name: Restore dependencies
+    #   run: cd mzLib && dotnet restore
+    # - name: Build
+    #   run: cd mzLib && dotnet build --no-restore --configuration Release
+    # - name: Pack
+    #   run: cd mzLib && nuget pack mzLib.nuspec
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:
-        path: MetaMorpheus
+        path: ./MetaMorpheus
         name: smith-chem-wisc/MetaMorpheus 
         ref: master
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,37 +7,33 @@ on:
     branches: [ master ]
 
 jobs:
-  #build:
-    # runs-on: windows-latest
-    # timeout-minutes: 15
-    # steps:
-    # - uses: actions/checkout@v2
-    # - name: Set up .NET
-    #   uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: 8.0.x
-    # - name: Restore dependencies
-    #   run: cd mzLib && dotnet restore
-    # - name: Build
-    #   run: cd mzLib && dotnet build --no-restore
-    # - name: Build (Test)
-    #   run: cd mzLib && dotnet build --no-restore ./Test/Test.csproj
-    # - name: Build (TestFlashLFQ)
-    #   run: cd mzLib && dotnet build --no-restore ./TestFlashLFQ/TestFlashLFQ.csproj
-    # - name: Add coverlet collector (Test)
-    #   run: cd mzLib && dotnet add Test/Test.csproj package coverlet.collector -v 6.0.2
-    # - name: Add coverlet collector (TestFlashLFQ)
-    #   run: cd mzLib && dotnet add TestFlashLFQ/TestFlashLFQ.csproj package coverlet.collector -v 6.0.2
-    # - name: Test
-    #   run: cd mzLib && dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura ./Test/Test.csproj
-    # - name: TestFlashLFQ
-    #   run: cd mzLib && dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura ./TestFlashLFQ/TestFlashLFQ.csproj
-    # - name: Upload coverage to Codecov
-    #   uses: codecov/codecov-action@v4
-    #   env:
-    #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    #     verbose: true
-    #     files: mzLib/Test*/TestResults/*/coverage.cobertura.xml
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: cd mzLib && dotnet restore
+    - name: Build
+      run: cd mzLib && dotnet build --no-restore
+    - name: Add coverlet collector (Test)
+      run: cd mzLib && dotnet add Test/Test.csproj package coverlet.collector -v 6.0.2
+    - name: Add coverlet collector (TestFlashLFQ)
+      run: cd mzLib && dotnet add TestFlashLFQ/TestFlashLFQ.csproj package coverlet.collector -v 6.0.2
+    - name: Test
+      run: cd mzLib && dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura ./Test/Test.csproj
+    - name: TestFlashLFQ
+      run: cd mzLib && dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura ./TestFlashLFQ/TestFlashLFQ.csproj
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true
+        files: mzLib/Test*/TestResults/*/coverage.cobertura.xml
   package:
     runs-on: windows-latest
     timeout-minutes: 15
@@ -54,7 +50,7 @@ jobs:
     - name: Change mzLib version, pack, add source
       run: |
         cd mzLib;
-        (Get-Content mzLib.nuspec) -replace "\<version\>(.*)\</version\>", "<version>9.9.9</version>" | Set-Content mzLib.nuspec;
+        (Get-Content mzLib.nuspec) -replace "\<version\>(.*)\</version\>", "<version>9.9.9</version>" | Set-Content mzLib.nuspec; 
         $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
         $mzlibVersion = $mzlibMatch.Matches[0].Value;
         echo "mzLib version number changed to: $mzlibVersion";
@@ -84,21 +80,6 @@ jobs:
         dotnet remove TaskLayer package mzLib;
         dotnet add TaskLayer package mzLib -v 9.9.9;
         dotnet restore;
-    # - name: Delete mzLib, replace with local
-    #   run: |
-    #     cd mzLib;
-    #     $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
-    #     $mzlibVersion = $mzlibMatch.Matches[0].Value;
-    #     echo "mzLib version: $mzlibVersion";
-    #     cd ../MetaMorpheus/MetaMorpheus;
-    #     dotnet add CMD package mzLib -v $mzlibVersion -s ../../packages;
-    #     dotnet add CMD package mzLib -v $mzlibVersion -s ../../packages;
-    #     dotnet add GUI package mzLib -v $mzlibVersion -s ../../packages;
-    #     dotnet add GuiFunctions package mzLib -v $mzlibVersion -s ../../packages;
-    #     dotnet add EngineLayer package mzLib -v $mzlibVersion -s ../../packages;
-    #     dotnet add Test package mzLib -v $mzlibVersion -s ../../packages;
-    #     dotnet add TaskLayer package mzLib -v $mzlibVersion -s ../../packages;
-    #     dotnet restore;
     - name: Build MetaMorpheus
       run: cd ./MetaMorpheus/MetaMorpheus && dotnet build --no-restore
     - name: Test

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,7 +56,13 @@ jobs:
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:
-        path: ../../MetaMorpheus
+        path: ../MetaMorpheus
         repository: smith-chem-wisc/MetaMorpheus 
         ref: master
+    - name: Restore MetaMorpheus
+      run: cd ../MetaMorpheus && dotnet restore
+    - name: Swap in local mzLib
+      run: dotnet nuget locals all -l
+    - name: Build MetaMorpheus
+      run: cd ../MetaMorpheus && dotnet build --no-restore
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,37 +7,37 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-    runs-on: windows-latest
-    timeout-minutes: 15
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 8.0.x
-    - name: Restore dependencies
-      run: cd mzLib && dotnet restore
-    - name: Build
-      run: cd mzLib && dotnet build --no-restore
-    - name: Build (Test)
-      run: cd mzLib && dotnet build --no-restore ./Test/Test.csproj
-    - name: Build (TestFlashLFQ)
-      run: cd mzLib && dotnet build --no-restore ./TestFlashLFQ/TestFlashLFQ.csproj
-    - name: Add coverlet collector (Test)
-      run: cd mzLib && dotnet add Test/Test.csproj package coverlet.collector -v 6.0.2
-    - name: Add coverlet collector (TestFlashLFQ)
-      run: cd mzLib && dotnet add TestFlashLFQ/TestFlashLFQ.csproj package coverlet.collector -v 6.0.2
-    - name: Test
-      run: cd mzLib && dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura ./Test/Test.csproj
-    - name: TestFlashLFQ
-      run: cd mzLib && dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura ./TestFlashLFQ/TestFlashLFQ.csproj
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        verbose: true
-        files: mzLib/Test*/TestResults/*/coverage.cobertura.xml
+  #build:
+    # runs-on: windows-latest
+    # timeout-minutes: 15
+    # steps:
+    # - uses: actions/checkout@v2
+    # - name: Set up .NET
+    #   uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: 8.0.x
+    # - name: Restore dependencies
+    #   run: cd mzLib && dotnet restore
+    # - name: Build
+    #   run: cd mzLib && dotnet build --no-restore
+    # - name: Build (Test)
+    #   run: cd mzLib && dotnet build --no-restore ./Test/Test.csproj
+    # - name: Build (TestFlashLFQ)
+    #   run: cd mzLib && dotnet build --no-restore ./TestFlashLFQ/TestFlashLFQ.csproj
+    # - name: Add coverlet collector (Test)
+    #   run: cd mzLib && dotnet add Test/Test.csproj package coverlet.collector -v 6.0.2
+    # - name: Add coverlet collector (TestFlashLFQ)
+    #   run: cd mzLib && dotnet add TestFlashLFQ/TestFlashLFQ.csproj package coverlet.collector -v 6.0.2
+    # - name: Test
+    #   run: cd mzLib && dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura ./Test/Test.csproj
+    # - name: TestFlashLFQ
+    #   run: cd mzLib && dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura ./TestFlashLFQ/TestFlashLFQ.csproj
+    # - name: Upload coverage to Codecov
+    #   uses: codecov/codecov-action@v4
+    #   env:
+    #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    #     verbose: true
+    #     files: mzLib/Test*/TestResults/*/coverage.cobertura.xml
   package:
     runs-on: windows-latest
     timeout-minutes: 15

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,7 +56,7 @@ jobs:
         cd mzLib && nuget pack mzLib.nuspec;
         $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
         $mzlibVersion = $mzlibMatch.Matches[0].Value;
-        nuget add "mzLib.$mzlibVersion.nupkg" -Source ../../packages
+        nuget add "mzLib.$mzlibVersion.nupkg" -Source ../packages
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -59,7 +59,9 @@ jobs:
         $mzlibVersion = $mzlibMatch.Matches[0].Value;
         echo "mzLib version number changed to: $mzlibVersion";
         nuget pack;
-        dotnet nuget add source ./;
+        $currentFolder = pwd;
+        dotnet nuget add source $currentFolder;
+        dotnet nuget list source;
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,7 +56,7 @@ jobs:
         cd mzLib && nuget pack mzLib.nuspec;
         $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
         $mzlibVersion = $mzlibMatch.Matches[0].Value;
-        nuget add "mzLib.$mzlibVersion.nupkg -Source ./packages
+        nuget add "mzLib.$mzlibVersion.nupkg" -Source ./packages
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -52,14 +52,16 @@ jobs:
     - name: Build
       run: cd mzLib && dotnet build --no-restore --configuration Release
     - name: Pack
-      run: cd mzLib && nuget pack mzLib.nuspec
+      run: |
+        cd mzLib && nuget pack mzLib.nuspec;
+        nuget add mzLib.*.nupkg -Source ./packages
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:
         path: ./MetaMorpheus
         repository: smith-chem-wisc/MetaMorpheus 
         ref: master
-    - name: Delete mzLib and restore MetaMorpheus dependencies
+    - name: Delete mzLib dependencies
       run: |
         cd ./MetaMorpheus/MetaMorpheus;
         dotnet remove CMD package mzLib;
@@ -68,13 +70,21 @@ jobs:
         dotnet remove EngineLayer package mzLib;
         dotnet remove Test package mzLib;
         dotnet remove TaskLayer package mzLib;
-        dotnet restore
     - name: Delete mzLib, replace with local
       run: |
         cd mzLib;
         $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
         $mzlibVersion = $mzlibMatch.Matches[0].Value;
         echo "mzLib version: $mzlibVersion";
+        cd ../MetaMorpheus/MetaMorpheus;
+        dotnet add CMD package mzLib -v $mzlibVersion -s ./packages;
+        dotnet add CMD package mzLib -v $mzlibVersion -s ./packages;
+        dotnet add GUI package mzLib -v $mzlibVersion -s ./packages;
+        dotnet add GuiFunctions package mzLib -v $mzlibVersion -s ./packages;
+        dotnet add EngineLayer package mzLib -v $mzlibVersion -s ./packages;
+        dotnet add Test package mzLib -v $mzlibVersion -s ./packages;
+        dotnet add TaskLayer package mzLib -v $mzlibVersion -s ./packages;
+        dotnet restore;
     - name: Build MetaMorpheus
       run: cd ./MetaMorpheus/MetaMorpheus && dotnet build --no-restore
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -38,3 +38,19 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
         files: mzLib/Test*/TestResults/*/coverage.cobertura.xml
+  package:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: cd mzLib && dotnet restore
+    - name: Build
+      run: cd mzLib && dotnet build --no-restore
+    - name: Pack
+      run: cd mzLib && dotnet pack --no-build --no-restore -c Release
+

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -54,7 +54,9 @@ jobs:
     - name: Pack
       run: |
         cd mzLib && nuget pack mzLib.nuspec;
-        nuget add mzLib.*.nupkg -Source ./packages
+        $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
+        $mzlibVersion = $mzlibMatch.Matches[0].Value;
+        nuget add "mzLib.$mzlibVersion.nupkg -Source ./packages
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -50,9 +50,9 @@ jobs:
     - name: Restore dependencies
       run: cd mzLib && dotnet restore
     - name: Build
-      run: cd mzLib && dotnet build --no-restore
+      run: cd mzLib && dotnet build --no-restore --configuration Release
     - name: Pack
-      run: cd mzLib && nuget pack mzLib.nuspec -Prop Configuration=Debug
+      run: cd mzLib && nuget pack mzLib.nuspec
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -52,5 +52,10 @@ jobs:
     - name: Build
       run: cd mzLib && dotnet build --no-restore
     - name: Pack
-      run: cd mzLib && dotnet pack --no-build --no-restore -c Release
+      run: cd mzLib && dotnet pack --no-build --no-restore -c Debug
+    - name: Clone MetaMorpheus
+      uses: actions/checkout@master
+      with:
+        name: smith-chem-wisc/MetaMorpheus    <-- clone https://github.com/org1/repo1
+        ref: refs/heads/release/v1
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -57,8 +57,9 @@ jobs:
         (Get-Content mzLib.nuspec) -replace "\<version\>(.*)\</version\>", "<version>9.9.9</version>" | Set-Content mzLib.nuspec;
         $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
         $mzlibVersion = $mzlibMatch.Matches[0].Value;
-        echo "mzLib version: $mzlibVersion";
-        dotnet nuget add source ./
+        echo "mzLib version number changed to: $mzlibVersion";
+        nuget pack;
+        dotnet nuget add source ./;
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -38,7 +38,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
         files: mzLib/Test*/TestResults/*/coverage.cobertura.xml
-  package:
+  integration:
     runs-on: windows-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -53,40 +53,49 @@ jobs:
       run: cd mzLib && dotnet build --no-restore --configuration Release
     - name: Pack
       run: |
-        cd mzLib && nuget pack mzLib.nuspec;
+        cd mzLib;
+        (Get-Content mzLib.nuspec) -replace "\<version\>(.*)\</version\>", "<version>9.9.9<version\> | Set-Content mzLib.nuspec;
         $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
         $mzlibVersion = $mzlibMatch.Matches[0].Value;
-        nuget add "mzLib.$mzlibVersion.nupkg" -Source ../packages
+        echo "mzLib version: $mzlibVersion";
+        dotnet nuget add source ./
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:
         path: ./MetaMorpheus
         repository: smith-chem-wisc/MetaMorpheus 
         ref: master
-    - name: Delete mzLib dependencies
+    - name: Change mzLib to local and restore
       run: |
         cd ./MetaMorpheus/MetaMorpheus;
         dotnet remove CMD package mzLib;
+        dotnet add CMD package mzLib -v 9.9.9;
         dotnet remove GUI package mzLib;
+        dotnet add GUI package mzLib -v 9.9.9;
         dotnet remove GuiFunctions package mzLib;
+        dotnet add GuiFunctions package mzLib -v 9.9.9;
         dotnet remove EngineLayer package mzLib;
+        dotnet add EngineLayer package mzLib -v 9.9.9;
         dotnet remove Test package mzLib;
+        dotnet add Test package mzLib -v 9.9.9;
         dotnet remove TaskLayer package mzLib;
-    - name: Delete mzLib, replace with local
-      run: |
-        cd mzLib;
-        $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
-        $mzlibVersion = $mzlibMatch.Matches[0].Value;
-        echo "mzLib version: $mzlibVersion";
-        cd ../MetaMorpheus/MetaMorpheus;
-        dotnet add CMD package mzLib -v $mzlibVersion -s ../../packages;
-        dotnet add CMD package mzLib -v $mzlibVersion -s ../../packages;
-        dotnet add GUI package mzLib -v $mzlibVersion -s ../../packages;
-        dotnet add GuiFunctions package mzLib -v $mzlibVersion -s ../../packages;
-        dotnet add EngineLayer package mzLib -v $mzlibVersion -s ../../packages;
-        dotnet add Test package mzLib -v $mzlibVersion -s ../../packages;
-        dotnet add TaskLayer package mzLib -v $mzlibVersion -s ../../packages;
+        dotnet add TaskLayer package mzLib -v 9.9.9;
         dotnet restore;
+    # - name: Delete mzLib, replace with local
+    #   run: |
+    #     cd mzLib;
+    #     $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
+    #     $mzlibVersion = $mzlibMatch.Matches[0].Value;
+    #     echo "mzLib version: $mzlibVersion";
+    #     cd ../MetaMorpheus/MetaMorpheus;
+    #     dotnet add CMD package mzLib -v $mzlibVersion -s ../../packages;
+    #     dotnet add CMD package mzLib -v $mzlibVersion -s ../../packages;
+    #     dotnet add GUI package mzLib -v $mzlibVersion -s ../../packages;
+    #     dotnet add GuiFunctions package mzLib -v $mzlibVersion -s ../../packages;
+    #     dotnet add EngineLayer package mzLib -v $mzlibVersion -s ../../packages;
+    #     dotnet add Test package mzLib -v $mzlibVersion -s ../../packages;
+    #     dotnet add TaskLayer package mzLib -v $mzlibVersion -s ../../packages;
+    #     dotnet restore;
     - name: Build MetaMorpheus
       run: cd ./MetaMorpheus/MetaMorpheus && dotnet build --no-restore
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,6 +56,7 @@ jobs:
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:
+        path: MetaMorpheus
         name: smith-chem-wisc/MetaMorpheus 
         ref: master
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Change mzLib version, pack, add source
       run: |
         cd mzLib;
-        (Get-Content mzLib.nuspec) -replace "\<version\>(.*)\</version\>", "<version>9.9.9<version\> | Set-Content mzLib.nuspec;
+        (Get-Content mzLib.nuspec) -replace "\<version\>(.*)\</version\>", "<version>9.9.9<version\>" | Set-Content mzLib.nuspec;
         $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
         $mzlibVersion = $mzlibMatch.Matches[0].Value;
         echo "mzLib version: $mzlibVersion";
@@ -98,4 +98,7 @@ jobs:
     #     dotnet restore;
     - name: Build MetaMorpheus
       run: cd ./MetaMorpheus/MetaMorpheus && dotnet build --no-restore
+    - name: Test
+      run: cd ./MetaMorpheus/MetaMorpheus && dotnet test --no-build --verbosity normal
+
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,6 +56,6 @@ jobs:
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:
-        name: smith-chem-wisc/MetaMorpheus    <-- clone https://github.com/org1/repo1
+        name: smith-chem-wisc/MetaMorpheus 
         ref: refs/heads/release/v1
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,13 +56,13 @@ jobs:
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:
-        path: ../MetaMorpheus
+        path: ./MetaMorpheus
         repository: smith-chem-wisc/MetaMorpheus 
         ref: master
     - name: Restore MetaMorpheus
-      run: cd ../MetaMorpheus && dotnet restore
+      run: cd ./MetaMorpheus && dotnet restore
     - name: Swap in local mzLib
       run: dotnet nuget locals all -l
     - name: Build MetaMorpheus
-      run: cd ../MetaMorpheus && dotnet build --no-restore
+      run: cd ./MetaMorpheus && dotnet build --no-restore
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -52,10 +52,10 @@ jobs:
     - name: Build
       run: cd mzLib && dotnet build --no-restore
     - name: Pack
-      run: cd mzLib && dotnet pack --no-build --no-restore -c Debug
+      run: dotnet pack --no-build --no-restore -c Debug
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:
         name: smith-chem-wisc/MetaMorpheus 
-        ref: refs/heads/release/v1
+        ref: master
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -47,12 +47,12 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 8.0.x
-    # - name: Restore dependencies
-    #   run: cd mzLib && dotnet restore
-    # - name: Build
-    #   run: cd mzLib && dotnet build --no-restore --configuration Release
-    # - name: Pack
-    #   run: cd mzLib && nuget pack mzLib.nuspec
+    - name: Restore dependencies
+      run: cd mzLib && dotnet restore
+    - name: Build
+      run: cd mzLib && dotnet build --no-restore --configuration Release
+    - name: Pack
+      run: cd mzLib && nuget pack mzLib.nuspec
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -71,6 +71,7 @@ jobs:
         dotnet restore
     - name: Delete mzLib, replace with local
       run: |
+        cd mzLib;
         $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
         $mzlibVersion = $mzlibMatch.Matches[0].Value;
         echo "mzLib version: $mzlibVersion";

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -51,7 +51,7 @@ jobs:
       run: cd mzLib && dotnet restore
     - name: Build
       run: cd mzLib && dotnet build --no-restore --configuration Release
-    - name: Pack
+    - name: Change mzLib version, pack, add source
       run: |
         cd mzLib;
         (Get-Content mzLib.nuspec) -replace "\<version\>(.*)\</version\>", "<version>9.9.9<version\> | Set-Content mzLib.nuspec;
@@ -65,7 +65,7 @@ jobs:
         path: ./MetaMorpheus
         repository: smith-chem-wisc/MetaMorpheus 
         ref: master
-    - name: Change mzLib to local and restore
+    - name: Change MetaMorpheus mzLib version and restore
       run: |
         cd ./MetaMorpheus/MetaMorpheus;
         dotnet remove CMD package mzLib;

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -60,9 +60,9 @@ jobs:
         repository: smith-chem-wisc/MetaMorpheus 
         ref: master
     - name: Restore MetaMorpheus
-      run: cd ./MetaMorpheus && dotnet restore
-    - name: Swap in local mzLib
+      run: cd ./MetaMorpheus/MetaMorpheus && dotnet restore
+    - name: 
       run: dotnet nuget locals all -l
     - name: Build MetaMorpheus
-      run: cd ./MetaMorpheus && dotnet build --no-restore
+      run: cd ./MetaMorpheus/MetaMorpheus && dotnet build --no-restore
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:
-        path: ./MetaMorpheus
-        name: smith-chem-wisc/MetaMorpheus 
+        path: ../../MetaMorpheus
+        repository: smith-chem-wisc/MetaMorpheus 
         ref: master
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Change mzLib version, pack, add source
       run: |
         cd mzLib;
-        (Get-Content mzLib.nuspec) -replace "\<version\>(.*)\</version\>", "<version>9.9.9<version\>" | Set-Content mzLib.nuspec;
+        (Get-Content mzLib.nuspec) -replace "\<version\>(.*)\</version\>", "<version>9.9.9</version>" | Set-Content mzLib.nuspec;
         $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
         $mzlibVersion = $mzlibMatch.Matches[0].Value;
         echo "mzLib version: $mzlibVersion";

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,7 +56,7 @@ jobs:
         cd mzLib && nuget pack mzLib.nuspec;
         $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
         $mzlibVersion = $mzlibMatch.Matches[0].Value;
-        nuget add "mzLib.$mzlibVersion.nupkg" -Source ./packages
+        nuget add "mzLib.$mzlibVersion.nupkg" -Source ../../packages
     - name: Clone MetaMorpheus
       uses: actions/checkout@master
       with:
@@ -79,13 +79,13 @@ jobs:
         $mzlibVersion = $mzlibMatch.Matches[0].Value;
         echo "mzLib version: $mzlibVersion";
         cd ../MetaMorpheus/MetaMorpheus;
-        dotnet add CMD package mzLib -v $mzlibVersion -s ./packages;
-        dotnet add CMD package mzLib -v $mzlibVersion -s ./packages;
-        dotnet add GUI package mzLib -v $mzlibVersion -s ./packages;
-        dotnet add GuiFunctions package mzLib -v $mzlibVersion -s ./packages;
-        dotnet add EngineLayer package mzLib -v $mzlibVersion -s ./packages;
-        dotnet add Test package mzLib -v $mzlibVersion -s ./packages;
-        dotnet add TaskLayer package mzLib -v $mzlibVersion -s ./packages;
+        dotnet add CMD package mzLib -v $mzlibVersion -s ../../packages;
+        dotnet add CMD package mzLib -v $mzlibVersion -s ../../packages;
+        dotnet add GUI package mzLib -v $mzlibVersion -s ../../packages;
+        dotnet add GuiFunctions package mzLib -v $mzlibVersion -s ../../packages;
+        dotnet add EngineLayer package mzLib -v $mzlibVersion -s ../../packages;
+        dotnet add Test package mzLib -v $mzlibVersion -s ../../packages;
+        dotnet add TaskLayer package mzLib -v $mzlibVersion -s ../../packages;
         dotnet restore;
     - name: Build MetaMorpheus
       run: cd ./MetaMorpheus/MetaMorpheus && dotnet build --no-restore


### PR DESCRIPTION
This PR adds a second job to the github actions workflow. 

The new job packs a local mzLib nuget, pulls the current master of MetaMorpheus, installs the local version of mzLib, then runs all tests in MetaMorpheus 

Addresses issue #816 