### PR TITLE
Mzml writer now rounds to 4 decimal places

### DIFF
--- a/mzLib/MassSpectrometry/MzSpectra/MzSpectrum.cs
+++ b/mzLib/MassSpectrometry/MzSpectra/MzSpectrum.cs
@@ -498,7 +498,7 @@ namespace MassSpectrometry
 
         public byte[] Get64BitXarray()
         {
-            return Get64Bitarray(XArray);
+            return Get64Bitarray(XArray.Select(x => Math.Round(x, 4, MidpointRounding.AwayFromZero)));
         }
 
         public override string ToString()


### PR DESCRIPTION
When writing mzMLs, we round the m/z values to 4 decimal places