### PR TITLE
Minor changes related  to timsTOF reading/search

### DIFF
--- a/mzLib/Readers/InternalResults/IndividualResultRecords/SpectrumMatchFromTsvHeader.cs
+++ b/mzLib/Readers/InternalResults/IndividualResultRecords/SpectrumMatchFromTsvHeader.cs
@@ -15,6 +15,7 @@
         public const string PrecursorIntensity = "Precursor Intensity";
         public const string PrecursorMz = "Precursor MZ";
         public const string PrecursorMass = "Precursor Mass";
+        public const string OneOverK0 = "1/K0";
         public const string Score = "Score";
         public const string DeltaScore = "Delta Score";
         public const string Notch = "Notch";

--- a/mzLib/Readers/timsTOF/FrameProxy.cs
+++ b/mzLib/Readers/timsTOF/FrameProxy.cs
@@ -97,9 +97,13 @@ namespace Readers
             }
         }
 
+        /// <summary>
+        /// Returns retention time in minutes for a given frame ID.
+        /// </summary>
+        /// <returns>Retention time in minutes</returns>
         internal double GetRetentionTime(long frameId)
         {
-            return (double)FramesTable.RetentionTime[frameId - 1];
+            return (double)FramesTable.RetentionTime[frameId - 1] / 60;
         }
 
         internal double GetInjectionTime(long frameId)

--- a/mzLib/Test/FileReadingTests/TestTimsTofFileReader.cs
+++ b/mzLib/Test/FileReadingTests/TestTimsTofFileReader.cs
@@ -219,6 +219,7 @@ namespace Test.FileReadingTests
             Assert.That(_testMs2Scan.ScanNumberStart == 410);
             Assert.That(_testMs2Scan.OneOverK0, Is.EqualTo(1.0424).Within(0.0001));
             Assert.That(_testReader.Scans.All(s => s != null));
+            Assert.That(_testMs1Scan.RetentionTime, Is.EqualTo(11.28).Within(0.01));
         }
 
         [Test]


### PR DESCRIPTION
timsTOF files store their retention times in seconds, not minutes. The reader now recognizes this and converts the RT to minutes.

Added a new Property to the SpectrumMatchFromTsvHeader, "OneOverK0". This will allow us to include ion mobility information in .psmtsv outputs