### PR TITLE
added setIsolationRange in MsDataScan

### DIFF
--- a/mzLib/MassSpectrometry/MsDataScan.cs
+++ b/mzLib/MassSpectrometry/MsDataScan.cs
@@ -292,6 +292,11 @@ namespace MassSpectrometry
             this.IsolationMz = value;
         }
 
+        public void SetIsolationRange(double min, double max)
+        {
+            this.isolationRange = new MzRange(min, max);
+        }
+
         private IEnumerable<double> GetNoiseDataMass(double[,] noiseData)
         {
             for (int i = 0; i < noiseData.Length / 3; i++)

--- a/mzLib/Test/FileReadingTests/TestMsDataFile.cs
+++ b/mzLib/Test/FileReadingTests/TestMsDataFile.cs
@@ -164,6 +164,10 @@ namespace Test.FileReadingTests
 
             theSpectrum.SetMsnOrder(2);
             Assert.AreEqual(2, theSpectrum.MsnOrder);
+
+            theSpectrum.SetIsolationRange(400, 2000);
+            Assert.AreEqual(400, theSpectrum.IsolationRange.Minimum);
+            Assert.AreEqual(2000, theSpectrum.IsolationRange.Maximum);
         }
 
         [Test]


### PR DESCRIPTION
Added a setter for isolation range in MsDataScan to analyze some mzML files that do not have a defined isolation range