### PR TITLE
Add interfaces for external decon results and implement for Ms1Feature/Dinosaur classes

### DIFF
--- a/mzLib/Readers/BaseClasses/IMs1FeatureFile.cs
+++ b/mzLib/Readers/BaseClasses/IMs1FeatureFile.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Readers
+{
+    public interface IMs1FeatureFile
+    {
+        public IEnumerable<ISingleChargeMs1Feature> GetMs1Features();
+    }
+}

--- a/mzLib/Readers/BaseClasses/IMs1FeatureFile.cs
+++ b/mzLib/Readers/BaseClasses/IMs1FeatureFile.cs
@@ -6,6 +6,35 @@ using System.Threading.Tasks;
 
 namespace Readers
 {
+    /// <summary>
+    /// Contract for a reader or adapter that can produce a sequence of
+    /// <see cref="ISingleChargeMs1Feature"/> instances from an external
+    /// deconvolution results file.
+    /// </summary>
+    /// <remarks>
+    /// Implementations are responsible for:
+    /// <list type="bullet">
+    /// <item>
+    ///     <description>
+    ///     Parsing the file format (e.g., CSV, vendor export, mzML with decon results)
+    ///     into one or more <see cref="ISingleChargeMs1Feature"/> objects.
+    ///     </description>
+    /// </item>
+    /// <item>
+    ///     <description>
+    ///     Mapping source file fields to the required interface properties:
+    ///     <see cref="ISingleChargeMs1Feature.MZ"/>,
+    ///     <see cref="ISingleChargeMs1Feature.Charge"/>,
+    ///     <see cref="ISingleChargeMs1Feature.RetentionTimeStart"/>,
+    ///     <see cref="ISingleChargeMs1Feature.RetentionTimeEnd"/>,
+    ///     <see cref="ISingleChargeMs1Feature.NumberOfIsotopes"/>.
+    ///     </description>
+    /// </item>
+    /// </list>
+    /// This interface provides a consistent entry point for the pairing logic
+    /// to consume external results from various deconvolution tools without
+    /// caring about the underlying file format.
+    /// </remarks>
     public interface IMs1FeatureFile
     {
         public IEnumerable<ISingleChargeMs1Feature> GetMs1Features();

--- a/mzLib/Readers/BaseClasses/ISingleChargeMs1Feature.cs
+++ b/mzLib/Readers/BaseClasses/ISingleChargeMs1Feature.cs
@@ -6,6 +6,25 @@ using System.Threading.Tasks;
 
 namespace Readers
 {
+    /// <summary>
+    /// Contract for an external deconvolution result used to pair with raw MS2 scans
+    /// and (optionally) construct external MS2 spectra for database searching.
+    /// Implementations are typically produced by mzLib Readers that parse
+    /// third-party deconvolution outputs.
+    /// </summary>
+    /// <remarks>
+    /// Required fields:
+    /// <list type="bullet">
+    /// <item><description><see cref="Mz"/>: precursor m/z (double)</description></item>
+    /// <item><description><see cref="Charge"/>: precursor charge state (int)</description></item>
+    /// <item><description><see cref="RetentionTimeStart"/>: RT window start, minutes (double)</description></item>
+    /// <item><description><see cref="RetentionTimeEnd"/>: RT window end, minutes (double)</description></item>
+    /// <item><description><see cref="NumberOfIsotopes"/>: Number of isotopes observed, nullable int</description></item>
+    /// </list>
+    /// Pairing is performed by checking if an MS2 scan’s RT apex lies within
+    /// [<see cref="RetentionTimeStart"/>, <see cref="RetentionTimeEnd"/>].
+    /// Implementations should ensure values are valid (no NaN; charge &gt; 0; start ≤ end).
+    /// </remarks>
     public interface ISingleChargeMs1Feature
     {
         double Mz { get; }
@@ -14,6 +33,5 @@ namespace Readers
         double RetentionTimeEnd { get; }
         double Intensity { get; }
         int? NumberOfIsotopes { get; }
-        double? FractionalIntensity { get; }
     }
 }

--- a/mzLib/Readers/BaseClasses/ISingleChargeMs1Feature.cs
+++ b/mzLib/Readers/BaseClasses/ISingleChargeMs1Feature.cs
@@ -13,5 +13,7 @@ namespace Readers
         double RetentionTimeStart { get; }
         double RetentionTimeEnd { get; }
         double Intensity { get; }
+        int? NumberOfIsotopes { get; }
+        double? FractionalIntensity { get; }
     }
 }

--- a/mzLib/Readers/BaseClasses/ISingleChargeMs1Feature.cs
+++ b/mzLib/Readers/BaseClasses/ISingleChargeMs1Feature.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Readers
+{
+    public interface ISingleChargeMs1Feature
+    {
+        double Mz { get; }
+        int Charge { get; }
+        double RetentionTimeStart { get; }
+        double RetentionTimeEnd { get; }
+        double Intensity { get; }
+    }
+}

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/DinosaurFeature.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/DinosaurFeature.cs
@@ -15,6 +15,8 @@ namespace Readers
         public double RetentionTimeStart => RtStart;
         public double RetentionTimeEnd => RtEnd;
         public double Intensity => IntensityApex;
+        public int? NumberOfIsotopes => NIsotopes;
+        public double? FractionalIntensity => null;
 
         #endregion
 

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/DinosaurFeature.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/DinosaurFeature.cs
@@ -8,8 +8,16 @@ namespace Readers
     /// <summary>
     /// A class representing a single entry in a .feature.tsv file, the output from Dinosaur
     /// </summary>
-    public class DinosaurFeature
+    public class DinosaurFeature : ISingleChargeMs1Feature
     {
+        #region IMs1FeatureProperties
+
+        public double RetentionTimeStart => RtStart;
+        public double RetentionTimeEnd => RtEnd;
+        public double Intensity => IntensityApex;
+
+        #endregion
+
         [Ignore]
         public static CsvConfiguration CsvConfiguration => new CsvConfiguration(CultureInfo.InvariantCulture)
         {

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/DinosaurFeature.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/DinosaurFeature.cs
@@ -16,7 +16,6 @@ namespace Readers
         public double RetentionTimeEnd => RtEnd;
         public double Intensity => IntensityApex;
         public int? NumberOfIsotopes => NIsotopes;
-        public double? FractionalIntensity => null;
 
         #endregion
 

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1Feature.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1Feature.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Text;
+using Chemistry;
 using CsvHelper.Configuration;
 using CsvHelper.Configuration.Attributes;
 
@@ -56,5 +57,15 @@ namespace Readers
 
         [Name("Maximum_fraction_id")]
         public int FractionIdMax { get; set; }
+
+        public IEnumerable<ISingleChargeMs1Feature> GetSingleChargeFeatures()
+        {
+            for (int z = ChargeStateMin; z <= ChargeStateMax ; z++)
+            {
+                yield return new SingleChargeMs1Feature(Mass.ToMz(z), z, RetentionTimeBegin, RetentionTimeEnd, IntensityApex ?? 0);
+            }
+        }
     }
+
+    public record SingleChargeMs1Feature(double Mz, int Charge, double RetentionTimeStart, double RetentionTimeEnd, double Intensity) : ISingleChargeMs1Feature;
 }

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1Feature.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1Feature.cs
@@ -67,5 +67,6 @@ namespace Readers
         }
     }
 
-    public record SingleChargeMs1Feature(double Mz, int Charge, double RetentionTimeStart, double RetentionTimeEnd, double Intensity) : ISingleChargeMs1Feature;
+    public record SingleChargeMs1Feature(double Mz, int Charge, double RetentionTimeStart, double RetentionTimeEnd, double Intensity,
+        int? NumberOfIsotopes = null, double? FractionalIntensity = null) : ISingleChargeMs1Feature;
 }

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1Feature.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1Feature.cs
@@ -68,5 +68,5 @@ namespace Readers
     }
 
     public record SingleChargeMs1Feature(double Mz, int Charge, double RetentionTimeStart, double RetentionTimeEnd, double Intensity,
-        int? NumberOfIsotopes = null, double? FractionalIntensity = null) : ISingleChargeMs1Feature;
+        int? NumberOfIsotopes = null) : ISingleChargeMs1Feature;
 }

--- a/mzLib/Readers/ExternalResults/ResultFiles/DinosaurTsvFile.cs
+++ b/mzLib/Readers/ExternalResults/ResultFiles/DinosaurTsvFile.cs
@@ -7,10 +7,11 @@ namespace Readers
     /// For supported versions and software this file type can come from see
     ///     Readers.ExternalResources.SupportedVersions.txt
     /// </summary>
-    public class DinosaurTsvFile : ResultFile<DinosaurFeature>, IResultFile
+    public class DinosaurTsvFile : ResultFile<DinosaurFeature>, IResultFile, IMs1FeatureFile
     {
         public override SupportedFileType FileType => SupportedFileType.Tsv_Dinosaur;
         public override Software Software { get; set; }
+        public IEnumerable<ISingleChargeMs1Feature> GetMs1Features() { return Results; }
 
         public DinosaurTsvFile(string filePath) : base(filePath, Software.Dinosaur) { }
 

--- a/mzLib/Readers/ExternalResults/ResultFiles/Ms1FeatureFile.cs
+++ b/mzLib/Readers/ExternalResults/ResultFiles/Ms1FeatureFile.cs
@@ -7,11 +7,13 @@ namespace Readers
     /// For supported versions and software this file type can come from see
     ///     Readers.ExternalResources.SupportedVersions.txt
     /// </summary>
-    public class Ms1FeatureFile : ResultFile<Ms1Feature>, IResultFile
+    public class Ms1FeatureFile : ResultFile<Ms1Feature>, IResultFile, IMs1FeatureFile
     {
         public override SupportedFileType FileType => SupportedFileType.Ms1Feature;
 
         public sealed override Software Software { get; set; }
+
+        public IEnumerable<ISingleChargeMs1Feature> GetMs1Features() => Results.SelectMany(r => r.GetSingleChargeFeatures());
 
         public Ms1FeatureFile(string filePath, Software deconSoftware = Software.Unspecified) : base(filePath,
             deconSoftware)

--- a/mzLib/Test/FileReadingTests/TestDinosaurTsv.cs
+++ b/mzLib/Test/FileReadingTests/TestDinosaurTsv.cs
@@ -97,7 +97,19 @@ namespace Test.FileReadingTests
             Assert.That(first.MassCalib, Is.EqualTo(1317.687788));
             Assert.That(first.IntensityApex, Is.EqualTo(8809.755127));
             Assert.That(first.IntensitySum, Is.EqualTo(52349.81689));
+        }
 
+        [Test]
+        public void TestDinosaurIMs1FeatureFileImplementation()
+        {
+            var dinoFile = new DinosaurTsvFile(filePath);
+            dinoFile.LoadResults();
+
+            // Check that all required properties are populated for the first entry
+            var first = dinoFile.Results.First();
+
+            var firstIMs1Feature = dinoFile.GetMs1Features().First();
+            Assert.That(first, Is.EqualTo(firstIMs1Feature), "First entry from Results should match first from GetMs1Features().");
         }
 
         [Test]

--- a/mzLib/Test/FileReadingTests/TestMsFeature.cs
+++ b/mzLib/Test/FileReadingTests/TestMsFeature.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using Chemistry;
 using CsvHelper;
 using MzLibUtil;
 using Newtonsoft.Json;
@@ -183,6 +184,28 @@ namespace Test.FileReadingTests
             Assert.That(last.ChargeStateMax, Is.EqualTo(1));
             Assert.That(last.FractionIdMin, Is.EqualTo(0));
             Assert.That(last.FractionIdMax, Is.EqualTo(0));
+        }
+
+        [Test]
+        public static void TestTopFDMs1GetSingleChargeFeatureFunctions()
+        {
+            string filePath = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                @"FileReadingTests\ExternalFileTypes\Ms1Feature_TopFDv1.6.2_ms1.feature");
+            var ms1Features = FileReader.ReadFile<Ms1FeatureFile>(filePath);
+
+            var first = ms1Features.First();
+            var last = ms1Features.Last();
+
+            var singleChargeFeatures = first.GetSingleChargeFeatures();
+            Assert.That(singleChargeFeatures.Count(), Is.EqualTo(11)); // 11 charge states from 7 to 17
+            Assert.That(singleChargeFeatures.First().Charge, Is.EqualTo(7));
+            Assert.That(singleChargeFeatures.Last().Charge, Is.EqualTo(17));
+            Assert.That(singleChargeFeatures.First().Mz, Is.EqualTo(first.Mass.ToMz(7)).Within(0.001));
+
+            var firstSingleChargeFeature = ms1Features.GetMs1Features().First();
+            Assert.That(first.GetSingleChargeFeatures().First(), Is.EqualTo(firstSingleChargeFeature));
+
+            Assert.That(last.GetSingleChargeFeatures().Count, Is.EqualTo(1));
         }
 
         [Test]


### PR DESCRIPTION
**Summary**
This PR adds new interfaces to formalize the handling of external deconvolution results in mzLib, along with concrete implementations for existing feature and file classes.

**Key Changes**

* **Defined `ISingleChargeMs1Feature`**

  * Guarantees that an external decon result exposes `MZ`, `Charge`, `RetentionTimeStart`, and `RetentionTimeEnd`.
  * Added XML documentation comments describing intended usage and validation expectations.

* **Defined `IMs1FeatureFile`**

  * Ensures that a results file class can produce an `IEnumerable<ISingleChargeMs1Feature>`.
  * Added XML documentation comments clarifying responsibilities for parsing, mapping, and validation.

* **Implemented `ISingleChargeMs1Feature` for:**

  * `Ms1Feature`
  * `DinosaurFeature`

* **Implemented `IMs1FeatureFile` for:**

  * `Ms1FeatureFile`
  * `DinosaurTsvFile`

**Motivation**
These interfaces provide a consistent contract for consuming deconvolution results from various sources. They allow downstream workflows (e.g., external decon pairing to raw MS2 scans) to operate on a unified API without format-specific logic. This will simplify integration of additional decon formats in the future and ensure consistent validation.

**Next Steps**

* Integrate these interfaces into the external decon → MS2 pairing workflow in MetaMorpheus.
