### PR TITLE
Isotracker: Acceptable peak width

### DIFF
--- a/mzLib/FlashLFQ/FlashLfqEngine.cs
+++ b/mzLib/FlashLFQ/FlashLfqEngine.cs
@@ -48,6 +48,7 @@ namespace FlashLFQ
         public readonly bool IsoTracker; //Searching parameter for the FlashLFQ engine
         public bool IsoTrackerIsRunning { get; private set;} // a flag used to indicate if the isobaric case is running, used to control the indexEngine
         public ConcurrentDictionary<string, Dictionary<PeakRegion, List<ChromatographicPeak>>> IsobaricPeptideDict { get; private set; } // The dictionary of isobaric peaks for each modified sequence
+        public double AcceptablePeakWidthForSearch;
 
         // MBR settings
         public readonly bool MatchBetweenRuns;
@@ -123,6 +124,7 @@ namespace FlashLFQ
 
             // IsoTracker settings
             bool isoTracker = false,
+            double acceptablePeakWidthForSearch = 0.3,
 
             // MBR settings
             bool matchBetweenRuns = false,
@@ -179,6 +181,7 @@ namespace FlashLFQ
             UseSharedPeptidesForProteinQuant = useSharedPeptidesForProteinQuant;
             //IsoTracker settings
             IsoTracker = isoTracker;
+            AcceptablePeakWidthForSearch = acceptablePeakWidthForSearch;
 
             // MBR settings
             MatchBetweenRuns = matchBetweenRuns;
@@ -2022,8 +2025,8 @@ namespace FlashLFQ
                             //Step 4: Iterate the shared peaks in the XICGroups
                             foreach (var peak in xICGroups.SharedPeaks)
                             {
-                                double peakWindow = peak.Width;
-                                if (peakWindow > 0.001) //make sure we have enough length of the window (0.001 min) for peak searching
+                                double peakWidth = peak.Width;
+                                if (peakWidth > AcceptablePeakWidthForSearch) //make sure we have enough length of the window (default value : 0.5 min) for peak searching
                                 {
                                     List<ChromatographicPeak> chromPeaksInSharedPeak = new List<ChromatographicPeak>();
                                     CollectChromPeakInRuns(peak, chromPeaksInSharedPeak, xICGroups);

--- a/mzLib/FlashLFQ/FlashLfqEngine.cs
+++ b/mzLib/FlashLFQ/FlashLfqEngine.cs
@@ -124,7 +124,7 @@ namespace FlashLFQ
 
             // IsoTracker settings
             bool isoTracker = false,
-            double acceptablePeakWidthForSearch = 0.3,
+            double acceptablePeakWidthForSearch = 0.4,
 
             // MBR settings
             bool matchBetweenRuns = false,

--- a/mzLib/FlashLFQ/IsoTracker/XICGroups.cs
+++ b/mzLib/FlashLFQ/IsoTracker/XICGroups.cs
@@ -203,7 +203,7 @@ namespace FlashLFQ.IsoTracker
         /// </summary>
         /// /// <param name="windowLimit"> The minimum time window to generate a peak region</param>
         /// <returns></returns>
-        public List<PeakRegion> BuildSharedPeaks(double windowLimit = 0.5)
+        public List<PeakRegion> BuildSharedPeaks(double windowLimit = 0.4)
         {
             var sharedPeaks = new List<PeakRegion>();
             foreach (var extremumPoint in SharedExtrema.Where(p=>p.Type == ExtremumType.Maximum))

--- a/mzLib/FlashLFQ/IsoTracker/XICGroups.cs
+++ b/mzLib/FlashLFQ/IsoTracker/XICGroups.cs
@@ -91,9 +91,7 @@ namespace FlashLFQ.IsoTracker
 
             SharedExtrema = group_min.Concat(group_max).ToList();
             SharedExtrema.Sort((p1, p2) => p1.RetentionTime.CompareTo(p2.RetentionTime)); // sort the shared extrema by the retention time
-            SharePeakTrimming();
-
-
+            ExtremaTrimming(); // Trim the close extrema points by same type 
         }
 
         /// <summary>
@@ -146,7 +144,7 @@ namespace FlashLFQ.IsoTracker
         /// Trim the shared extremas in the close time range. Ex. if the two minimums are close and the intensity is going up, remove the first one
         /// </summary>
         /// <param name="cutOff"> The time range for trimming</param>
-        private void SharePeakTrimming(double cutOff = 0.3) 
+        private void ExtremaTrimming(double cutOff = 0.1) 
         {
             int removeIndex = 0;
             int count = SharedExtrema.Count();
@@ -205,7 +203,7 @@ namespace FlashLFQ.IsoTracker
         /// </summary>
         /// /// <param name="windowLimit"> The minimum time window to generate a peak region</param>
         /// <returns></returns>
-        public List<PeakRegion> BuildSharedPeaks(double windowLimit = 0.3)
+        public List<PeakRegion> BuildSharedPeaks(double windowLimit = 0.5)
         {
             var sharedPeaks = new List<PeakRegion>();
             foreach (var extremumPoint in SharedExtrema.Where(p=>p.Type == ExtremumType.Maximum))


### PR DESCRIPTION
In Isotracker, we will start searching from the peak region. However, too many peaks are identified and reported in the output. In order to eliminate the noise report, we create two parameters to set up the acceptable peak width to control the resulting quality.
(1) Acceptable width for peak generating: In the XIC groups class, every peak over this value can be generated.
(2) Acceptable peak width for IsoTracker searching: any peak region over the value can be searched for isobaric peaks.