### PR TITLE
Tims tof reader fix to enable reading off of NAS

### DIFF
--- a/mzLib/Readers/timsTOF/TimsTofFileReader.cs
+++ b/mzLib/Readers/timsTOF/TimsTofFileReader.cs
@@ -79,8 +79,8 @@ namespace Readers
                 return;
 
             _sqlConnection = new SQLiteConnection("Data Source=" +
-                Path.Combine(FilePath, "analysis.tdf") +
-                "; Version=3");
+                                    Path.Combine(FilePath, "analysis.tdf") +
+                                    "; Version=3", parseViaFramework: true);
             try
             {
                 _sqlConnection.Open();

--- a/mzLib/Test/FileReadingTests/TestTimsTofFileReader.cs
+++ b/mzLib/Test/FileReadingTests/TestTimsTofFileReader.cs
@@ -18,7 +18,8 @@ namespace Test.FileReadingTests
     public class TestTimsTofFileReader
     {
 
-        public string _testDataPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "DataFiles", "timsTOF_snippet.d");
+        //public string _testDataPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "DataFiles", "timsTOF_snippet.d");
+        public string _testDataPath = @"\\bison.chem.wisc.edu\share\Users\AlexanderS_Bison\timsTOF reader\MetaDrawTest\Bulk_Elastase_100ng_DDAPASEF_Slot1-47_1_11945.d";
         public TimsTofFileReader _testReader;
         public TimsDataScan _testMs2Scan;
         public TimsDataScan _testMs1Scan;

--- a/mzLib/Test/FileReadingTests/TestTimsTofFileReader.cs
+++ b/mzLib/Test/FileReadingTests/TestTimsTofFileReader.cs
@@ -18,8 +18,7 @@ namespace Test.FileReadingTests
     public class TestTimsTofFileReader
     {
 
-        //public string _testDataPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "DataFiles", "timsTOF_snippet.d");
-        public string _testDataPath = @"\\bison.chem.wisc.edu\share\Users\AlexanderS_Bison\timsTOF reader\MetaDrawTest\Bulk_Elastase_100ng_DDAPASEF_Slot1-47_1_11945.d";
+        public string _testDataPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "DataFiles", "timsTOF_snippet.d");
         public TimsTofFileReader _testReader;
         public TimsDataScan _testMs2Scan;
         public TimsDataScan _testMs1Scan;


### PR DESCRIPTION
Previously, attempting to read in a timsTOF file stored on a NAS drive (e.g., bison) would cause the reader to throw an exception.

This PR changes how the SQL connection is configured to enable reading off of NAS drives.