### PR TITLE
Update dotnet.yml to increase timeout time

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: windows-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
     - uses: actions/checkout@v2
     - name: Set up .NET


### PR DESCRIPTION
Recently had a build cancelled due to time out. Tests were actively running, but we hit 15 minutes and it was cancelled