### PR TITLE
IsMBR replacement by DetectionType

### DIFF
--- a/mzLib/FlashLFQ/ChromatographicPeak.cs
+++ b/mzLib/FlashLFQ/ChromatographicPeak.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using ClassExtensions = Chemistry.ClassExtensions;

--- a/mzLib/FlashLFQ/ChromatographicPeak.cs
+++ b/mzLib/FlashLFQ/ChromatographicPeak.cs
@@ -267,16 +267,16 @@ namespace FlashLFQ
             switch (DetectionType)
             {
                 case DetectionType.MSMS:
-                    sb.Append("" + "MSMS" + "\t");
+                    sb.Append("MSMS" + "\t");
                     break;
                 case DetectionType.MBR:
-                    sb.Append("" + "MBR" + "\t");
+                    sb.Append("MBR" + "\t");
                     break;
                 case DetectionType.IsoTrack_MBR:
-                    sb.Append("" + "MBR_IsoTrack" + "\t");
+                    sb.Append("MBR_IsoTrack" + "\t");
                     break;
                 case DetectionType.IsoTrack_Ambiguous:
-                    sb.Append("" + "IsoTrack_Ambiguous" + "\t");
+                    sb.Append("IsoTrack_Ambiguous" + "\t");
                     break;
             }
 

--- a/mzLib/FlashLFQ/DetectionType.cs
+++ b/mzLib/FlashLFQ/DetectionType.cs
@@ -9,6 +9,6 @@
         IsoTrack_MBR,                   // The peak is detected from MBR by IsoTrack
         IsoTrack_Ambiguous,             // Multiple peptides are mapped to this peak by IsoTracker.
         MSMSIdentifiedButNotQuantified, // We have MS2ID but no peak for quantification
-        NotDetected,                    // We don't have MS2ID either peak for quantification
+        NotDetected,                    // We don't have MS2ID either peak for quantification, only for peptide quantification
     }
 }

--- a/mzLib/FlashLFQ/DetectionType.cs
+++ b/mzLib/FlashLFQ/DetectionType.cs
@@ -9,6 +9,6 @@
         IsoTrack_MBR,                   // The peak is detected from MBR by IsoTrack
         IsoTrack_Ambiguous,             // Multiple peptides are mapped to this peak by IsoTracker.
         MSMSIdentifiedButNotQuantified, // We have MS2ID but no peak for quantification
-        NotDetected,                    // We don't have MS2ID either peak for quantification, only for peptide quantification
+        NotDetected,                    // Peptide was not detected by MS2 or MBR. Only used in FlashLFQ Results when performing peptide-level quantification
     }
 }

--- a/mzLib/FlashLFQ/DetectionType.cs
+++ b/mzLib/FlashLFQ/DetectionType.cs
@@ -2,14 +2,12 @@
 {
     public enum DetectionType
     {
-        MSMS,
-        MBR,
-        IsoTrack_MBR, // MBR detected by IsoTrack
-        IsoTrack_Ambiguous, // Ambiguous(more than two Id in one peak) detected by IsoTrack
-        NotDetected,
-        MSMSAmbiguousPeakfinding,
-        MSMSIdentifiedButNotQuantified,
-        Imputed,
-        Default // Default value, will be removed in the future
+        MSMS,                           // The peak is detected from MS2ID
+        MBR,                            // The peak is detected from MBR
+        MSMSAmbiguousPeakfinding,       // The peak is detected from more than one MS2ID
+        IsoTrack_MBR,                   // The peak is detected from MBR by IsoTrack
+        IsoTrack_Ambiguous,             // The peak is detected from more than one MS2ID by IsoTrack
+        MSMSIdentifiedButNotQuantified, // We have MS2ID but no peak for quantification
+        NotDetected,                    // We don't have MS2ID either peak for quantification
     }
 }

--- a/mzLib/FlashLFQ/DetectionType.cs
+++ b/mzLib/FlashLFQ/DetectionType.cs
@@ -1,5 +1,6 @@
 ﻿namespace FlashLFQ
 {
+
     public enum DetectionType
     {
         MSMS,                           // The peak is detected from MS2ID
@@ -9,5 +10,13 @@
         IsoTrack_Ambiguous,             // The peak is detected from more than one MS2ID by IsoTrack
         MSMSIdentifiedButNotQuantified, // We have MS2ID but no peak for quantification
         NotDetected,                    // We don't have MS2ID either peak for quantification
+    }
+
+    static class DetectionTypeExtensions
+    {
+        public static bool IsPsmInclude()
+        {
+            return MSMS ;
+        }
     }
 }

--- a/mzLib/FlashLFQ/DetectionType.cs
+++ b/mzLib/FlashLFQ/DetectionType.cs
@@ -7,7 +7,7 @@
         MBR,                            // The peak is detected from MBR
         MSMSAmbiguousPeakfinding,       // The peak is detected from more than one MS2ID
         IsoTrack_MBR,                   // The peak is detected from MBR by IsoTrack
-        IsoTrack_Ambiguous,             // The peak is detected from more than one MS2ID by IsoTrack
+        IsoTrack_Ambiguous,             // Multiple peptides are mapped to this peak by IsoTracker.
         MSMSIdentifiedButNotQuantified, // We have MS2ID but no peak for quantification
         NotDetected,                    // We don't have MS2ID either peak for quantification
     }

--- a/mzLib/FlashLFQ/DetectionType.cs
+++ b/mzLib/FlashLFQ/DetectionType.cs
@@ -11,12 +11,4 @@
         MSMSIdentifiedButNotQuantified, // We have MS2ID but no peak for quantification
         NotDetected,                    // We don't have MS2ID either peak for quantification
     }
-
-    static class DetectionTypeExtensions
-    {
-        public static bool IsPsmInclude()
-        {
-            return MSMS ;
-        }
-    }
 }

--- a/mzLib/FlashLFQ/FlashLFQResults.cs
+++ b/mzLib/FlashLFQ/FlashLFQResults.cs
@@ -145,7 +145,7 @@ namespace FlashLFQ
                 var groupedPeaks = filePeaks.Value
                     .Where(p => p.NumIdentificationsByFullSeq == 1)
                     .Where(p => !p.Identifications.First().IsDecoy)
-                    .Where(p => !p.IsMbrPeak || (p.MbrQValue < MbrQValueThreshold && !p.RandomRt))
+                    .Where(p => p.DetectionType != DetectionType.MBR || (p.MbrQValue < MbrQValueThreshold && !p.RandomRt))
                     .GroupBy(p => p.Identifications.First().ModifiedSequence)
                     .Where(group => _peptideModifiedSequencesToQuantify.Contains(group.Key))
                     .ToDictionary(p => p.Key, p => p.ToList());
@@ -157,15 +157,15 @@ namespace FlashLFQ
                     ChromatographicPeak bestPeak = sequenceWithPeaks.Value.First(p => p.Intensity == intensity);
                     DetectionType detectionType;
 
-                    if (bestPeak.IsMbrPeak && intensity > 0)
+                    if (bestPeak.DetectionType == DetectionType.MBR && intensity > 0)
                     {
                         detectionType = DetectionType.MBR;
                     }
-                    else if (!bestPeak.IsMbrPeak && intensity > 0)
+                    else if (bestPeak.DetectionType != DetectionType.MBR && intensity > 0)
                     {
                         detectionType = DetectionType.MSMS;
                     }
-                    else if (!bestPeak.IsMbrPeak && intensity == 0)
+                    else if (bestPeak.DetectionType != DetectionType.MBR && intensity == 0)
                     {
                         detectionType = DetectionType.MSMSIdentifiedButNotQuantified;
                     }
@@ -183,7 +183,7 @@ namespace FlashLFQ
                 var ambiguousPeaks = filePeaks.Value
                     .Where(p => p.NumIdentificationsByFullSeq > 1)
                     .Where(p => !p.Identifications.First().IsDecoy)
-                    .Where(p => !p.IsMbrPeak || (p.MbrQValue < MbrQValueThreshold && !p.RandomRt))
+                    .Where(p => p.DetectionType != DetectionType.MBR || (p.MbrQValue < MbrQValueThreshold && !p.RandomRt))
                     .ToList();
                 foreach (ChromatographicPeak ambiguousPeak in ambiguousPeaks)
                 {
@@ -255,7 +255,7 @@ namespace FlashLFQ
 
                     foreach (SpectraFileInfo file in sample)
                     {
-                        foreach (ChromatographicPeak peak in Peaks[file].Where(p => !p.IsMbrPeak || p.MbrQValue < MbrQValueThreshold))
+                        foreach (ChromatographicPeak peak in Peaks[file].Where(p => p.DetectionType != DetectionType.MBR || p.MbrQValue < MbrQValueThreshold))
                         {
                             foreach (Identification id in peak.Identifications)
                             {

--- a/mzLib/FlashLFQ/FlashLfqEngine.cs
+++ b/mzLib/FlashLFQ/FlashLfqEngine.cs
@@ -497,7 +497,7 @@ namespace FlashLFQ
                     for (int i = range.Item1; i < range.Item2; i++)
                     {
                         var identification = ms2IdsForThisFile[i];
-                        ChromatographicPeak msmsFeature = new ChromatographicPeak(identification, false, fileInfo);
+                        ChromatographicPeak msmsFeature = new ChromatographicPeak(identification, DetectionType.MSMS, fileInfo);
                         chromatographicPeaks[i] = msmsFeature;
 
                         foreach (var chargeState in _chargeStates)
@@ -570,7 +570,7 @@ namespace FlashLFQ
 
             Dictionary<string, List<ChromatographicPeak>> donorFileAllMsmsPeaks = _results.Peaks[donor]
                 .Where(peak => peak.NumIdentificationsByFullSeq == 1
-                    && !peak.IsMbrPeak
+                    && peak.DetectionType != DetectionType.MBR
                     && peak.IsotopicEnvelopes.Any()
                     && peak.Identifications.Min(id => id.QValue) < DonorQValueThreshold)
                 .GroupBy(peak => peak.Identifications.First().ModifiedSequence)
@@ -591,7 +591,7 @@ namespace FlashLFQ
 
             Dictionary<string, List<ChromatographicPeak>> acceptorFileAllMsmsPeaks = _results.Peaks[acceptor]
                 .Where(peak => peak.NumIdentificationsByFullSeq == 1
-                    && !peak.IsMbrPeak
+                    && peak.DetectionType != DetectionType.MBR
                     && peak.IsotopicEnvelopes.Any()
                     && peak.Identifications.Min(id => id.QValue) < DonorQValueThreshold)
                 .GroupBy(peak => peak.Identifications.First().ModifiedSequence)
@@ -944,7 +944,7 @@ namespace FlashLFQ
                 // only match peptides from proteins that have at least one MS/MS identified peptide in the condition
                 foreach (SpectraFileInfo conditionFile in _spectraFileInfo.Where(p => p.Condition == acceptorFile.Condition))
                 {
-                    foreach (ProteinGroup proteinGroup in _results.Peaks[conditionFile].Where(p => !p.IsMbrPeak).SelectMany(p => p.Identifications.SelectMany(v => v.ProteinGroups)))
+                    foreach (ProteinGroup proteinGroup in _results.Peaks[conditionFile].Where(p => p.DetectionType != DetectionType.MBR).SelectMany(p => p.Identifications.SelectMany(v => v.ProteinGroups)))
                     {
                         thisFilesMsmsIdentifiedProteins.Add(proteinGroup);
                     }
@@ -1303,7 +1303,7 @@ namespace FlashLFQ
             double? randomRt = null)
         {
             var donorId = donorPeak.Identifications.OrderBy(p => p.QValue).First();
-            var acceptorPeak = new ChromatographicPeak(donorId, true, acceptorFile, randomRt != null);
+            var acceptorPeak = new ChromatographicPeak(donorId, DetectionType.MBR, acceptorFile, randomRt != null);
 
             // Grab the first scan/envelope from charge envelopes. This should be the most intense envelope in the list
             IsotopicEnvelope seedEnv = chargeEnvelopes.First();
@@ -1345,20 +1345,20 @@ namespace FlashLFQ
                 Console.WriteLine("Checking errors");
             }
 
-            _results.Peaks[spectraFile].RemoveAll(p => p == null || p.IsMbrPeak && !p.IsotopicEnvelopes.Any());
+            _results.Peaks[spectraFile].RemoveAll(p => p == null || p.DetectionType == DetectionType.MBR && !p.IsotopicEnvelopes.Any());
 
             // merge duplicate peaks and handle MBR/MSMS peakfinding conflicts
             var errorCheckedPeaksGroupedByApex = new Dictionary<IIndexedMzPeak, ChromatographicPeak>();
             var errorCheckedPeaks = new List<ChromatographicPeak>();
             
-            foreach (ChromatographicPeak tryPeak in _results.Peaks[spectraFile].OrderBy(p => p.IsMbrPeak))
+            foreach (ChromatographicPeak tryPeak in _results.Peaks[spectraFile].OrderBy(p => p.DetectionType == DetectionType.MBR))
             {
                 tryPeak.CalculateIntensityForThisFeature(Integrate);
                 tryPeak.ResolveIdentifications();
 
                 if (tryPeak.Apex == null)
                 {
-                    if (tryPeak.IsMbrPeak)
+                    if (tryPeak.DetectionType == DetectionType.MBR)
                     {
                         continue;
                     }
@@ -1370,7 +1370,7 @@ namespace FlashLFQ
                 IIndexedMzPeak apexImsPeak = tryPeak.Apex.IndexedPeak;
                 if (errorCheckedPeaksGroupedByApex.TryGetValue(apexImsPeak, out ChromatographicPeak storedPeak) && storedPeak != null)
                 {
-                    if (!tryPeak.IsMbrPeak && !storedPeak.IsMbrPeak)
+                    if (tryPeak.DetectionType != DetectionType.MBR && storedPeak.DetectionType != DetectionType.MBR)
                     {
                         if (PeptideModifiedSequencesToQuantify.Contains(tryPeak.Identifications.First().ModifiedSequence))
                         {
@@ -1385,7 +1385,7 @@ namespace FlashLFQ
                             }
                         }
                     }
-                    else if (tryPeak.IsMbrPeak && !storedPeak.IsMbrPeak)
+                    else if (tryPeak.DetectionType == DetectionType.MBR && storedPeak.DetectionType != DetectionType.MBR)
                     {
                         // Default to MSMS peaks over MBR Peaks.
                         // Most of these have already been eliminated
@@ -1403,7 +1403,7 @@ namespace FlashLFQ
                             continue;
                         }
                     }
-                    else if (tryPeak.IsMbrPeak && storedPeak.IsMbrPeak)
+                    else if (tryPeak.DetectionType == DetectionType.MBR && storedPeak.DetectionType == DetectionType.MBR)
                     {
                         if (tryPeak.Identifications.First().ModifiedSequence == storedPeak.Identifications.First().ModifiedSequence)
                         {
@@ -1429,7 +1429,7 @@ namespace FlashLFQ
         private bool RunPEPAnalysis()
         {
             List<ChromatographicPeak> mbrPeaks = _results.Peaks.SelectMany(kvp => kvp.Value)
-                .Where(peak => peak.IsMbrPeak)
+                .Where(peak => peak.DetectionType == DetectionType.MBR)
                 .OrderByDescending(peak => peak.MbrScore)
                 .ToList();
 
@@ -1465,21 +1465,21 @@ namespace FlashLFQ
                 // Take only the top scoring acceptor for each donor (acceptor can be target or decoy!)
                 // Maybe we're sorting twice when we don't have to but idk if order is preserved using group by
                 mbrPeaks = _results.Peaks[acceptorFile]
-                    .Where(peak => peak.IsMbrPeak)
+                    .Where(peak => peak.DetectionType == DetectionType.MBR)
                     .GroupBy(peak => peak.Identifications.First())
                     .Select(group => group.OrderBy(peak => peak.MbrPep).ThenByDescending(peak => peak.MbrScore).First())
                     .OrderBy(peak => peak.MbrPep)
                     .ThenByDescending(peak => peak.MbrScore)
                     .ToList();
 
-                _results.Peaks[acceptorFile] = mbrPeaks.Concat(_results.Peaks[acceptorFile].Where(peak => !peak.IsMbrPeak)).ToList();
+                _results.Peaks[acceptorFile] = mbrPeaks.Concat(_results.Peaks[acceptorFile].Where(peak => peak.DetectionType != DetectionType.MBR)).ToList();
             }
             else
             {
                 // If PEP wasn't performed, things probably aren't calibrated very well, and so it's better
                 // To err on the safe side and not remove the decoys
                 mbrPeaks = _results.Peaks[acceptorFile]
-                    .Where(peak => peak.IsMbrPeak)
+                    .Where(peak => peak.DetectionType == DetectionType.MBR)
                     .OrderByDescending(peak => peak.MbrScore)
                     .ToList();
             }
@@ -2128,7 +2128,6 @@ namespace FlashLFQ
                             .Where(p => Within(p.Ms2RetentionTimeInMinutes, peakStart, PeakEnd))
                             .DistinctBy(p=>p.ModifiedSequence)
                             .ToList();
-                        isMBR = true;
                         detectionType = DetectionType.IsoTrack_MBR;
                         // If there are more than one Id from other files in the time window, then detectionType should be IsoTrack_Ambiguous.
                         if (idsForThisPeak.Count > 1) 
@@ -2138,11 +2137,9 @@ namespace FlashLFQ
 
                         break;
                     case 1: // If there is one Id from the same file in the time window, then detectionType should be MSMS.
-                        isMBR = false;
                         detectionType = DetectionType.MSMS;
                         break;
                     case > 1: // If there are more than one Id from the same file in the time window, then detectionType should be IsoTrack_Ambiguous.
-                        isMBR = true;
                         detectionType = DetectionType.IsoTrack_Ambiguous;
                         break;
                 }
@@ -2159,7 +2156,7 @@ namespace FlashLFQ
                 // Generate the practical time for searching. Time info: predicted RT, RtStartHypothesis, RtEndHypothesis
                 Tuple<double, double, double> rtInfo = new Tuple<double, double, double>(rt, start, end); 
 
-                ChromatographicPeak peak = FindChromPeak(rtInfo, xic, idsForThisPeak, isMBR, detectionType);
+                ChromatographicPeak peak = FindChromPeak(rtInfo, xic, idsForThisPeak, detectionType);
                 chromPeaksInSharedPeak.Add(peak);
             }
         }
@@ -2181,7 +2178,7 @@ namespace FlashLFQ
         /// <param name="idForChrom"></param>
         /// <param name="isMBR"></param>
         /// <returns></returns>
-        internal ChromatographicPeak FindChromPeak(Tuple<double, double, double> rtInfo, XIC xic, List<Identification> idsForChrom, bool isMBR = false, DetectionType detectionType = DetectionType.Default) 
+        internal ChromatographicPeak FindChromPeak(Tuple<double, double, double> rtInfo, XIC xic, List<Identification> idsForChrom, DetectionType detectionType) 
         {
             // Get the snippedPeaks from the window, then used for finding the isotopic envelope.
             List<IIndexedMzPeak> snippedPeaks = new ();
@@ -2207,11 +2204,11 @@ namespace FlashLFQ
             ChromatographicPeak acceptorPeak = null;
             if (idsForChrom.Count == 1)
             {
-                acceptorPeak = new ChromatographicPeak(id, isMBR, xic.SpectraFile, predictedRetentionTime: rtInfo.Item1, detectionType: detectionType);
+                acceptorPeak = new ChromatographicPeak(id, detectionType, xic.SpectraFile, predictedRetentionTime: rtInfo.Item1);
             }
             else
             {
-                acceptorPeak = new ChromatographicPeak(idsForChrom, isMBR, xic.SpectraFile, predictedRetentionTime: rtInfo.Item1, detectionType: detectionType);
+                acceptorPeak = new ChromatographicPeak(idsForChrom, detectionType, xic.SpectraFile, predictedRetentionTime: rtInfo.Item1);
             }
 
             IsotopicEnvelope bestEnvelopes = chargeEnvelopes.OrderByDescending(p => p.Intensity).First();

--- a/mzLib/FlashLFQ/FlashLfqEngine.cs
+++ b/mzLib/FlashLFQ/FlashLfqEngine.cs
@@ -591,7 +591,7 @@ namespace FlashLFQ
 
             Dictionary<string, List<ChromatographicPeak>> acceptorFileAllMsmsPeaks = _results.Peaks[acceptor]
                 .Where(peak => peak.NumIdentificationsByFullSeq == 1
-                    && peak.DetectionType != DetectionType.MSMS
+                    && peak.DetectionType == DetectionType.MSMS
                     && peak.IsotopicEnvelopes.Any()
                     && peak.Identifications.Min(id => id.QValue) < DonorQValueThreshold)
                 .GroupBy(peak => peak.Identifications.First().ModifiedSequence)

--- a/mzLib/FlashLFQ/MbrScorer.cs
+++ b/mzLib/FlashLFQ/MbrScorer.cs
@@ -39,7 +39,7 @@ namespace FlashLFQ
             Normal logIntensityDistribution)
         {
             ApexToAcceptorFilePeakDict = apexToAcceptorFilePeakDict;
-            UnambiguousMsMsAcceptorPeaks = acceptorFileMsmsPeaks.Where(p => p.Apex != null && !p.IsMbrPeak && p.NumIdentificationsByFullSeq == 1).ToList();
+            UnambiguousMsMsAcceptorPeaks = acceptorFileMsmsPeaks.Where(p => p.Apex != null && p.DetectionType != DetectionType.MBR && p.NumIdentificationsByFullSeq == 1).ToList();
             MaxNumberOfScansObserved = acceptorFileMsmsPeaks.Max(peak => peak.ScanCount);
             _logIntensityDistribution = logIntensityDistribution;
             _ppmDistribution = ppmDistribution;

--- a/mzLib/FlashLFQ/PEP/PepAnalysisEngine.cs
+++ b/mzLib/FlashLFQ/PEP/PepAnalysisEngine.cs
@@ -63,7 +63,7 @@ namespace FlashLFQ.PEP
             // this is target peak not target peptide
             List<DonorGroup> donors= new();
             foreach(var donorGroup in Peaks
-                .Where(peak => peak.IsMbrPeak)
+                .Where(peak => peak.DetectionType == DetectionType.MBR)
                 .OrderByDescending(peak => peak.MbrScore)
                 .GroupBy(peak => peak.Identifications.First())) //Group by donor peptide
             {

--- a/mzLib/TestFlashLFQ/ChromatographicPeakTests.cs
+++ b/mzLib/TestFlashLFQ/ChromatographicPeakTests.cs
@@ -63,5 +63,65 @@ namespace Test
             string expected = "sampleFile\tMPEPTIDE\tM[Oxidation]PEPTIDE\t\t\t100\t10\t2\t51.007276466879\t0\t-\t-\t-\t-\t-\t0\tMSMS\t\t\t1\t1\t1\t0\tNaN\tFalse\tFalse";
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        public void TestDetectionType()
+        {
+            // create the sample ChromatographicPeaks with different DetectionTypes
+            SpectraFileInfo spectraFileInfo = new SpectraFileInfo("sampleFile", "A", 1, 1, 1);
+            Identification identification = new Identification(spectraFileInfo, "MPEPTIDE", "M[Oxidation]PEPTIDE", 100, 10, 2, new List<ProteinGroup>());
+            IndexedMassSpectralPeak peak1 = new IndexedMassSpectralPeak(100, 300, 1, 9.5);
+            IndexedMassSpectralPeak peak2 = new IndexedMassSpectralPeak(100, 300, 1, 10.5);
+
+            ChromatographicPeak peak_MSMS = new ChromatographicPeak(identification, DetectionType.MSMS, spectraFileInfo);
+            ChromatographicPeak peak_MBR = new ChromatographicPeak(identification, DetectionType.MBR, spectraFileInfo);
+            ChromatographicPeak peak_IsoTecker_MBR = new ChromatographicPeak(identification, DetectionType.IsoTrack_MBR, spectraFileInfo);
+            ChromatographicPeak peak_IsoTecker_Amb = new ChromatographicPeak(identification, DetectionType.IsoTrack_Ambiguous, spectraFileInfo);
+
+            peak_MSMS.IsotopicEnvelopes = new List<IsotopicEnvelope>()
+            {
+                new IsotopicEnvelope(peak1, 2, 300, 1),
+                new IsotopicEnvelope(peak2, 2, 300, 1)
+            };
+            peak_MBR.IsotopicEnvelopes = new List<IsotopicEnvelope>()
+            {
+                new IsotopicEnvelope(peak1, 2, 300, 1),
+                new IsotopicEnvelope(peak2, 2, 300, 1)
+            };
+            peak_IsoTecker_MBR.IsotopicEnvelopes = new List<IsotopicEnvelope>()
+            {
+                new IsotopicEnvelope(peak1, 2, 300, 1),
+                new IsotopicEnvelope(peak2, 2, 300, 1)
+            };
+            peak_IsoTecker_Amb.IsotopicEnvelopes = new List<IsotopicEnvelope>()
+            {
+                new IsotopicEnvelope(peak1, 2, 300, 1),
+                new IsotopicEnvelope(peak2, 2, 300, 1)
+            };
+
+            // Test the DetectionType of the peaks
+            Assert.AreEqual(peak_MSMS.DetectionType, DetectionType.MSMS);
+            Assert.AreEqual(peak_MBR.DetectionType, DetectionType.MBR);
+            Assert.AreEqual(peak_IsoTecker_MBR.DetectionType, DetectionType.IsoTrack_MBR);
+            Assert.AreEqual(peak_IsoTecker_Amb.DetectionType, DetectionType.IsoTrack_Ambiguous);
+            
+            List<string> str_MSMS = peak_MSMS.ToString().Split("\t").ToList();
+            List<string> str_MBR = peak_MBR.ToString().Split("\t").ToList();
+            List<string> str_IsoTecker_MBR = peak_IsoTecker_MBR.ToString().Split("\t").ToList();
+            List<string> str_IsoTecker_Amb = peak_IsoTecker_Amb.ToString().Split("\t").ToList();
+
+            // Test the DetectionType output
+            Assert.AreEqual(str_MSMS[16], "MSMS");
+            Assert.AreEqual(str_MBR[16], "MBR");
+            Assert.AreEqual(str_IsoTecker_MBR[16], "MBR_IsoTrack");
+            Assert.AreEqual(str_IsoTecker_Amb[16], "IsoTrack_Ambiguous");
+
+            // The MS2Retention time will only be printed for MSMS peaks
+            Assert.AreEqual(str_MSMS[6], "10");
+            Assert.AreEqual(str_MBR[6], "");
+            Assert.AreEqual(str_IsoTecker_MBR[6], "");
+            Assert.AreEqual(str_IsoTecker_Amb[6], "");
+
+        }
     }
 }

--- a/mzLib/TestFlashLFQ/ChromatographicPeakTests.cs
+++ b/mzLib/TestFlashLFQ/ChromatographicPeakTests.cs
@@ -20,7 +20,7 @@ namespace Test
             Identification identification = new Identification(spectraFileInfo, "MPEPTIDE", "M[Oxidation]PEPTIDE", 100, 10, 2, new List<ProteinGroup>());
 
             // Create a ChromatographicPeak instance
-            ChromatographicPeak chromatographicPeak = new ChromatographicPeak(identification, false, spectraFileInfo);
+            ChromatographicPeak chromatographicPeak = new ChromatographicPeak(identification, DetectionType.MSMS, spectraFileInfo);
 
             IndexedMassSpectralPeak peak1 = new IndexedMassSpectralPeak(100, 300, 1, 9.5);
             IndexedMassSpectralPeak peak2 = new IndexedMassSpectralPeak(100, 300, 1, 10.5);

--- a/mzLib/TestFlashLFQ/TestFlashLFQ.cs
+++ b/mzLib/TestFlashLFQ/TestFlashLFQ.cs
@@ -62,7 +62,7 @@ namespace Test
             // check raw results
             Assert.That(results.Peaks[raw].Count == 1);
             Assert.That(results.Peaks[raw].First().Intensity > 0);
-            Assert.That(!results.Peaks[raw].First().IsMbrPeak);
+            Assert.That(results.Peaks[raw].First().DetectionType != DetectionType.MBR);
             Assert.That(results.PeptideModifiedSequences["EGFQVADGPLYR"].GetIntensity(raw) > 0);
 
             // NOTE: this is commented out because the protein quantity will be listed as NaN.
@@ -80,7 +80,7 @@ namespace Test
             // check mzml results
             Assert.That(results.Peaks[mzml].Count == 1);
             Assert.That(results.Peaks[mzml].First().Intensity > 0);
-            Assert.That(!results.Peaks[mzml].First().IsMbrPeak);
+            Assert.That(results.Peaks[mzml].First().DetectionType != DetectionType.MBR );
             Assert.That(results.PeptideModifiedSequences["EGFQVADGPLYR"].GetIntensity(mzml) > 0);
             //Assert.That(results.ProteinGroups["MyProtein"].GetIntensity(mzml) > 0);
 
@@ -121,7 +121,7 @@ namespace Test
             // check raw results
             Assert.That(results.Peaks[raw].Count == 1);
             Assert.That(results.Peaks[raw].First().Intensity > 0);
-            Assert.That(!results.Peaks[raw].First().IsMbrPeak);
+            Assert.That(results.Peaks[raw].First().DetectionType != DetectionType.MBR);
             Assert.That(results.PeptideModifiedSequences["EGFQVADGPLYR"].GetIntensity(raw) > 0);
 
             // NOTE: this is commented out because the protein quantity will be listed as NaN.
@@ -139,7 +139,7 @@ namespace Test
             // check mzml results
             Assert.That(results.Peaks[mzml].Count == 1);
             Assert.That(results.Peaks[mzml].First().Intensity > 0);
-            Assert.That(!results.Peaks[mzml].First().IsMbrPeak);
+            Assert.That(results.Peaks[mzml].First().DetectionType != DetectionType.MBR);
             Assert.That(results.PeptideModifiedSequences["EGFQVADGPLYR"].GetIntensity(mzml) > 0);
             //Assert.That(results.ProteinGroups["MyProtein"].GetIntensity(mzml) > 0);
 
@@ -180,7 +180,7 @@ namespace Test
             // check raw results
             Assert.That(results.Peaks[raw].Count == 1);
             Assert.That(results.Peaks[raw].First().Intensity > 0);
-            Assert.That(!results.Peaks[raw].First().IsMbrPeak);
+            Assert.That(results.Peaks[raw].First().DetectionType != DetectionType.MBR);
             Assert.That(results.PeptideModifiedSequences["EGFQVADGPLYR"].GetIntensity(raw) > 0);
 
             // NOTE: this is commented out because the protein quantity will be listed as NaN.
@@ -198,7 +198,7 @@ namespace Test
             // check mzml results
             Assert.That(results.Peaks[mzml].Count == 1);
             Assert.That(results.Peaks[mzml].First().Intensity > 0);
-            Assert.That(!results.Peaks[mzml].First().IsMbrPeak);
+            Assert.That(results.Peaks[mzml].First().DetectionType != DetectionType.MBR);
             Assert.That(results.PeptideModifiedSequences["EGFQVADGPLYR"].GetIntensity(mzml) > 0);
             //Assert.That(results.ProteinGroups["MyProtein"].GetIntensity(mzml) > 0);
 
@@ -239,7 +239,7 @@ namespace Test
             // check raw results
             Assert.That(results.Peaks[raw].Count == 1);
             Assert.That(results.Peaks[raw].First().Intensity > 0);
-            Assert.That(!results.Peaks[raw].First().IsMbrPeak);
+            Assert.That(results.Peaks[raw].First().DetectionType != DetectionType.MBR);
             Assert.That(results.PeptideModifiedSequences["EGF[+42]QVADGPLYR"].GetIntensity(raw) > 0);
 
             // NOTE: this is commented out because the protein quantity will be listed as NaN.
@@ -257,7 +257,7 @@ namespace Test
             // check mzml results
             Assert.That(results.Peaks[mzml].Count == 1);
             Assert.That(results.Peaks[mzml].First().Intensity > 0);
-            Assert.That(!results.Peaks[mzml].First().IsMbrPeak);
+            Assert.That(results.Peaks[mzml].First().DetectionType != DetectionType.MBR);
             Assert.That(results.PeptideModifiedSequences["EGF[+42]QVADGPLYR"].GetIntensity(mzml) > 0);
             //Assert.That(results.ProteinGroups["MyProtein"].GetIntensity(mzml) > 0);
 
@@ -298,14 +298,14 @@ namespace Test
             // check raw results
             Assert.That(results.Peaks[raw].Count == 1);
             Assert.That(results.Peaks[raw].First().Intensity > 0);
-            Assert.That(!results.Peaks[raw].First().IsMbrPeak);
+            Assert.That(results.Peaks[raw].First().DetectionType != DetectionType.MBR);
             Assert.That(results.PeptideModifiedSequences["EGFQVAD[15.99]GPLYR"].GetIntensity(raw) > 0);
             //Assert.That(results.ProteinGroups["MyProtein"].GetIntensity(raw) > 0);
 
             // check mzml results
             Assert.That(results.Peaks[mzml].Count == 1);
             Assert.That(results.Peaks[mzml].First().Intensity > 0);
-            Assert.That(!results.Peaks[mzml].First().IsMbrPeak);
+            Assert.That(results.Peaks[mzml].First().DetectionType != DetectionType.MBR);
             Assert.That(results.PeptideModifiedSequences["EGFQVAD[15.99]GPLYR"].GetIntensity(mzml) > 0);
             //Assert.That(results.ProteinGroups["MyProtein"].GetIntensity(mzml) > 0);
 
@@ -600,9 +600,9 @@ namespace Test
             var results = engine.Run();
 
             Assert.That(results.Peaks[file2].Count == 5);
-            Assert.That(results.Peaks[file2].Where(p => p.IsMbrPeak).Count() == 1);
+            Assert.That(results.Peaks[file2].Count(p => p.DetectionType == DetectionType.MBR) == 1);
 
-            var peak = results.Peaks[file2].Where(p => p.IsMbrPeak).First();
+            var peak = results.Peaks[file2].First(p => p.DetectionType == DetectionType.MBR);
             var otherFilePeak = results.Peaks[file1].Where(p => p.Identifications.First().BaseSequence ==
                 peak.Identifications.First().BaseSequence).First();
 
@@ -616,10 +616,10 @@ namespace Test
             }
 
             Assert.That(results.Peaks[file1].Count == 5);
-            Assert.That(!results.Peaks[file1].Any(p => p.IsMbrPeak));
+            Assert.That(!results.Peaks[file1].Any(p => p.DetectionType == DetectionType.MBR));
 
             results = interquartileEngine.Run();
-            peak = results.Peaks[file2].Where(p => p.IsMbrPeak).First();
+            peak = results.Peaks[file2].Where(p => p.DetectionType == DetectionType.MBR).First();
 
             for (int i = 0; i < 5; i++)
             {
@@ -634,7 +634,7 @@ namespace Test
             Assert.False(results.PeptideModifiedSequences.Select(kvp => kvp.Key).Contains("DECOYPEP"));
             Assert.False(results.Peaks[file1].Any(peak => peak.Identifications.Any(id => id.ModifiedSequence.Contains("DECOYPEP"))));
             Assert.That(results.Peaks[file2].Any(peak => peak.Identifications.First().ModifiedSequence == "TARGETPEP"));
-            Assert.AreEqual(results.Peaks[file2].Count(peak => peak.IsMbrPeak), 2);
+            Assert.AreEqual(results.Peaks[file2].Count(peak => peak.DetectionType == DetectionType.MBR), 2);
         }
 
         [Test]
@@ -1014,7 +1014,7 @@ namespace Test
                 new List<ProteinGroup> { proteinGroup });
             string idString = identification.ToString();
 
-            var chromPeak = new ChromatographicPeak(identification, false, spectraFile);
+            var chromPeak = new ChromatographicPeak(identification, DetectionType.MSMS, spectraFile);
             string chromPeakString = chromPeak.ToString();
             chromPeak.CalculateIntensityForThisFeature(true);
             string peakAfterCalculatingIntensity = chromPeak.ToString();
@@ -1059,7 +1059,7 @@ namespace Test
 
             Assert.That(results.Peaks[mzml].Count == 1);
             Assert.That(results.Peaks[mzml].First().Intensity > 0);
-            Assert.That(!results.Peaks[mzml].First().IsMbrPeak);
+            Assert.That(results.Peaks[mzml].First().DetectionType != DetectionType.MBR);
             Assert.That(results.Peaks[mzml].First().NumIdentificationsByFullSeq == 2);
             Assert.That(results.PeptideModifiedSequences["EGFQVADGPLYR"].GetIntensity(mzml) == 0);
             Assert.That(results.PeptideModifiedSequences["EGFQVADGPLRY"].GetIntensity(mzml) == 0);
@@ -1078,7 +1078,7 @@ namespace Test
 
             Assert.That(results.Peaks[mzml].Count == 1);
             Assert.That(results.Peaks[mzml].First().Intensity > 0);
-            Assert.That(!results.Peaks[mzml].First().IsMbrPeak);
+            Assert.That(results.Peaks[mzml].First().DetectionType != DetectionType.MBR);
             Assert.That(results.Peaks[mzml].First().NumIdentificationsByFullSeq == 2);
             Assert.That(results.PeptideModifiedSequences["EGFQVADGPLYR"].GetIntensity(mzml) > 0);
             Assert.That(results.PeptideModifiedSequences["EGFQVADGPLRY"].GetIntensity(mzml) > 0);
@@ -1346,8 +1346,8 @@ namespace Test
             var peptides = results.PeptideModifiedSequences.Values.ToList();
             var proteins = results.ProteinGroups.Values.ToList();
 
-            Assert.AreEqual(4, peaks[0].Count(m => m.IsMbrPeak == false));
-            Assert.AreEqual(5, peaks[1].Count(m => m.IsMbrPeak == false));
+            Assert.AreEqual(4, peaks[0].Count(m => m.DetectionType != DetectionType.MBR));
+            Assert.AreEqual(5, peaks[1].Count(m => m.DetectionType != DetectionType.MBR));
 
             CollectionAssert.AreEquivalent(new string[] { "Q7KZF4", "Q7KZF4", "P52298", "Q15149", "Q15149" }, peaks[0].SelectMany(i => i.Identifications).Select(g => g.ProteinGroups.First()).Select(m => m.ProteinGroupName).ToArray());
             CollectionAssert.AreEquivalent(new string[] { "Q7KZF4", "P52298", "Q15149", "Q15149", "Q7KZF4", "Q7KZF4", "P52298" }, peaks[1].SelectMany(i => i.Identifications).Select(g => g.ProteinGroups.First()).Select(m => m.ProteinGroupName).ToArray());
@@ -1771,8 +1771,8 @@ namespace Test
             Identification id2 = new Identification(fraction2, "peptide1", "peptide1", 0, 0, 0, new List<ProteinGroup>());
             Identification id3 = new Identification(fraction2, "peptide2", "peptide2", 0, 0, 0, new List<ProteinGroup>());
 
-            ChromatographicPeak peak1 = new ChromatographicPeak(id1, false, fraction1);
-            ChromatographicPeak peak2 = new ChromatographicPeak(id2, false, fraction1);
+            ChromatographicPeak peak1 = new ChromatographicPeak(id1, DetectionType.MSMS, fraction1);
+            ChromatographicPeak peak2 = new ChromatographicPeak(id2, DetectionType.MSMS, fraction1);
             peak2.Identifications.Add(id3);
 
             peak1.ResolveIdentifications();

--- a/mzLib/TestFlashLFQ/TestPipEcho.cs
+++ b/mzLib/TestFlashLFQ/TestPipEcho.cs
@@ -28,8 +28,8 @@ namespace Test
             SpectraFileInfo fakeFile = new SpectraFileInfo("fakeFile", "A", 1, 1, 1);
             Identification id = new Identification(fakeFile, "KPVGAAK", "KPVGAAK", 669.4173, 1.9398, 2, new List<ProteinGroup> { new ProteinGroup("P16403", "H12", "HUMAN") });
 
-            ChromatographicPeak targetPeak = new ChromatographicPeak(id, isMbrPeak: true, fakeFile, randomRt: false);
-            ChromatographicPeak decoyPeak = new ChromatographicPeak(id, isMbrPeak: true, fakeFile, randomRt: true);
+            ChromatographicPeak targetPeak = new ChromatographicPeak(id, DetectionType.MBR, fakeFile, randomRt: false);
+            ChromatographicPeak decoyPeak = new ChromatographicPeak(id, DetectionType.MBR, fakeFile, randomRt: true);
             targetPeak.MbrScore = 100;
 
             Random random = new Random(42);
@@ -80,12 +80,12 @@ namespace Test
             id2.PeakfindingMass = idMass;
             donorId.PeakfindingMass = idMass;
 
-            var peak1 = new ChromatographicPeak(id, isMbrPeak: false, fakeFile, randomRt: false);
-            var peak2 = new ChromatographicPeak(id, isMbrPeak: false, fakeFile, randomRt: false);
-            var peak3 = new ChromatographicPeak(id2, isMbrPeak: false, fakeFile, randomRt: false);
-            var peak4 = new ChromatographicPeak(id, isMbrPeak: false, fakeFile, randomRt: false);
-            var donorPeak = new ChromatographicPeak(donorId, isMbrPeak: false, fakeDonorFile, randomRt: false);
-            var acceptorPeak = new ChromatographicPeak(donorId, isMbrPeak: true, fakeFile, randomRt: false);
+            var peak1 = new ChromatographicPeak(id, DetectionType.MSMS, fakeFile, randomRt: false);
+            var peak2 = new ChromatographicPeak(id, DetectionType.MSMS, fakeFile, randomRt: false);
+            var peak3 = new ChromatographicPeak(id2, DetectionType.MSMS, fakeFile, randomRt: false);
+            var peak4 = new ChromatographicPeak(id, DetectionType.MSMS, fakeFile, randomRt: false);
+            var donorPeak = new ChromatographicPeak(donorId, DetectionType.MSMS, fakeDonorFile, randomRt: false);
+            var acceptorPeak = new ChromatographicPeak(donorId, DetectionType.MSMS, fakeFile, randomRt: false);
 
             IndexedMassSpectralPeak imsPeak = new IndexedMassSpectralPeak((idMass + 0.001).ToMz(1), 1.1, 1, 25);
             IndexedMassSpectralPeak imsPeak2 = new IndexedMassSpectralPeak((idMass - 0.001).ToMz(1), 1, 2, 26);
@@ -138,10 +138,11 @@ namespace Test
             Identification id = new Identification(fakeFile, "KPVGAAK", "KPVGAAK", 669.4173, 1.9398, 2, new List<ProteinGroup> { new ProteinGroup("P16403", "H12", "HUMAN") });
             Identification id2 = new Identification(fakeFile, "KPVGK", "KPVGK", 669.4173, 1.9398, 2, new List<ProteinGroup> { new ProteinGroup("P16403", "H12", "HUMAN") });
 
-            var peak1 = new ChromatographicPeak(id, isMbrPeak: true, fakeFile, randomRt: false);
-            var peak2 = new ChromatographicPeak(id, isMbrPeak: true, fakeFile, randomRt: false);
-            var peak3 = new ChromatographicPeak(id2, isMbrPeak: true, fakeFile, randomRt: false);
-            var peak4 = new ChromatographicPeak(id, isMbrPeak: true, fakeFile, randomRt: false);
+            var peak1 = new ChromatographicPeak(id, DetectionType.MBR, fakeFile, randomRt: false);
+            var peak2 = new ChromatographicPeak(id, DetectionType.MBR, fakeFile, randomRt: false);
+            var peak3 = new ChromatographicPeak(id2, DetectionType.MBR, fakeFile, randomRt: false);
+            var peak4 = new ChromatographicPeak(id, DetectionType.MBR, fakeFile, randomRt: false);
+
 
             IndexedMassSpectralPeak imsPeak = new IndexedMassSpectralPeak(1, 1, 1, 25);
             IndexedMassSpectralPeak imsPeak2 = new IndexedMassSpectralPeak(1, 1, 1, 50);
@@ -275,9 +276,9 @@ namespace Test
             var results = neighborsEngine.Run();
 
             Assert.That(results.Peaks[file2].Count == 5);
-            Assert.That(results.Peaks[file2].Where(p => p.IsMbrPeak).Count() == 1);
+            Assert.That(results.Peaks[file2].Count(p => p.DetectionType == DetectionType.MBR) == 1);
 
-            var peak = results.Peaks[file2].Where(p => p.IsMbrPeak).First();
+            var peak = results.Peaks[file2].First(p => p.DetectionType == DetectionType.MBR);
             var otherFilePeak = results.Peaks[file1].Where(p => p.Identifications.First().BaseSequence ==
                 peak.Identifications.First().BaseSequence).First();
 
@@ -294,9 +295,9 @@ namespace Test
             results = intensityEngine.Run();
 
             Assert.That(results.Peaks[file2].Count == 5);
-            Assert.That(results.Peaks[file2].Where(p => p.IsMbrPeak).Count() == 1);
+            Assert.That(results.Peaks[file2].Count(p => p.DetectionType == DetectionType.MBR) == 1);
 
-            peak = results.Peaks[file2].Where(p => p.IsMbrPeak).First();
+            peak = results.Peaks[file2].First(p => p.DetectionType == DetectionType.MBR);
             otherFilePeak = results.Peaks[file3].Where(p => p.Identifications.First().BaseSequence ==
                 peak.Identifications.First().BaseSequence).First();
 


### PR DESCRIPTION
Due to more chromatographic Peak detectionTypes, only IsMBR is insufficient to handle it.
In this pull request, I try to replace the argument with the DetectionType property.
For example:
IsMBR -> peak.DetectionType == DetectionType.MBR
!IsMBR -> peak.DetectionType != DetectionType.MBR

![PR](https://github.com/user-attachments/assets/9f15a670-d1a1-4aff-a391-e271171a9f4f)