### PR TITLE
GetAllXics with cutPeak

### DIFF
--- a/mzLib/MassSpectrometry/PeakIndexing/ExtractedIonChromatogram.cs
+++ b/mzLib/MassSpectrometry/PeakIndexing/ExtractedIonChromatogram.cs
@@ -19,7 +19,8 @@ namespace MassSpectrometry
 
         public double ApexRT;
         public int ApexScanIndex;
-        public double AveragedM => AverageM();
+        public double ApexIntensity;
+        public double AveragedM;
         public (double, double)[] XYData { get; set; }
         public double[] NormalizedPeakIntensities { get; set; }
         public double StartRT { get; set; }
@@ -41,7 +42,7 @@ namespace MassSpectrometry
         public ExtractedIonChromatogram(List<IIndexedPeak> peaks)
         {
             Peaks = peaks;
-            SetRtInfo();
+            SetXicInfo();
         }
 
         public void SetNormalizedPeakIntensities()
@@ -138,7 +139,7 @@ namespace MassSpectrometry
             CutPeak(Peaks, discriminationFactorToCutPeak);
             if (updateRtInfo)
             {
-                SetRtInfo(); // Update RT info after cutting the peak
+                SetXicInfo(); // Update RT info after cutting the peak
             }
         }
 
@@ -154,14 +155,16 @@ namespace MassSpectrometry
             RemovePeaks(peaks, peakBoundaries, apexPeak.RetentionTime);
         }
 
-        public void SetRtInfo()
+        public void SetXicInfo()
         {
             ApexRT = Peaks.MaxBy(p => p.Intensity).RetentionTime;
+            ApexIntensity = Peaks.MaxBy(p => p.Intensity).Intensity;
             StartRT = Peaks.Min(p => p.RetentionTime);
             EndRT = Peaks.Max(p => p.RetentionTime);
             ApexScanIndex = Peaks.MaxBy(p => p.Intensity).ZeroBasedScanIndex;
             StartScanIndex = Peaks.Min(p => p.ZeroBasedScanIndex);
             EndScanIndex = Peaks.Max(p => p.ZeroBasedScanIndex);
+            AveragedM = AverageM();
         }
     }
 }

--- a/mzLib/MassSpectrometry/PeakIndexing/ExtractedIonChromatogram.cs
+++ b/mzLib/MassSpectrometry/PeakIndexing/ExtractedIonChromatogram.cs
@@ -19,7 +19,7 @@ namespace MassSpectrometry
         public IIndexedPeak ApexPeak;
         public double ApexRT => ApexPeak.RetentionTime;
         public int ApexScanIndex => ApexPeak.ZeroBasedScanIndex;
-        public double AveragedM;
+        public double AveragedMassOrMz;
         public (double, double)[] XYData { get; set; }
         public double[] NormalizedPeakIntensities { get; set; }
         public double StartRT { get; set; }
@@ -150,7 +150,7 @@ namespace MassSpectrometry
             EndRT = Peaks.Max(p => p.RetentionTime);
             StartScanIndex = Peaks.Min(p => p.ZeroBasedScanIndex);
             EndScanIndex = Peaks.Max(p => p.ZeroBasedScanIndex);
-            AveragedM = AverageM();
+            AveragedMassOrMz = AverageM();
         }
     }
 }

--- a/mzLib/MassSpectrometry/PeakIndexing/ExtractedIonChromatogram.cs
+++ b/mzLib/MassSpectrometry/PeakIndexing/ExtractedIonChromatogram.cs
@@ -129,27 +129,16 @@ namespace MassSpectrometry
         }
 
         /// <summary>
-        /// Find the peak boundaries of this ExtractedIonChromatogram and remove the peaks that are outside of the boundaries.
+        /// Find the peak boundaries of XIC and remove the peaks that are outside of the boundaries.
         /// </summary>
         public void CutPeak(double discriminationFactorToCutPeak = 0.6, bool updateRtInfo = true)
         {
-            CutPeak(Peaks, discriminationFactorToCutPeak);
+            var peakBoundaries = FindPeakBoundaries(Peaks, Peaks.IndexOf(ApexPeak), discriminationFactorToCutPeak);
+            RemovePeaks(Peaks, peakBoundaries, ApexPeak.RetentionTime);
             if (updateRtInfo)
             {
                 SetXicInfo(); // Update RT info after cutting the peak
             }
-        }
-
-        /// <summary>
-        /// Find the peak boundaries of any IIndexedPeak list and remove the peaks that are outside of the boundaries.
-        /// </summary>
-        public static void CutPeak(List<IIndexedPeak> peaks, double discriminationFactorToCutPeak = 0.6)
-        {
-            if (peaks == null || peaks.Count < 5) return;
-            var apexPeak = peaks.MaxBy(p => p.Intensity);
-            peaks.Sort((x, y) => x.RetentionTime.CompareTo(y.RetentionTime));
-            var peakBoundaries = FindPeakBoundaries(peaks, peaks.IndexOf(apexPeak), discriminationFactorToCutPeak);
-            RemovePeaks(peaks, peakBoundaries, apexPeak.RetentionTime);
         }
 
         public void SetXicInfo()

--- a/mzLib/MassSpectrometry/PeakIndexing/ExtractedIonChromatogram.cs
+++ b/mzLib/MassSpectrometry/PeakIndexing/ExtractedIonChromatogram.cs
@@ -139,7 +139,7 @@ namespace MassSpectrometry
             RemovePeaks(Peaks, peakBoundaries, ApexPeak.RetentionTime);
             if (updateRtInfo)
             {
-                SetXicInfo(); // Update RT info after cutting the peak
+                SetXicInfo(); // Update XIC info after cutting the peak
             }
         }
 

--- a/mzLib/MassSpectrometry/PeakIndexing/ExtractedIonChromatogram.cs
+++ b/mzLib/MassSpectrometry/PeakIndexing/ExtractedIonChromatogram.cs
@@ -16,10 +16,7 @@ namespace MassSpectrometry
     public class ExtractedIonChromatogram
     {
         public virtual List<IIndexedPeak> Peaks { get; set; }
-
-        public double ApexRT;
-        public int ApexScanIndex;
-        public double ApexIntensity;
+        public IIndexedPeak ApexPeak;
         public double AveragedM;
         public (double, double)[] XYData { get; set; }
         public double[] NormalizedPeakIntensities { get; set; }
@@ -157,11 +154,9 @@ namespace MassSpectrometry
 
         public void SetXicInfo()
         {
-            ApexRT = Peaks.MaxBy(p => p.Intensity).RetentionTime;
-            ApexIntensity = Peaks.MaxBy(p => p.Intensity).Intensity;
+            ApexPeak = Peaks.MaxBy(p => p.Intensity);
             StartRT = Peaks.Min(p => p.RetentionTime);
             EndRT = Peaks.Max(p => p.RetentionTime);
-            ApexScanIndex = Peaks.MaxBy(p => p.Intensity).ZeroBasedScanIndex;
             StartScanIndex = Peaks.Min(p => p.ZeroBasedScanIndex);
             EndScanIndex = Peaks.Max(p => p.ZeroBasedScanIndex);
             AveragedM = AverageM();

--- a/mzLib/MassSpectrometry/PeakIndexing/ExtractedIonChromatogram.cs
+++ b/mzLib/MassSpectrometry/PeakIndexing/ExtractedIonChromatogram.cs
@@ -17,6 +17,8 @@ namespace MassSpectrometry
     {
         public virtual List<IIndexedPeak> Peaks { get; set; }
         public IIndexedPeak ApexPeak;
+        public double ApexRT => ApexPeak.RetentionTime;
+        public int ApexScanIndex => ApexPeak.ZeroBasedScanIndex;
         public double AveragedM;
         public (double, double)[] XYData { get; set; }
         public double[] NormalizedPeakIntensities { get; set; }

--- a/mzLib/MassSpectrometry/PeakIndexing/IndexingEngine.cs
+++ b/mzLib/MassSpectrometry/PeakIndexing/IndexingEngine.cs
@@ -194,11 +194,11 @@ namespace MassSpectrometry
         /// <summary>
         /// A generic method performing peak tracing for all the peaks in an indexingEngine and trying to find all XICs.
         /// <returns> A list of ExtractedIonChromatogram objects representing all XICs that can be found in an indexingEngine </returns>
-        public virtual List<ExtractedIonChromatogram> GetAllXics(Tolerance peakFindingTolerance, int maxMissedScanAllowed, double maxRTRange, int numPeakThreshold)
+        public virtual List<ExtractedIonChromatogram> GetAllXics(Tolerance peakFindingTolerance, int maxMissedScanAllowed, double maxRTRange, int numPeakThreshold, double cutPeakDiscriminationFactor = -1)
         {
             var xics = new List<ExtractedIonChromatogram>();
             var matchedPeaks = new Dictionary<IIndexedPeak, ExtractedIonChromatogram>();
-            var sortedPeaks = IndexedPeaks.Where(v => v != null).SelectMany(peaks => peaks).OrderBy(p => p.Intensity).ToList();
+            var sortedPeaks = IndexedPeaks.Where(v => v != null).SelectMany(peaks => peaks).OrderByDescending(p => p.Intensity).ToList();
             foreach (var peak in sortedPeaks)
             {
                 if (!matchedPeaks.ContainsKey(peak))
@@ -208,7 +208,8 @@ namespace MassSpectrometry
                     if (peakList.Count >= numPeakThreshold)
                     {
                         var newXIC = new ExtractedIonChromatogram(peakList);
-                        foreach(var matchedPeak in peakList)
+                        if (cutPeakDiscriminationFactor > 0) newXIC.CutPeak(cutPeakDiscriminationFactor);
+                        foreach (var matchedPeak in newXIC.Peaks)
                         {
                             matchedPeaks.Add(matchedPeak, newXIC);
                         }

--- a/mzLib/MassSpectrometry/PeakIndexing/IndexingEngine.cs
+++ b/mzLib/MassSpectrometry/PeakIndexing/IndexingEngine.cs
@@ -193,8 +193,9 @@ namespace MassSpectrometry
 
         /// <summary>
         /// A generic method performing peak tracing for all the peaks in an indexingEngine and trying to find all XICs.
+        /// <param name="cutPeakDiscriminationFactor"> The discrimination factor to determine if a peak should be cut if we are doing peak cutting </param>
         /// <returns> A list of ExtractedIonChromatogram objects representing all XICs that can be found in an indexingEngine </returns>
-        public virtual List<ExtractedIonChromatogram> GetAllXics(Tolerance peakFindingTolerance, int maxMissedScanAllowed, double maxRTRange, int numPeakThreshold, double cutPeakDiscriminationFactor = -1)
+        public virtual List<ExtractedIonChromatogram> GetAllXics(Tolerance peakFindingTolerance, int maxMissedScanAllowed, double maxRTRange, int numPeakThreshold, double? cutPeakDiscriminationFactor = null)
         {
             var xics = new List<ExtractedIonChromatogram>();
             var matchedPeaks = new Dictionary<IIndexedPeak, ExtractedIonChromatogram>();
@@ -208,7 +209,7 @@ namespace MassSpectrometry
                     if (peakList.Count >= numPeakThreshold)
                     {
                         var newXIC = new ExtractedIonChromatogram(peakList);
-                        if (cutPeakDiscriminationFactor > 0) newXIC.CutPeak(cutPeakDiscriminationFactor);
+                        if (cutPeakDiscriminationFactor.HasValue) newXIC.CutPeak(cutPeakDiscriminationFactor.Value);
                         foreach (var matchedPeak in newXIC.Peaks)
                         {
                             matchedPeaks.Add(matchedPeak, newXIC);

--- a/mzLib/Test/TestXic.cs
+++ b/mzLib/Test/TestXic.cs
@@ -61,7 +61,7 @@ namespace Test
             Assert.That(xic.StartRT, Is.EqualTo(1.0f));
             Assert.That(xic.EndRT, Is.EqualTo(1.9f));
             var mass = Dist.Masses.First().ToMz(1);
-            Assert.That(xic.AveragedM, Is.EqualTo(Dist.Masses.First().ToMz(1)).Within(0.0001));
+            Assert.That(xic.AveragedMassOrMz, Is.EqualTo(Dist.Masses.First().ToMz(1)).Within(0.0001));
             Assert.That(xic.ApexPeak.Intensity, Is.EqualTo(Dist.Intensities.First() * 1e6 * 10).Within(1));
 
             //Test normalized peak intensities
@@ -302,7 +302,7 @@ namespace Test
             Assert.That(xic.ApexScanIndex, Is.EqualTo(peaks.First().ZeroBasedScanIndex));
             Assert.That(xic.StartRT, Is.EqualTo(peaks.First().RetentionTime));
             Assert.That(xic.EndRT, Is.EqualTo(peaks.First().RetentionTime));
-            Assert.That(xic.AveragedM, Is.EqualTo(peaks.First().M).Within(0.0001));
+            Assert.That(xic.AveragedMassOrMz, Is.EqualTo(peaks.First().M).Within(0.0001));
             Assert.That(xic.ApexPeak.Intensity, Is.EqualTo(peaks.First().Intensity));
         }
     }

--- a/mzLib/Test/TestXic.cs
+++ b/mzLib/Test/TestXic.cs
@@ -175,6 +175,7 @@ namespace Test
             var indexingEngine2 = PeakIndexingEngine.InitializeIndexingEngine(fakeScans2);
             var xics2 = indexingEngine2.GetAllXics(new PpmTolerance(20), 2, 2, 3);
             Assert.That(xics2.Count, Is.EqualTo(40)); //the first three scans and the last four scans will each contain two XICs
+            Assert.That(xics2.SequenceEqual(xics2.OrderByDescending(x => x.ApexPeak.Intensity)));//make sure the XICs are ordered by descending apex intensity
             //Test with massIndexingEngine
             var massIndexingEngine2 = MassIndexingEngine.InitializeMassIndexingEngine(fakeScans2, deconParameters);
             var massXics2 = massIndexingEngine2.GetAllXics(new PpmTolerance(20), 2, 2, 3);

--- a/mzLib/Test/TestXic.cs
+++ b/mzLib/Test/TestXic.cs
@@ -56,13 +56,13 @@ namespace Test
 
             //Test XIC properties
             Assert.That(xic.Peaks.Count, Is.EqualTo(10));
-            Assert.That(xic.ApexRT, Is.EqualTo(1.6f));
-            Assert.That(xic.ApexScanIndex, Is.EqualTo(6));
+            Assert.That(xic.ApexPeak.RetentionTime, Is.EqualTo(1.6f));
+            Assert.That(xic.ApexPeak.ZeroBasedScanIndex, Is.EqualTo(6));
             Assert.That(xic.StartRT, Is.EqualTo(1.0f));
             Assert.That(xic.EndRT, Is.EqualTo(1.9f));
             var mass = Dist.Masses.First().ToMz(1);
             Assert.That(xic.AveragedM, Is.EqualTo(Dist.Masses.First().ToMz(1)).Within(0.0001));
-            Assert.That(xic.ApexIntensity, Is.EqualTo(Dist.Intensities.First() * 1e6 * 10).Within(1));
+            Assert.That(xic.ApexPeak.Intensity, Is.EqualTo(Dist.Intensities.First() * 1e6 * 10).Within(1));
 
             //Test normalized peak intensities
             xic.SetNormalizedPeakIntensities();
@@ -227,7 +227,7 @@ namespace Test
             Assert.That(xic.Peaks.Count, Is.EqualTo(peak1.Count + peak2.Count));
             xic.CutPeak();
             Assert.That(xic.Peaks.Count, Is.EqualTo(peak1.Count));
-            Assert.That(xic.ApexRT, Is.EqualTo(xic1.ApexRT));
+            Assert.That(xic.ApexPeak.RetentionTime, Is.EqualTo(xic1.ApexPeak.RetentionTime));
             Assert.That(xic.StartRT, Is.EqualTo(xic1.StartRT));
             Assert.That(xic.EndRT, Is.EqualTo(xic1.EndRT));
 
@@ -273,14 +273,14 @@ namespace Test
             Assert.That(xics.Count(), Is.EqualTo(10)); 
             Assert.That(xics.All(x => x.Peaks.Count == 10), Is.True);
             //The XICs should have an apex at the eighth scan
-            Assert.That(xics.All(x => x.ApexScanIndex == 7), Is.True);
+            Assert.That(xics.All(x => x.ApexPeak.ZeroBasedScanIndex == 7), Is.True);
 
             var xicsWithCutPeak = indexingEngine.GetAllXics(new PpmTolerance(5), 2, 3, 3, 0.6);
             // since each original XIC contain two apex, cutting peaks should double the number of XICs found and each XIC should contain 5 peaks now
             Assert.That(xicsWithCutPeak.Count(), Is.EqualTo(20));
             Assert.That(xicsWithCutPeak.All(x => x.Peaks.Count == 5), Is.True);
             // The XICs should have an apex at either the third or the eighth scan
-            Assert.That(xicsWithCutPeak.All(x => x.ApexScanIndex == 2 || x.ApexScanIndex == 7), Is.True);
+            Assert.That(xicsWithCutPeak.All(x => x.ApexPeak.ZeroBasedScanIndex == 2 || x.ApexPeak.ZeroBasedScanIndex == 7), Is.True);
         }
 
         [Test]

--- a/mzLib/Test/TestXic.cs
+++ b/mzLib/Test/TestXic.cs
@@ -62,6 +62,7 @@ namespace Test
             Assert.That(xic.EndRT, Is.EqualTo(1.9f));
             var mass = Dist.Masses.First().ToMz(1);
             Assert.That(xic.AveragedM, Is.EqualTo(Dist.Masses.First().ToMz(1)).Within(0.0001));
+            Assert.That(xic.ApexIntensity, Is.EqualTo(Dist.Intensities.First() * 1e6 * 10).Within(1));
 
             //Test normalized peak intensities
             xic.SetNormalizedPeakIntensities();

--- a/mzLib/Test/TestXic.cs
+++ b/mzLib/Test/TestXic.cs
@@ -11,12 +11,13 @@ using MassSpectrometry;
 using Microsoft.ML.Transforms;
 using MathNet.Numerics.Distributions;
 using System.Collections;
+using Proteomics.AminoAcidPolymer;
 
 namespace Test
 {
     public class TestXic
     {
-        public static MsDataScan[] FakeScans { get; set; }
+        public static MsDataScan[] testScans { get; set; }
         public static IsotopicDistribution Dist { get; set; }
         public static List<IIndexedPeak> PeakList { get; set; } 
 
@@ -26,25 +27,25 @@ namespace Test
             string peptide = "PEPTIDE";
             double intensity = 1e6;
 
-            FakeScans = new MsDataScan[10];
+            testScans = new MsDataScan[10];
             double[] intensityMultipliers = { 1, 3, 1, 1, 3, 5, 10, 5, 3, 1 };
             ChemicalFormula cf = new Proteomics.AminoAcidPolymer.Peptide(peptide).GetChemicalFormula();
             Dist = IsotopicDistribution.GetDistribution(cf, 0.125, 1e-8);
 
             // Create mzSpectra where two peaks appear very close together
-            for (int s = 0; s < FakeScans.Length; s++)
+            for (int s = 0; s < testScans.Length; s++)
             {
                 double[] mz = Dist.Masses.SelectMany(v => new List<double> { v.ToMz(1), (v + 0.0001).ToMz(1) }).ToArray();
                 double[] intensities = Dist.Intensities.SelectMany(v => new List<double> { v * intensity * intensityMultipliers[s], v * intensity }).ToArray();
 
                 // add the scan
-                FakeScans[s] = new MsDataScan(massSpectrum: new MzSpectrum(mz, intensities, false), oneBasedScanNumber: s + 1, msnOrder: 1, isCentroid: true,
+                testScans[s] = new MsDataScan(massSpectrum: new MzSpectrum(mz, intensities, false), oneBasedScanNumber: s + 1, msnOrder: 1, isCentroid: true,
                     polarity: Polarity.Positive, retentionTime: 1.0 + s / 10.0, scanWindowRange: new MzRange(400, 1600), scanFilter: "f",
                     mzAnalyzer: MZAnalyzerType.Orbitrap, totalIonCurrent: intensities.Sum(), injectionTime: 1.0, noiseData: null, nativeId: "scan=" + (s + 1));
             }
 
             //Example XIC
-            var peakIndexEngine = PeakIndexingEngine.InitializeIndexingEngine(FakeScans);
+            var peakIndexEngine = PeakIndexingEngine.InitializeIndexingEngine(testScans);
             PeakList = peakIndexEngine.GetXic(Dist.Masses.First().ToMz(1), zeroBasedStartIndex: 4, new PpmTolerance(20), 1);
         }
 
@@ -139,7 +140,7 @@ namespace Test
         public static void TestGetAllXics()
         {
             //Test case using FakeScans
-            var indexingEngine = PeakIndexingEngine.InitializeIndexingEngine(FakeScans);
+            var indexingEngine = PeakIndexingEngine.InitializeIndexingEngine(testScans);
             var xics = indexingEngine.GetAllXics(new PpmTolerance(20), 2, 2, 3);
             Assert.That(xics.Count, Is.EqualTo(20));
             foreach(var xic in xics)
@@ -148,8 +149,8 @@ namespace Test
             }
             //Test with massIndexingEngine
             var deconParameters = new ClassicDeconvolutionParameters(1, 20, 4, 3);
-            var allMasses = Deconvoluter.Deconvolute(FakeScans[0].MassSpectrum, deconParameters);
-            var massIndexingEngine = MassIndexingEngine.InitializeMassIndexingEngine(FakeScans, deconParameters);
+            var allMasses = Deconvoluter.Deconvolute(testScans[0].MassSpectrum, deconParameters);
+            var massIndexingEngine = MassIndexingEngine.InitializeMassIndexingEngine(testScans, deconParameters);
             var massXics = massIndexingEngine.GetAllXics(new PpmTolerance(20), 2, 2, 3);
             Assert.That(massXics.Count, Is.EqualTo(2));
             foreach (var mass in allMasses)
@@ -162,7 +163,7 @@ namespace Test
             }
 
             //Test if there are three missed scans in the middle
-            var fakeScans2 = (MsDataScan[])FakeScans.Clone();
+            var fakeScans2 = (MsDataScan[])testScans.Clone();
             var missedIndices = new List<int> { 3, 4, 5 }; //the ten scnas would be 1,1,1,0,0,0,1,1,1,1
             foreach(var s in missedIndices)
             {
@@ -178,7 +179,7 @@ namespace Test
             var massXics2 = massIndexingEngine2.GetAllXics(new PpmTolerance(20), 2, 2, 3);
             Assert.That(massXics2.Count, Is.EqualTo(4));
 
-            var fakeScans3 = (MsDataScan[])FakeScans.Clone();
+            var fakeScans3 = (MsDataScan[])testScans.Clone();
             var missedIndices2 = new List<int> { 2, 3, 4 }; //the ten scnas would be 1,1,0,0,0,1,1,1,1,1
             foreach (var s in missedIndices2)
             {
@@ -252,9 +253,39 @@ namespace Test
         }
 
         [Test]
+        public static void TestGetAllXicsWithCutPeak()
+        {
+            var testScans = new MsDataScan[10];
+            //make all peak traces to have two apex at the third and the eighth scan
+            double[] intensityMultipliers = { 1, 2, 6, 2, 1, 1.1, 2, 8, 2, 1.1 };
+            var intensity = 1e6;
+
+            for (int s = 0; s < testScans.Length; s++)
+            {
+                double[] mz = Dist.Masses.SelectMany(v => new List<double> { v.ToMz(1) }).ToArray();
+                double[] intensities = Dist.Intensities.SelectMany(v => new List<double> { v * intensity * intensityMultipliers[s] }).ToArray();
+                testScans[s] = new MsDataScan(massSpectrum: new MzSpectrum(mz, intensities, false), oneBasedScanNumber: s + 1, msnOrder: 1, isCentroid: true,polarity: Polarity.Positive, retentionTime: 1.0 + s / 10.0, scanWindowRange: new MzRange(400, 1600), scanFilter: "f",mzAnalyzer: MZAnalyzerType.Orbitrap, totalIonCurrent: intensities.Sum(), injectionTime: 1.0, noiseData: null, nativeId: "scan=" + (s + 1));
+            }
+            var indexingEngine = PeakIndexingEngine.InitializeIndexingEngine(testScans);
+            var xics = indexingEngine.GetAllXics(new PpmTolerance(5), 2, 3, 3);
+            // 10 XICs should be found without peak cutting, each containing 10 peaks
+            Assert.That(xics.Count(), Is.EqualTo(10)); 
+            Assert.That(xics.All(x => x.Peaks.Count == 10), Is.True);
+            //The XICs should have an apex at the eighth scan
+            Assert.That(xics.All(x => x.ApexScanIndex == 7), Is.True);
+
+            var xicsWithCutPeak = indexingEngine.GetAllXics(new PpmTolerance(5), 2, 3, 3, 0.6);
+            // since each original XIC contain two apex, cutting peaks should double the number of XICs found and each XIC should contain 5 peaks now
+            Assert.That(xicsWithCutPeak.Count(), Is.EqualTo(20));
+            Assert.That(xicsWithCutPeak.All(x => x.Peaks.Count == 5), Is.True);
+            // The XICs should have an apex at either the third or the eighth scan
+            Assert.That(xicsWithCutPeak.All(x => x.ApexScanIndex == 2 || x.ApexScanIndex == 7), Is.True);
+        }
+
+        [Test]
         public static void TestMassXicExceptionHandling()
         {
-            var peakIndexEngine = PeakIndexingEngine.InitializeIndexingEngine(FakeScans);
+            var peakIndexEngine = PeakIndexingEngine.InitializeIndexingEngine(testScans);
             var ex = Assert.Throws<MzLibException>(() => peakIndexEngine.GetXic(Dist.Masses.First().ToMz(1), zeroBasedStartIndex: 4, new PpmTolerance(20), 1, 10, 1));
             Assert.That(ex.Message, Is.EqualTo("Error: Attempted to access a peak using a charge parameter, but the peaks do not have charge information available."));
         }

--- a/mzLib/Test/TestXic.cs
+++ b/mzLib/Test/TestXic.cs
@@ -56,8 +56,8 @@ namespace Test
 
             //Test XIC properties
             Assert.That(xic.Peaks.Count, Is.EqualTo(10));
-            Assert.That(xic.ApexPeak.RetentionTime, Is.EqualTo(1.6f));
-            Assert.That(xic.ApexPeak.ZeroBasedScanIndex, Is.EqualTo(6));
+            Assert.That(xic.ApexRT, Is.EqualTo(1.6f));
+            Assert.That(xic.ApexScanIndex, Is.EqualTo(6));
             Assert.That(xic.StartRT, Is.EqualTo(1.0f));
             Assert.That(xic.EndRT, Is.EqualTo(1.9f));
             var mass = Dist.Masses.First().ToMz(1);
@@ -228,7 +228,7 @@ namespace Test
             Assert.That(xic.Peaks.Count, Is.EqualTo(peak1.Count + peak2.Count));
             xic.CutPeak();
             Assert.That(xic.Peaks.Count, Is.EqualTo(peak1.Count));
-            Assert.That(xic.ApexPeak.RetentionTime, Is.EqualTo(xic1.ApexPeak.RetentionTime));
+            Assert.That(xic.ApexRT, Is.EqualTo(xic1.ApexRT));
             Assert.That(xic.StartRT, Is.EqualTo(xic1.StartRT));
             Assert.That(xic.EndRT, Is.EqualTo(xic1.EndRT));
 
@@ -274,14 +274,14 @@ namespace Test
             Assert.That(xics.Count(), Is.EqualTo(10)); 
             Assert.That(xics.All(x => x.Peaks.Count == 10), Is.True);
             //The XICs should have an apex at the eighth scan
-            Assert.That(xics.All(x => x.ApexPeak.ZeroBasedScanIndex == 7), Is.True);
+            Assert.That(xics.All(x => x.ApexScanIndex == 7), Is.True);
 
             var xicsWithCutPeak = indexingEngine.GetAllXics(new PpmTolerance(5), 2, 3, 3, 0.6);
             // since each original XIC contain two apex, cutting peaks should double the number of XICs found and each XIC should contain 5 peaks now
             Assert.That(xicsWithCutPeak.Count(), Is.EqualTo(20));
             Assert.That(xicsWithCutPeak.All(x => x.Peaks.Count == 5), Is.True);
             // The XICs should have an apex at either the third or the eighth scan
-            Assert.That(xicsWithCutPeak.All(x => x.ApexPeak.ZeroBasedScanIndex == 2 || x.ApexPeak.ZeroBasedScanIndex == 7), Is.True);
+            Assert.That(xicsWithCutPeak.All(x => x.ApexScanIndex == 2 || x.ApexScanIndex == 7), Is.True);
         }
 
         [Test]
@@ -290,6 +290,20 @@ namespace Test
             var peakIndexEngine = PeakIndexingEngine.InitializeIndexingEngine(testScans);
             var ex = Assert.Throws<MzLibException>(() => peakIndexEngine.GetXic(Dist.Masses.First().ToMz(1), zeroBasedStartIndex: 4, new PpmTolerance(20), 1, 10, 1));
             Assert.That(ex.Message, Is.EqualTo("Error: Attempted to access a peak using a charge parameter, but the peaks do not have charge information available."));
+        }
+
+        [Test]
+        public static void TestXicOnePeak()
+        {
+            var peaks = new List<IIndexedPeak> { new IndexedMassSpectralPeak(intensity: 10, retentionTime: 1, zeroBasedScanIndex: 0, mz: 500.0) };
+            var xic = new ExtractedIonChromatogram(peaks);
+            Assert.That(xic.Peaks.Count, Is.EqualTo(1));
+            Assert.That(xic.ApexRT, Is.EqualTo(peaks.First().RetentionTime));
+            Assert.That(xic.ApexScanIndex, Is.EqualTo(peaks.First().ZeroBasedScanIndex));
+            Assert.That(xic.StartRT, Is.EqualTo(peaks.First().RetentionTime));
+            Assert.That(xic.EndRT, Is.EqualTo(peaks.First().RetentionTime));
+            Assert.That(xic.AveragedM, Is.EqualTo(peaks.First().M).Within(0.0001));
+            Assert.That(xic.ApexPeak.Intensity, Is.EqualTo(peaks.First().Intensity));
         }
     }
 }


### PR DESCRIPTION
Incorporate CutPeak into GetAllXics() to enable trimming a peak trace while constructing all the XICs. Update SetXicInfo() method to include averaging M for all indexedPeaks in the XIC and setting the apex intensity for the XIC.