### PR TITLE
Undo Rounding

### DIFF
--- a/mzLib/MassSpectrometry/MzSpectra/MzSpectrum.cs
+++ b/mzLib/MassSpectrometry/MzSpectra/MzSpectrum.cs
@@ -498,7 +498,7 @@ namespace MassSpectrometry
 
         public byte[] Get64BitXarray()
         {
-            return Get64Bitarray(XArray.Select(x => Math.Round(x, 4)));
+            return Get64Bitarray(XArray);
         }
 
         public override string ToString()

--- a/mzLib/Test/FileReadingTests/TestMsDataFileToResultsAdapter.cs
+++ b/mzLib/Test/FileReadingTests/TestMsDataFileToResultsAdapter.cs
@@ -137,7 +137,7 @@ namespace Test.FileReadingTests
                 Assert.That(readInScan.MsnOrder.Equals(writtenScan.MsnOrder));
                 Assert.That(readInScan.IsCentroid.Equals(writtenScan.IsCentroid));
                 Assert.That(readInScan.MassSpectrum.YArray, Is.EquivalentTo(writtenScan.MassSpectrum.YArray));
-                Assert.That(readInScan.MassSpectrum.XArray, Is.EquivalentTo(writtenScan.MassSpectrum.XArray.Select(x => Math.Round(x, 4))));
+                Assert.That(readInScan.MassSpectrum.XArray, Is.EquivalentTo(writtenScan.MassSpectrum.XArray));
             }
 
             File.Delete(outfile);

--- a/mzLib/Test/FileReadingTests/TestMzML.cs
+++ b/mzLib/Test/FileReadingTests/TestMzML.cs
@@ -741,8 +741,7 @@ namespace Test.FileReadingTests
             Assert.AreEqual(2, reader.GetClosestOneBasedSpectrumNumber(2));
 
             var newFirstValue = reader.GetOneBasedScan(1).MassSpectrum.FirstX;
-            Assert.AreNotEqual(oldFirstValue.Value, newFirstValue.Value);
-            Assert.AreEqual(Math.Round((double)oldFirstValue, 4), newFirstValue.Value, 1e-6);
+            Assert.AreEqual(oldFirstValue.Value, newFirstValue.Value);
 
             var secondScan2 = reader.GetOneBasedScan(2);
 
@@ -1450,32 +1449,6 @@ namespace Test.FileReadingTests
 
             Assert.AreEqual(3, fakeMzml.GetAllScansList().ElementAt(5).OneBasedPrecursorScanNumber);
             Assert.AreEqual(1, fakeMzml1.GetAllScansList().ElementAt(3).OneBasedPrecursorScanNumber);
-        }
-
-        [Test]
-        public void TestMzmlWriterRounding()
-        {
-            // This test ensure the CreateAndWriteMzml method only writes m/z values out to 4 decimal places of precision
-            MsDataScan[] scans = new MsDataScan[1];
-
-            double[] intensities0 = new double[] { 1, 1, 1, 1 };
-            double[] mz0 = new double[] { 50.00014, 50.00015, 50.0004, 50.0005 };
-            MzSpectrum massSpec0 = new MzSpectrum(mz0, intensities0, false);
-            scans[0] = new MsDataScan(massSpec0, 1, 1, true, Polarity.Positive, 1, new MzRange(1, 100), "f", MZAnalyzerType.Orbitrap, massSpec0.SumOfAllY, null, null, "1");
-
-            FakeMsDataFile fakeFile = new FakeMsDataFile(scans);
-            MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(fakeFile, Path.Combine(TestContext.CurrentContext.TestDirectory, "what.mzML"), false);
-            var fakeMzml =
-                MsDataFileReader.GetDataFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "what.mzML"));
-            fakeMzml.LoadAllStaticData();
-
-            var readSpectrum = fakeMzml.Scans[0].MassSpectrum;
-
-            // Ensure that the spectrum was rounded to the fourth decimal place on write
-            Assert.That(readSpectrum.XArray[0], Is.EqualTo(50.0001).Within(0.000001));
-            Assert.That(readSpectrum.XArray[1], Is.EqualTo(50.0002).Within(0.000001));
-            Assert.That(readSpectrum.XArray[2], Is.EqualTo(50.0004).Within(0.000001));
-            Assert.That(readSpectrum.XArray[3], Is.EqualTo(50.0005).Within(0.000001));
         }
 
         [Test]

--- a/mzLib/Test/FileReadingTests/TestRawFileReader.cs
+++ b/mzLib/Test/FileReadingTests/TestRawFileReader.cs
@@ -172,9 +172,10 @@ namespace Test.FileReadingTests
                 for (int j = 0; j < mzmlScan.MassSpectrum.XArray.Length; j++)
                 {
                     double roundedRawMz = Math.Round(rawScan.MassSpectrum.XArray[j], 4);
+                    double roundedMzmlMz = Math.Round(mzmlScan.MassSpectrum.XArray[j], 4);
 
                     //  XArray is rounded to the 4th digit during CreateAndWrite
-                    Assert.AreEqual(mzmlScan.MassSpectrum.XArray[j], roundedRawMz);
+                    Assert.AreEqual(roundedMzmlMz, roundedRawMz);
 
                     double roundedMzmlIntensity = Math.Round(mzmlScan.MassSpectrum.XArray[j], 0);
                     double roundedRawIntensity = Math.Round(rawScan.MassSpectrum.XArray[j], 0);

--- a/mzLib/TestFlashLFQ/TestFlashLFQ.cs
+++ b/mzLib/TestFlashLFQ/TestFlashLFQ.cs
@@ -1493,7 +1493,7 @@ namespace Test
 
             Assert.That((int)results.PeptideModifiedSequences[sequence].GetIntensity(file1) == 1386491);
             ChromatographicPeak peak = results.Peaks[file1].First(p => p.Identifications.First().ModifiedSequence == sequence);
-            Assert.That(Math.Round(peak.MassError, 3), Is.EqualTo(0.006).Within(0.0001));
+            Assert.That(Math.Round(peak.MassError, 3), Is.EqualTo(0));
             Assert.That(peak.IsotopicEnvelopes.Count == 10);
         }
 


### PR DESCRIPTION
This reverts PR #821.

Rounding mz values was an attempt to resolve an issue where calibration within metamorpheus returned variable results. Rounding did not, in fact, resolve that issue.