### PR TITLE
Changed rounding method

### DIFF
--- a/mzLib/MassSpectrometry/MzSpectra/MzSpectrum.cs
+++ b/mzLib/MassSpectrometry/MzSpectra/MzSpectrum.cs
@@ -498,7 +498,7 @@ namespace MassSpectrometry
 
         public byte[] Get64BitXarray()
         {
-            return Get64Bitarray(XArray.Select(x => Math.Round(x, 4, MidpointRounding.AwayFromZero)));
+            return Get64Bitarray(XArray.Select(x => Math.Round(x, 4)));
         }
 
         public override string ToString()

--- a/mzLib/Test/FileReadingTests/TestMsDataFileToResultsAdapter.cs
+++ b/mzLib/Test/FileReadingTests/TestMsDataFileToResultsAdapter.cs
@@ -137,7 +137,7 @@ namespace Test.FileReadingTests
                 Assert.That(readInScan.MsnOrder.Equals(writtenScan.MsnOrder));
                 Assert.That(readInScan.IsCentroid.Equals(writtenScan.IsCentroid));
                 Assert.That(readInScan.MassSpectrum.YArray, Is.EquivalentTo(writtenScan.MassSpectrum.YArray));
-                Assert.That(readInScan.MassSpectrum.XArray, Is.EquivalentTo(writtenScan.MassSpectrum.XArray.Select(x => Math.Round(x, 4, MidpointRounding.AwayFromZero))));
+                Assert.That(readInScan.MassSpectrum.XArray, Is.EquivalentTo(writtenScan.MassSpectrum.XArray.Select(x => Math.Round(x, 4))));
             }
 
             File.Delete(outfile);

--- a/mzLib/Test/FileReadingTests/TestMzML.cs
+++ b/mzLib/Test/FileReadingTests/TestMzML.cs
@@ -742,7 +742,7 @@ namespace Test.FileReadingTests
 
             var newFirstValue = reader.GetOneBasedScan(1).MassSpectrum.FirstX;
             Assert.AreNotEqual(oldFirstValue.Value, newFirstValue.Value);
-            Assert.AreEqual(Math.Round((double)oldFirstValue, 4, MidpointRounding.AwayFromZero), newFirstValue.Value, 1e-6);
+            Assert.AreEqual(Math.Round((double)oldFirstValue, 4), newFirstValue.Value, 1e-6);
 
             var secondScan2 = reader.GetOneBasedScan(2);
 
@@ -1459,7 +1459,7 @@ namespace Test.FileReadingTests
             MsDataScan[] scans = new MsDataScan[1];
 
             double[] intensities0 = new double[] { 1, 1, 1, 1 };
-            double[] mz0 = new double[] { 50.00004, 50.00005, 50.0004, 50.0005 };
+            double[] mz0 = new double[] { 50.00014, 50.00015, 50.0004, 50.0005 };
             MzSpectrum massSpec0 = new MzSpectrum(mz0, intensities0, false);
             scans[0] = new MsDataScan(massSpec0, 1, 1, true, Polarity.Positive, 1, new MzRange(1, 100), "f", MZAnalyzerType.Orbitrap, massSpec0.SumOfAllY, null, null, "1");
 
@@ -1472,8 +1472,8 @@ namespace Test.FileReadingTests
             var readSpectrum = fakeMzml.Scans[0].MassSpectrum;
 
             // Ensure that the spectrum was rounded to the fourth decimal place on write
-            Assert.That(readSpectrum.XArray[0], Is.EqualTo(50).Within(0.000001));
-            Assert.That(readSpectrum.XArray[1], Is.EqualTo(50.0001).Within(0.000001));
+            Assert.That(readSpectrum.XArray[0], Is.EqualTo(50.0001).Within(0.000001));
+            Assert.That(readSpectrum.XArray[1], Is.EqualTo(50.0002).Within(0.000001));
             Assert.That(readSpectrum.XArray[2], Is.EqualTo(50.0004).Within(0.000001));
             Assert.That(readSpectrum.XArray[3], Is.EqualTo(50.0005).Within(0.000001));
         }

--- a/mzLib/Test/FileReadingTests/TestRawFileReader.cs
+++ b/mzLib/Test/FileReadingTests/TestRawFileReader.cs
@@ -171,13 +171,13 @@ namespace Test.FileReadingTests
 
                 for (int j = 0; j < mzmlScan.MassSpectrum.XArray.Length; j++)
                 {
-                    double roundedRawMz = Math.Round(rawScan.MassSpectrum.XArray[j], 4, MidpointRounding.AwayFromZero);
+                    double roundedRawMz = Math.Round(rawScan.MassSpectrum.XArray[j], 4);
 
                     //  XArray is rounded to the 4th digit during CreateAndWrite
                     Assert.AreEqual(mzmlScan.MassSpectrum.XArray[j], roundedRawMz);
 
-                    double roundedMzmlIntensity = Math.Round(mzmlScan.MassSpectrum.XArray[j], 0, MidpointRounding.AwayFromZero);
-                    double roundedRawIntensity = Math.Round(rawScan.MassSpectrum.XArray[j], 0, MidpointRounding.AwayFromZero);
+                    double roundedMzmlIntensity = Math.Round(mzmlScan.MassSpectrum.XArray[j], 0);
+                    double roundedRawIntensity = Math.Round(rawScan.MassSpectrum.XArray[j], 0);
 
                     Assert.AreEqual(roundedMzmlIntensity, roundedRawIntensity);
                 }


### PR DESCRIPTION
As it turns out, there is a very good reason that Math.Round() uses MidpointRounding.RoundToEven as the default method of rounding. For more information, see here:n [https://learn.microsoft.com/en-us/dotnet/api/system.math.round?view=net-9.0](https://learn.microsoft.com/en-us/dotnet/api/system.math.round?view=net-9.0)


This PR amends the mzML writer rounding PR (#821) to use the default rounding method.