### PR TITLE
Parallelized Isotracker

### DIFF
--- a/mzLib/FlashLFQ/FlashLFQResults.cs
+++ b/mzLib/FlashLFQ/FlashLFQResults.cs
@@ -17,7 +17,7 @@ namespace FlashLFQ
         public readonly Dictionary<string, ProteinGroup> ProteinGroups;
         public readonly Dictionary<SpectraFileInfo, List<ChromatographicPeak>> Peaks;
         private readonly HashSet<string> _peptideModifiedSequencesToQuantify;
-        public Dictionary<string, Dictionary<PeakRegion, List<ChromatographicPeak>>> IsobaricPeptideDict = null;
+        public IDictionary<string, Dictionary<PeakRegion, List<ChromatographicPeak>>> IsobaricPeptideDict = null;
         public string PepResultString { get; set; }
         public double MbrQValueThreshold { get; set; }
 

--- a/mzLib/FlashLFQ/FlashLfqEngine.cs
+++ b/mzLib/FlashLFQ/FlashLfqEngine.cs
@@ -14,11 +14,8 @@ using System.IO;
 using Easy.Common.Extensions;
 using FlashLFQ.PEP;
 using FlashLFQ.IsoTracker;
-using MassSpectrometry;
 using System.Threading;
 using FlashLFQ.Interfaces;
-using Proteomics;
-using System.Data.SQLite;
 
 [assembly: InternalsVisibleTo("TestFlashLFQ")]
 

--- a/mzLib/FlashLFQ/FlashLfqEngine.cs
+++ b/mzLib/FlashLFQ/FlashLfqEngine.cs
@@ -1953,7 +1953,8 @@ namespace FlashLFQ
         {
             Console.WriteLine("Quantifying isobaric species...");
             int isoGroupsSearched = 0;
-            int oldPercentProgress = 0;
+            double lastReportedProgress = 0;
+            double currentProgress = 0;
 
             var idGroupedBySeq = _allIdentifications
                 .Where(p => p.BaseSequence != p.ModifiedSequence && !p.IsDecoy)
@@ -2032,12 +2033,13 @@ namespace FlashLFQ
                         // report search progress (proteins searched so far out of total proteins in database)
                         Interlocked.Increment(ref isoGroupsSearched);
 
-                        var percentProgress = (int)((isoGroupsSearched / idGroupedBySeq.Count) * 100);
+                        double percentProgress = ((double)isoGroupsSearched / idGroupedBySeq.Count * 100);
+                        currentProgress = Math.Max(percentProgress, currentProgress);
 
-                        if (percentProgress > oldPercentProgress)
+                        if (currentProgress > lastReportedProgress + 10)
                         {
-                            oldPercentProgress = percentProgress;
-                            Console.WriteLine("{0}% of isobaric species quantified", percentProgress);
+                            Console.WriteLine("{0:0.}% of isobaric species quantified", currentProgress);
+                            lastReportedProgress = currentProgress;
                         }
                     }
                 });

--- a/mzLib/FlashLFQ/FlashLfqEngine.cs
+++ b/mzLib/FlashLFQ/FlashLfqEngine.cs
@@ -17,6 +17,8 @@ using FlashLFQ.IsoTracker;
 using MassSpectrometry;
 using System.Threading;
 using FlashLFQ.Interfaces;
+using Proteomics;
+using System.Data.SQLite;
 
 [assembly: InternalsVisibleTo("TestFlashLFQ")]
 
@@ -1952,74 +1954,96 @@ namespace FlashLFQ
 
         private void QuantifyIsobaricPeaks()
         {
+            Console.WriteLine("Quantifying isobaric species...");
+            int isoGroupsSearched = 0;
+            int oldPercentProgress = 0;
+
             var idGroupedBySeq = _allIdentifications
                 .Where(p => p.BaseSequence != p.ModifiedSequence && !p.IsDecoy)
                 .GroupBy(p => new
-                    { p.BaseSequence, MonoisotopicMassGroup = Math.Round(p.MonoisotopicMass / 0.0001) });
-            // We only consider the modified sequence in the IsoTracker
-            foreach (var idGroup in idGroupedBySeq) //Try to iterate the all ID in the group
-            {
-                List<XIC> xicGroup = new List<XIC>();
-                var mostCommonChargeIdGroup = idGroup.GroupBy(p => p.PrecursorChargeState).OrderBy(p => p.Count()).Last();
-                var id = mostCommonChargeIdGroup.First();
+                    { p.BaseSequence, MonoisotopicMassGroup = Math.Round(p.MonoisotopicMass / 0.0001) })
+                .ToList();
 
-                // Try to get the primitive window for the XIC , from the (firstOne - 2) ->  (lastOne + 2)
-                double rightWindow = mostCommonChargeIdGroup.Select(p => p.Ms2RetentionTimeInMinutes).Max() + 2;
-                double leftWindow = mostCommonChargeIdGroup.Select(p => p.Ms2RetentionTimeInMinutes).Min() - 2;
-
-                //generate XIC from each file
-                foreach (var spectraFile in _spectraFileInfo)
+            Parallel.ForEach(Partitioner.Create(0, idGroupedBySeq.Count),
+                new ParallelOptions { MaxDegreeOfParallelism = MaxThreads },
+                (range, loopState) =>
                 {
-                    var xicIds = mostCommonChargeIdGroup.Where(p => p.FileInfo.Equals(spectraFile)).ToList();
-
-                    //If in this run, there is no any ID, we will borrow the ID from other run to build the XIC.
-                    if (xicIds.Count == 0)
+                    for (int i = range.Item1; i < range.Item2; i++)
                     {
-                        xicIds = mostCommonChargeIdGroup.Where(p => !p.IsDecoy).ToList();
-                    }
+                        var idGroup = idGroupedBySeq[i];
+                        List<XIC> xicGroup = new List<XIC>();
+                        var mostCommonChargeIdGroup = idGroup.GroupBy(p => p.PrecursorChargeState).OrderBy(p => p.Count()).Last();
+                        var id = mostCommonChargeIdGroup.First();
 
-                    XIC xic = BuildXIC(xicIds, spectraFile, false, leftWindow, rightWindow);
-                    if (xic != null && xic.Ms1Peaks.Count() > 5) // each XIC should have at least 5 points
-                    {
-                        xicGroup.Add(xic);
-                    }
-                }
+                        // Try to get the primitive window for the XIC , from the (firstOne - 2) ->  (lastOne + 2)
+                        double rightWindow = mostCommonChargeIdGroup.Select(p => p.Ms2RetentionTimeInMinutes).Max() + 2;
+                        double leftWindow = mostCommonChargeIdGroup.Select(p => p.Ms2RetentionTimeInMinutes).Min() - 2;
 
-                // If we have more than one XIC, we can do the peak tracking
-                if (xicGroup.Count > 1)
-                {
-                    // Step 1: Find the XIC with most IDs then, set as reference XIC
-                    xicGroup.OrderBy(p => p.Ids.Count()).First().Reference = true;
-
-                    //Step 2: Build the XICGroups
-                    XICGroups xICGroups = new XICGroups(xicGroup);
-
-                    //Step 3: Build the peakPairChrom dictionary
-                    //The shared peak dictionary, each sharedPeak included serval ChromatographicPeak for each run [SharedPeak <-> ChromatographicPeaks]
-                    Dictionary<PeakRegion, List<ChromatographicPeak>> sharedPeaksDict = new Dictionary<PeakRegion, List<ChromatographicPeak>>();
-
-                    //Step 4: Iterate the shared peaks in the XICGroups
-                    foreach (var peak in xICGroups.SharedPeaks)
-                    {
-                        double peakWindow = peak.Width;
-                        if (peakWindow > 0.001) //make sure we have enough length of the window (0.001 min) for peak searching
+                        //generate XIC from each file
+                        foreach (var spectraFile in _spectraFileInfo)
                         {
-                            List<ChromatographicPeak> chromPeaksInSharedPeak = new List<ChromatographicPeak>();
-                            CollectChromPeakInRuns(peak, chromPeaksInSharedPeak, xICGroups);
+                            var xicIds = mostCommonChargeIdGroup.Where(p => p.FileInfo.Equals(spectraFile)).ToList();
 
-                            var allChromPeakInDict = sharedPeaksDict.SelectMany(pair => pair.Value).ToList();
-
-                            // ensuring no duplicates are added and only non-null peaks are considered.
-                            if (chromPeaksInSharedPeak.Where(p => p != null).Any() &&
-                                !chromPeaksInSharedPeak.Any(chromPeak => chromPeak != null && allChromPeakInDict.Any(peakInDict => peakInDict != null && peakInDict.Equals(chromPeak))))
+                            //If in this run, there is no any ID, we will borrow the ID from other run to build the XIC.
+                            if (xicIds.Count == 0)
                             {
-                                sharedPeaksDict[peak] = chromPeaksInSharedPeak;
+                                xicIds = mostCommonChargeIdGroup.Where(p => !p.IsDecoy).ToList();
+                            }
+
+                            XIC xic = BuildXIC(xicIds, spectraFile, false, leftWindow, rightWindow);
+                            if (xic != null && xic.Ms1Peaks.Count() > 5) // each XIC should have at least 5 points
+                            {
+                                xicGroup.Add(xic);
                             }
                         }
+
+                        // If we have more than one XIC, we can do the peak tracking
+                        if (xicGroup.Count > 1)
+                        {
+                            // Step 1: Find the XIC with most IDs then, set as reference XIC
+                            xicGroup.OrderBy(p => p.Ids.Count()).First().Reference = true;
+
+                            //Step 2: Build the XICGroups
+                            XICGroups xICGroups = new XICGroups(xicGroup);
+
+                            //Step 3: Build the peakPairChrom dictionary
+                            //The shared peak dictionary, each sharedPeak included serval ChromatographicPeak for each run [SharedPeak <-> ChromatographicPeaks]
+                            Dictionary<PeakRegion, List<ChromatographicPeak>> sharedPeaksDict = new Dictionary<PeakRegion, List<ChromatographicPeak>>();
+
+                            //Step 4: Iterate the shared peaks in the XICGroups
+                            foreach (var peak in xICGroups.SharedPeaks)
+                            {
+                                double peakWindow = peak.Width;
+                                if (peakWindow > 0.001) //make sure we have enough length of the window (0.001 min) for peak searching
+                                {
+                                    List<ChromatographicPeak> chromPeaksInSharedPeak = new List<ChromatographicPeak>();
+                                    CollectChromPeakInRuns(peak, chromPeaksInSharedPeak, xICGroups);
+
+                                    var allChromPeakInDict = sharedPeaksDict.SelectMany(pair => pair.Value).ToList();
+
+                                    // ensuring no duplicates are added and only non-null peaks are considered.
+                                    if (chromPeaksInSharedPeak.Where(p => p != null).Any() &&
+                                        !chromPeaksInSharedPeak.Any(chromPeak => chromPeak != null && allChromPeakInDict.Any(peakInDict => peakInDict != null && peakInDict.Equals(chromPeak))))
+                                    {
+                                        sharedPeaksDict[peak] = chromPeaksInSharedPeak;
+                                    }
+                                }
+                            }
+                            IsobaricPeptideDict[id.ModifiedSequence] = sharedPeaksDict;
+                        }
+
+                        // report search progress (proteins searched so far out of total proteins in database)
+                        Interlocked.Increment(ref isoGroupsSearched);
+
+                        var percentProgress = (int)((isoGroupsSearched / idGroupedBySeq.Count) * 100);
+
+                        if (percentProgress > oldPercentProgress)
+                        {
+                            oldPercentProgress = percentProgress;
+                            Console.WriteLine("{0}% of isobaric species quantified", percentProgress);
+                        }
                     }
-                    IsobaricPeptideDict[id.ModifiedSequence] = sharedPeaksDict;
-                }
-            }
+                });
         }
 
         /// <summary>

--- a/mzLib/mzLib.nuspec
+++ b/mzLib/mzLib.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>mzLib</id>
-    <version>8.0.0</version>
+    <version>1.0.559</version>
     <title>mzLib</title>
     <authors>Stef S.</authors>
     <owners>Stef S.</owners>

--- a/mzLib/mzLib.nuspec
+++ b/mzLib/mzLib.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>mzLib</id>
-    <version>1.0.559</version>
+    <version>8.0.0</version>
     <title>mzLib</title>
     <authors>Stef S.</authors>
     <owners>Stef S.</owners>


### PR DESCRIPTION
This PR increases the speed of IsoTracker through parallelization and adds progress reporting functionality to IsoTracker.

The results from running IsoTracker before and after this PR are identical

Progress reports are printed to the console when 10%, 20%,.... of the isobaric species have been quantified/ran through IsoTracker.
Example output:
![image](https://github.com/user-attachments/assets/2dbe5a59-30ad-4971-8af8-50f2dfc85481)

