### PR TITLE
IsoTracker: Change searching target

### DIFF
--- a/mzLib/FlashLFQ/IsoTracker/IsobaricPeptide.cs
+++ b/mzLib/FlashLFQ/IsoTracker/IsobaricPeptide.cs
@@ -1,0 +1,22 @@
+﻿using MzLibUtil;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FlashLFQ.IsoTracker
+{
+    public class IsobaricPeptide
+    {
+        public double MaxMass { get; private set; } // The mass of the isobaric peptide
+        public List<Identification> Ids { get; set; } // The identification of the isobaric peptide
+
+        public IsobaricPeptide(Identification id, string ppm)
+        {
+            Ids = new List<Identification>() {id};
+            Tolerance tolerance = Tolerance.ParseToleranceString(ppm);
+            MaxMass = tolerance.GetMaximumValue(id.PeakfindingMass);
+        }
+    }
+}


### PR DESCRIPTION
The origin searching target is **"the peptide with same base seq and same mass**"
But the definition of an Isobaric peptide is "**whatever peptide with the same mass**"
We changed the search target