### PR TITLE
IEquality hot fix hot fix

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -38,3 +38,55 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
         files: mzLib/Test*/TestResults/*/coverage.cobertura.xml
+  integration:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: cd mzLib && dotnet restore
+    - name: Build
+      run: cd mzLib && dotnet build --no-restore --configuration Release
+    - name: Change mzLib version, pack, add source
+      run: |
+        cd mzLib;
+        (Get-Content mzLib.nuspec) -replace "\<version\>(.*)\</version\>", "<version>9.9.9</version>" | Set-Content mzLib.nuspec; 
+        $mzlibMatch = Select-String -Path mzLib.nuspec -Pattern "(?<=\<version\>)(.*)(?=\</version)";
+        $mzlibVersion = $mzlibMatch.Matches[0].Value;
+        echo "mzLib version number changed to: $mzlibVersion";
+        nuget pack;
+        $currentFolder = pwd;
+        dotnet nuget add source $currentFolder;
+        dotnet nuget list source;
+    - name: Clone MetaMorpheus
+      uses: actions/checkout@master
+      with:
+        path: ./MetaMorpheus
+        repository: smith-chem-wisc/MetaMorpheus 
+        ref: master
+    - name: Change MetaMorpheus mzLib version and restore
+      run: |
+        cd ./MetaMorpheus/MetaMorpheus;
+        dotnet remove CMD package mzLib;
+        dotnet add CMD package mzLib -v 9.9.9;
+        dotnet remove GUI package mzLib;
+        dotnet add GUI package mzLib -v 9.9.9;
+        dotnet remove GuiFunctions package mzLib;
+        dotnet add GuiFunctions package mzLib -v 9.9.9;
+        dotnet remove EngineLayer package mzLib;
+        dotnet add EngineLayer package mzLib -v 9.9.9;
+        dotnet remove Test package mzLib;
+        dotnet add Test package mzLib -v 9.9.9;
+        dotnet remove TaskLayer package mzLib;
+        dotnet add TaskLayer package mzLib -v 9.9.9;
+        dotnet restore;
+    - name: Build MetaMorpheus
+      run: cd ./MetaMorpheus/MetaMorpheus && dotnet build --no-restore
+    - name: Test
+      run: cd ./MetaMorpheus/MetaMorpheus && dotnet test --no-build --verbosity normal
+
+

--- a/mzLib/Omics/IBioPolymerWithSetMods.cs
+++ b/mzLib/Omics/IBioPolymerWithSetMods.cs
@@ -44,29 +44,6 @@ namespace Omics
         char this[int zeroBasedIndex] => BaseSequence[zeroBasedIndex];
         IBioPolymer Parent { get; }
 
-        /// <summary>
-        /// Default Equals Method for IBioPolymerWithSetMods
-        /// </summary>
-        /// <param name="other"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// Different parent but same sequence and digestion condition => are equal
-        /// Different Digestion agent but same sequence => are not equal (this is for multi-protease analysis in MetaMorpheus)
-        /// </remarks>
-        bool IEquatable<IBioPolymerWithSetMods>.Equals(IBioPolymerWithSetMods? other)
-        {
-            if (other is null) return false;
-            if (ReferenceEquals(this, other)) return true;
-            if (other.GetType() != GetType()) return false;
-
-            // for those constructed from sequence and mods only
-            if (Parent is null && other.Parent is null)
-                return FullSequence.Equals(other.FullSequence);
-
-            return FullSequence == other.FullSequence
-                && Equals(DigestionParams?.DigestionAgent, other.DigestionParams?.DigestionAgent);
-        }
-
         public void Fragment(DissociationType dissociationType, FragmentationTerminus fragmentationTerminus,
             List<Product> products);
 

--- a/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -898,8 +898,7 @@ namespace Proteomics.ProteolyticDigestion
             // interface equals first because it does null and reference checks
             return (this as IBioPolymerWithSetMods).Equals(other)
                    && OneBasedStartResidue == other!.OneBasedStartResidue
-                   && (Parent?.Accession == null && other?.Parent.Accession == null 
-                        || other.Parent.Accession.Equals(Parent?.Accession));
+                   && Equals(Parent?.Accession, other.Parent?.Accession); 
         }
 
         public override int GetHashCode()

--- a/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -898,7 +898,8 @@ namespace Proteomics.ProteolyticDigestion
             // interface equals first because it does null and reference checks
             return (this as IBioPolymerWithSetMods).Equals(other)
                    && OneBasedStartResidue == other!.OneBasedStartResidue
-                   && Equals(Parent, other.Parent);
+                   && (Parent?.Accession == null && other?.Parent.Accession == null 
+                        || other.Parent.Accession.Equals(Parent?.Accession));
         }
 
         public override int GetHashCode()

--- a/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -16,7 +16,7 @@ namespace Proteomics.ProteolyticDigestion
     [Serializable]
     public class PeptideWithSetModifications : ProteolyticPeptide, IBioPolymerWithSetMods, IEquatable<PeptideWithSetModifications>
     {
-        public string FullSequence { get; private set; } //sequence with modifications
+        public string FullSequence { get; init; } //sequence with modifications
         public int NumFixedMods { get; }
         // Parameter to store the full sequence of the corresponding Target or Decoy peptide
         // If the peptide in question is a decoy, this pairs it to the target it was generated from
@@ -885,10 +885,9 @@ namespace Proteomics.ProteolyticDigestion
         }
 
         #region IEquatable
-        
+
         /// <summary>
-        /// Different parent but same sequence and digestion condition => are not equal.
-        /// Different Digestion agent but same sequence => are not equal (this is for multi-protease analysis in MetaMorpheus)
+        /// Peptides are equal if they have the same full sequence, parent, and digestion agent
         /// </summary>
         public override bool Equals(object obj)
         {
@@ -900,14 +899,12 @@ namespace Proteomics.ProteolyticDigestion
         }
 
         /// <summary>
-        /// Different parent but same sequence and digestion condition => are not equal.
-        /// Different Digestion agent but same sequence => are not equal (this is for multi-protease analysis in MetaMorpheus)
+        /// Peptides are equal if they have the same full sequence, parent, and digestion agent
         /// </summary>
         public bool Equals(IBioPolymerWithSetMods other) => Equals(other as PeptideWithSetModifications);
 
         /// <summary>
-        /// Different parent but same sequence and digestion condition => are not equal.
-        /// Different Digestion agent but same sequence => are not equal (this is for multi-protease analysis in MetaMorpheus)
+        /// Peptides are equal if they have the same full sequence, parent, and digestion agent
         /// </summary>
         public bool Equals(PeptideWithSetModifications other)
         {

--- a/mzLib/Test/TestPeptideWithSetMods.cs
+++ b/mzLib/Test/TestPeptideWithSetMods.cs
@@ -1195,6 +1195,34 @@ namespace Test
         }
 
         [Test]
+        public static void TestPeptideWithSetModsEquals()
+        {
+            // Create two proteins
+            Protein protein1 = new Protein("SEQUENCEK", "accession1");
+            Protein protein2 = new Protein("SEQUENCEK", "accession2");
+
+            // Create digestion parameters
+            DigestionParams digestionParams = new DigestionParams(protease: "trypsin", maxMissedCleavages: 0, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+
+            // Digest the proteins to get peptides
+            PeptideWithSetModifications peptide1 = protein1.Digest(digestionParams, new List<Modification>(), new List<Modification>()).First();
+            PeptideWithSetModifications peptide2 = protein2.Digest(digestionParams, new List<Modification>(), new List<Modification>()).First();
+
+            // Test equality
+            Assert.IsTrue(!peptide1.Equals(peptide2));
+            Assert.IsTrue(!peptide1.Equals((object)peptide2));
+            Assert.AreNotEqual(peptide1.GetHashCode(), peptide2.GetHashCode());
+
+            // Test inequality with different start residue
+            PeptideWithSetModifications peptide3 = new PeptideWithSetModifications(protein1, digestionParams, 2, 9, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+            Assert.IsFalse(peptide1.Equals(peptide3));
+
+            // Test inequality with different parent accession
+            PeptideWithSetModifications peptide4 = new PeptideWithSetModifications(protein2, digestionParams, 1, 9, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+            Assert.IsFalse(peptide1.Equals(peptide4));
+        }
+
+        [Test]
         public static void TestIBioPolymerWithSetModsModificationFromFullSequence()
         {
             Dictionary<string, Modification> un = new Dictionary<string, Modification>();

--- a/mzLib/Test/TestPeptideWithSetMods.cs
+++ b/mzLib/Test/TestPeptideWithSetMods.cs
@@ -71,6 +71,8 @@ namespace Test
             Assert.That(!peptide.Equals(oligo));
             Assert.That(!((IBioPolymerWithSetMods)oligo).Equals(peptide));
             Assert.That(!((IBioPolymerWithSetMods)peptide).Equals(oligo));
+            Assert.That(!((object)oligo).Equals(peptide));
+            Assert.That(!((object)peptide).Equals(oligo));
         }
 
         [Test]
@@ -1208,9 +1210,13 @@ namespace Test
             PeptideWithSetModifications peptide1 = protein1.Digest(digestionParams, new List<Modification>(), new List<Modification>()).First();
             PeptideWithSetModifications peptide2 = protein2.Digest(digestionParams, new List<Modification>(), new List<Modification>()).First();
 
-            // Test equality
+            // Test equality - same peptide
+            Assert.IsTrue(peptide1.Equals(peptide1));
+
+            // different peptide
             Assert.IsTrue(!peptide1.Equals(peptide2));
             Assert.IsTrue(!peptide1.Equals((object)peptide2));
+            Assert.IsTrue(!peptide1.Equals((IBioPolymerWithSetMods)peptide2));
             Assert.AreNotEqual(peptide1.GetHashCode(), peptide2.GetHashCode());
 
             // Test inequality with different start residue
@@ -1220,7 +1226,14 @@ namespace Test
             // Test inequality with different parent accession
             PeptideWithSetModifications peptide4 = new PeptideWithSetModifications(protein2, digestionParams, 1, 9, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
             Assert.IsFalse(peptide1.Equals(peptide4));
+
+            // all fail on null
+            Assert.That(!peptide1.Equals(null));
+            Assert.That(!peptide1.Equals((object)null));
+            Assert.That(!peptide1.Equals((PeptideWithSetModifications)null));
         }
+
+       
 
         [Test]
         public static void TestIBioPolymerWithSetModsModificationFromFullSequence()

--- a/mzLib/Test/Transcriptomics/TestOligoWithSetMods.cs
+++ b/mzLib/Test/Transcriptomics/TestOligoWithSetMods.cs
@@ -128,11 +128,11 @@ namespace Test.Transcriptomics
         {
             var digestionParams = new RnaDigestionParams(rnase: enzyme, minLength: 1, maxMissedCleavages: 0);
 
-            var oligo1 = new RNA(sequence1)
+            var oligo1 = new RNA(sequence1, "", "rna1", "", "")
                 .Digest(digestionParams, [], [])
                 .First();
 
-            var oligo2 = new RNA(sequence2)
+            var oligo2 = new RNA(sequence2, "", "rna3", "", "")
                 .Digest(digestionParams, [], [])
                 .First();
 

--- a/mzLib/Test/Transcriptomics/TestOligoWithSetMods.cs
+++ b/mzLib/Test/Transcriptomics/TestOligoWithSetMods.cs
@@ -91,22 +91,34 @@ namespace Test.Transcriptomics
                 .Digest(new RnaDigestionParams(), [], [])
                 .ElementAt(1);
 
-            Assert.That(oligoWithSetMods, Is.EqualTo(oligoWithSetMods2));
+            // same oligos
+            Assert.That(oligoWithSetMods.Equals(oligoWithSetMods2));
+            Assert.That(oligoWithSetMods.Equals((object)oligoWithSetMods2));
+            Assert.That(oligoWithSetMods.Equals((OligoWithSetMods)oligoWithSetMods2));
+            Assert.That(oligoWithSetMods.Equals(oligoWithSetMods));
+            Assert.That(oligoWithSetMods.Equals((object)oligoWithSetMods));
+            Assert.That(oligoWithSetMods.Equals((OligoWithSetMods)oligoWithSetMods));
             Assert.That(oligoWithSetMods.GetHashCode(), Is.EqualTo(oligoWithSetMods2.GetHashCode()));
-            Assert.That(oligoWithSetMods.Equals((object)oligoWithSetMods2)); // Test the Equals(Object obj) method
+
+            // all fail on null
             Assert.That(!oligoWithSetMods2.Equals(null));
+            Assert.That(!oligoWithSetMods2.Equals((object)null));
+            Assert.That(!oligoWithSetMods2.Equals((OligoWithSetMods)null));
 
             // Null parent checks
             oligoWithSetMods = new(oligoWithSetMods.FullSequence, modDict.ToDictionary(p => p.Value.First().IdWithMotif, p => p.Value.First()));
             oligoWithSetMods2 = new OligoWithSetMods(oligoWithSetMods.FullSequence, modDict.ToDictionary(p => p.Value.First().IdWithMotif, p => p.Value.First()));
             var oligoWithSetMods3 = new OligoWithSetMods(oligoWithSetMods.FullSequence + "AGAUA", modDict.ToDictionary(p => p.Value.First().IdWithMotif, p => p.Value.First()));
 
-            Assert.That(oligoWithSetMods, Is.EqualTo(oligoWithSetMods2));
-            Assert.That(oligoWithSetMods, Is.EqualTo((object)oligoWithSetMods2));
-            Assert.That(oligoWithSetMods, Is.EqualTo((OligoWithSetMods)oligoWithSetMods2));
-            Assert.That(oligoWithSetMods, Is.Not.EqualTo(oligoWithSetMods3));
-            Assert.That(oligoWithSetMods, Is.Not.EqualTo((object)oligoWithSetMods3));
-            Assert.That(oligoWithSetMods, Is.Not.EqualTo((IBioPolymerWithSetMods)oligoWithSetMods3));
+            // same oligo null parent
+            Assert.That(oligoWithSetMods.Equals(oligoWithSetMods2));
+            Assert.That(oligoWithSetMods.Equals((object)oligoWithSetMods2));
+            Assert.That(oligoWithSetMods.Equals((OligoWithSetMods)oligoWithSetMods2));
+
+            // different oligo null parent
+            Assert.That(!oligoWithSetMods.Equals(oligoWithSetMods3));
+            Assert.That(!oligoWithSetMods.Equals((object)oligoWithSetMods3));
+            Assert.That(!oligoWithSetMods.Equals((IBioPolymerWithSetMods)oligoWithSetMods3));
         }
 
         [Test]

--- a/mzLib/Test/Transcriptomics/TestOligoWithSetMods.cs
+++ b/mzLib/Test/Transcriptomics/TestOligoWithSetMods.cs
@@ -124,7 +124,7 @@ namespace Test.Transcriptomics
         [Test]
         [TestCase("GUACUG", "GUACUGGUACUG", "RNase A")]
         [TestCase("GUAGGAG", "GUAGCAG", "RNase A")]
-        public static void TestEquality_DifferentParentSameDigestionProduct(string sequence1, string sequence2, string enzyme)
+        public static void TestInequality_DifferentParentSameDigestionProduct(string sequence1, string sequence2, string enzyme)
         {
             var digestionParams = new RnaDigestionParams(rnase: enzyme, minLength: 1, maxMissedCleavages: 0);
 
@@ -136,10 +136,10 @@ namespace Test.Transcriptomics
                 .Digest(digestionParams, [], [])
                 .First();
 
-            Assert.That(oligo1, Is.EqualTo(oligo2));
+            Assert.That(oligo1, Is.Not.EqualTo(oligo2));
             Assert.That(oligo1.Equals(oligo1));
-            Assert.That(oligo1, Is.EqualTo((object)oligo2));
-            Assert.That(oligo1.GetHashCode(), Is.EqualTo(oligo2.GetHashCode()));
+            Assert.That(oligo1, Is.Not.EqualTo((object)oligo2));
+            Assert.That(oligo1.GetHashCode(), Is.Not.EqualTo(oligo2.GetHashCode()));
         }
 
         /// <summary>

--- a/mzLib/Transcriptomics/Digestion/OligoWithSetMods.cs
+++ b/mzLib/Transcriptomics/Digestion/OligoWithSetMods.cs
@@ -215,6 +215,12 @@ namespace Transcriptomics.Digestion
                     products.AddRange(GetNeutralFragments(type, sequence));
         }
 
+        #region IEquatable
+
+        /// <summary>
+        /// Different parent but same sequence and digestion condition => are equal.
+        /// Different Digestion agent but same sequence => are not equal (this is for multi-protease analysis in MetaMorpheus)
+        /// </summary>
         public override bool Equals(object? obj)
         {
             if (obj is OligoWithSetMods oligo)
@@ -224,9 +230,28 @@ namespace Transcriptomics.Digestion
             return false;
         }
 
+        /// <summary>
+        /// Different parent but same sequence and digestion condition => are equal.
+        /// Different Digestion agent but same sequence => are not equal (this is for multi-protease analysis in MetaMorpheus)
+        /// </summary>
+        public bool Equals(IBioPolymerWithSetMods? other) => Equals(other as OligoWithSetMods);
+
+        /// <summary>
+        /// Different parent but same sequence and digestion condition => are equal.
+        /// Different Digestion agent but same sequence => are not equal (this is for multi-protease analysis in MetaMorpheus)
+        /// </summary>
         public bool Equals(OligoWithSetMods? other)
         {
-            return (this as IBioPolymerWithSetMods).Equals(other);
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            if (other.GetType() != GetType()) return false;
+
+            // for those constructed from sequence and mods only
+            if (Parent is null && other.Parent is null)
+                return FullSequence.Equals(other.FullSequence);
+
+            return FullSequence == other.FullSequence
+                   && Equals(DigestionParams?.DigestionAgent, other.DigestionParams?.DigestionAgent);
         }
 
         public override int GetHashCode()
@@ -244,6 +269,8 @@ namespace Transcriptomics.Digestion
             }
             return hash.ToHashCode();
         }
+
+        #endregion
 
         /// <summary>
         /// Generates theoretical internal fragments for given dissociation type for this peptide. 

--- a/mzLib/Transcriptomics/Digestion/OligoWithSetMods.cs
+++ b/mzLib/Transcriptomics/Digestion/OligoWithSetMods.cs
@@ -218,8 +218,7 @@ namespace Transcriptomics.Digestion
         #region IEquatable
 
         /// <summary>
-        /// Different parent but same sequence and digestion condition => are equal.
-        /// Different Digestion agent but same sequence => are not equal (this is for multi-protease analysis in MetaMorpheus)
+        /// Oligos are equal if they have the same full sequence, parent, and digestion agent, and terminal caps
         /// </summary>
         public override bool Equals(object? obj)
         {
@@ -231,14 +230,12 @@ namespace Transcriptomics.Digestion
         }
 
         /// <summary>
-        /// Different parent but same sequence and digestion condition => are equal.
-        /// Different Digestion agent but same sequence => are not equal (this is for multi-protease analysis in MetaMorpheus)
+        /// Oligos are equal if they have the same full sequence, parent, and digestion agent, and terminal caps
         /// </summary>
         public bool Equals(IBioPolymerWithSetMods? other) => Equals(other as OligoWithSetMods);
 
         /// <summary>
-        /// Different parent but same sequence and digestion condition => are equal.
-        /// Different Digestion agent but same sequence => are not equal (this is for multi-protease analysis in MetaMorpheus)
+        /// Oligos are equal if they have the same full sequence, parent, and digestion agent, and terminal caps
         /// </summary>
         public bool Equals(OligoWithSetMods? other)
         {
@@ -251,7 +248,12 @@ namespace Transcriptomics.Digestion
                 return FullSequence.Equals(other.FullSequence);
 
             return FullSequence == other.FullSequence
-                   && Equals(DigestionParams?.DigestionAgent, other.DigestionParams?.DigestionAgent);
+                   && Equals(DigestionParams?.DigestionAgent, other.DigestionParams?.DigestionAgent)
+                   && _fivePrimeTerminus.Equals(other._fivePrimeTerminus)
+                   && _threePrimeTerminus.Equals(other._threePrimeTerminus)
+                   // These last two are important for parsimony in MetaMorpheus
+                   && OneBasedStartResidue == other!.OneBasedStartResidue
+                   && Equals(Parent?.Accession, other.Parent?.Accession);
         }
 
         public override int GetHashCode()
@@ -267,6 +269,8 @@ namespace Transcriptomics.Digestion
             {
                 hash.Add(DigestionParams.DigestionAgent);
             }
+            hash.Add(FivePrimeTerminus);
+            hash.Add(ThreePrimeTerminus);
             return hash.ToHashCode();
         }
 

--- a/mzLib/Transcriptomics/RNA.cs
+++ b/mzLib/Transcriptomics/RNA.cs
@@ -23,7 +23,7 @@ namespace Transcriptomics
         /// </summary>
         /// <param name="sequence"></param>
         /// <param name="name"></param>
-        /// <param name="identifier"></param>
+        /// <param name="accession"></param>
         /// <param name="organism"></param>
         /// <param name="databaseFilePath"></param>
         /// <param name="fivePrimeTerminus"></param>
@@ -33,12 +33,12 @@ namespace Transcriptomics
         /// <param name="isDecoy"></param>
         /// <param name="geneNames"></param>
         /// <param name="databaseAdditionalFields"></param>
-        public RNA(string sequence, string name, string identifier, string organism, string databaseFilePath,
+        public RNA(string sequence, string name, string accession, string organism, string databaseFilePath,
             IHasChemicalFormula? fivePrimeTerminus = null, IHasChemicalFormula? threePrimeTerminus = null,
             IDictionary<int, List<Modification>>? oneBasedPossibleModifications = null,
             bool isContaminant = false, bool isDecoy = false, List<Tuple<string, string>> geneNames = null,
             Dictionary<string, string>? databaseAdditionalFields = null)
-            : base(sequence, name, identifier, organism, databaseFilePath, fivePrimeTerminus, threePrimeTerminus,
+            : base(sequence, name, accession, organism, databaseFilePath, fivePrimeTerminus, threePrimeTerminus,
                 oneBasedPossibleModifications, isContaminant, isDecoy, geneNames, databaseAdditionalFields)
         {
 

--- a/mzLib/mzLib.sln.DotSettings
+++ b/mzLib/mzLib.sln.DotSettings
@@ -8,6 +8,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Modomics/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nucleolytic/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Oligo/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Oligos/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Prsm/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Regexes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Toppic/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Refactor Equals methods and add IEquatable regions. 

Removed Equals from IBioPolymerWithSetMods interface in Omics. This ensures it is called on one class and not the interface ambiguously so that any call in MetaMorhpeus uses the correct equals without needing understanding of the codebase to perform the operation correctly.


- Updated Equals in PeptideWithSetModifications to check OneBasedStartResidue and Parent?.Accession.
- Updated Equals in OligoWithSetMods to check FullSequence and DigestionParams?.DigestionAgent.
- Added IEquatable regions to PeptideWithSetModifications and OligoWithSetMods.
- Organized Equals methods with #region IEquatable directives.