### PR TITLE
Update ParseModifications output and modification regex. 

### DIFF
--- a/mzLib/Readers/InternalResults/IndividualResultRecords/SpectrumMatchFromTsv.cs
+++ b/mzLib/Readers/InternalResults/IndividualResultRecords/SpectrumMatchFromTsv.cs
@@ -299,20 +299,6 @@ namespace Readers
             return fullSeq.ParseModifications();
         }
 
-        /// <summary>
-        /// Fixes an issue where the | appears and throws off the numbering if there are multiple mods on a single amino acid.
-        /// Local wrapper for MzLibUtil extension method.
-        /// </summary>
-        /// <param name="fullSeq"></param>
-        /// <param name="replacement"></param>
-        /// <param name="specialCharacter"></param>
-        /// <returns></returns>
-        public static void RemoveSpecialCharacters(ref string fullSeq, string replacement = @"", string specialCharacter = @"\|")
-        {
-            MzLibUtil.ClassExtensions.RemoveSpecialCharacters(ref fullSeq, replacement, specialCharacter);
-        }
-
-
         protected static List<MatchedFragmentIon> ReadFragmentIonsFromString(string matchedMzString, string matchedIntensityString, string peptideBaseSequence, string? matchedMassErrorDaString = null, bool isProtein = true)
         {
             List<MatchedFragmentIon> matchedIons = new List<MatchedFragmentIon>();

--- a/mzLib/Readers/InternalResults/IndividualResultRecords/SpectrumMatchFromTsv.cs
+++ b/mzLib/Readers/InternalResults/IndividualResultRecords/SpectrumMatchFromTsv.cs
@@ -6,6 +6,7 @@ using Chemistry;
 using Omics.Fragmentation.Peptide;
 using Omics.SpectrumMatch;
 using System.Collections.Generic;
+using MzLibUtil;
 
 namespace Readers
 {
@@ -289,56 +290,18 @@ namespace Readers
         }
 
         /// <summary>
-        /// Parses the full sequence to identify mods
+        /// Parses the full sequence to identify mods. Local wrapper for MzLibUtil extension method.
         /// </summary>
         /// <param name="fullSequence"> Full sequence of the peptide in question</param>
         /// <returns> Dictionary with the key being the amino acid position of the mod and the value being the string representing the mod</returns>
-        public static Dictionary<int, List<string>> ParseModifications(string fullSeq)
+        public static Dictionary<int, string> ParseModifications(string fullSeq)
         {
-            // use a regex to get all modifications
-            string pattern = @"\[(.+?)\]";
-            Regex regex = new(pattern);
-
-            // remove each match after adding to the dict. Otherwise, getting positions
-            // of the modifications will be rather difficult.
-            //int patternMatches = regex.Matches(fullSeq).Count;
-            Dictionary<int, List<string>> modDict = new();
-
-            RemoveSpecialCharacters(ref fullSeq);
-            MatchCollection matches = regex.Matches(fullSeq);
-            int totalCaptureLength = 0;
-            foreach (Match match in matches)
-            {
-                GroupCollection group = match.Groups;
-                string val = group[1].Value;
-                int startIndex = group[0].Index;
-                int position = group["(.+?)"].Index;
-
-                List<string> modList = new List<string>();
-                modList.Add(val);
-                // check to see if key already exist
-                // if there is a missed cleavage, then there will be a label on K and a Label on X modification.
-                // And, it'll be like [label]|[label] which complicates the positional stuff a little bit.
-                // if the already key exists, update the current position with the capture length + 1.
-                // otherwise, add the modification to the dict.
-
-                // int to add is startIndex - current position
-                int positionToAddToDict = startIndex - totalCaptureLength;
-                if (modDict.ContainsKey(positionToAddToDict))
-                {
-                    modDict[positionToAddToDict].Add(val);
-                }
-                else
-                {
-                    modDict.Add(positionToAddToDict, modList);
-                }
-                totalCaptureLength = totalCaptureLength + group[0].Length;
-            }
-            return modDict;
+            return fullSeq.ParseModifications();
         }
 
         /// <summary>
         /// Fixes an issue where the | appears and throws off the numbering if there are multiple mods on a single amino acid.
+        /// Local wrapper for MzLibUtil extension method.
         /// </summary>
         /// <param name="fullSeq"></param>
         /// <param name="replacement"></param>
@@ -346,9 +309,7 @@ namespace Readers
         /// <returns></returns>
         public static void RemoveSpecialCharacters(ref string fullSeq, string replacement = @"", string specialCharacter = @"\|")
         {
-            // next regex is used in the event that multiple modifications are on a missed cleavage Lysine (K)
-            Regex regexSpecialChar = new(specialCharacter);
-            fullSeq = regexSpecialChar.Replace(fullSeq, replacement);
+            MzLibUtil.ClassExtensions.RemoveSpecialCharacters(ref fullSeq, replacement, specialCharacter);
         }
 
 

--- a/mzLib/Test/FileReadingTests/TestPsmFromTsv.cs
+++ b/mzLib/Test/FileReadingTests/TestPsmFromTsv.cs
@@ -304,33 +304,6 @@ namespace Test.FileReadingTests
         }
 
         [Test]
-        public static void TestRemoveSpecialCharacters()
-        {
-            // successful removal of the default character
-            string toRemove = "ANDVHAO|CNVASDF|ABVCUAE";
-            int length = toRemove.Length;
-            SpectrumMatchFromTsv.RemoveSpecialCharacters(ref toRemove);
-            Assert.That(toRemove.Length == length - 2);
-            Assert.That(toRemove.Equals("ANDVHAOCNVASDFABVCUAE"));
-
-            // does not remove default character when prompted otherwise
-            toRemove = "ANDVHAO|CNVASDF|ABVCUAE";
-            SpectrumMatchFromTsv.RemoveSpecialCharacters(ref toRemove, specialCharacter: @"\[");
-            Assert.That(toRemove.Length == length);
-            Assert.That(toRemove.Equals("ANDVHAO|CNVASDF|ABVCUAE"));
-
-            // replaces default symbol when prompted
-            SpectrumMatchFromTsv.RemoveSpecialCharacters(ref toRemove, replacement: @"%");
-            Assert.That(toRemove.Length == length);
-            Assert.That(toRemove.Equals("ANDVHAO%CNVASDF%ABVCUAE"));
-
-            // replaces inputted symbol with non-default symbol
-            SpectrumMatchFromTsv.RemoveSpecialCharacters(ref toRemove, replacement: @"=", specialCharacter: @"%");
-            Assert.That(toRemove.Length == length);
-            Assert.That(toRemove.Equals("ANDVHAO=CNVASDF=ABVCUAE"));
-        }
-
-        [Test]
         public static void TestToString()
         {
             string psmTsvPath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"FileReadingTests\SearchResults\TDGPTMDSearchResults.psmtsv");

--- a/mzLib/Test/FileReadingTests/TestPsmFromTsv.cs
+++ b/mzLib/Test/FileReadingTests/TestPsmFromTsv.cs
@@ -10,7 +10,6 @@ using Omics.Fragmentation;
 using Readers;
 using MzLibUtil;
 using FlashLFQ;
-using System.Windows.Media;
 
 namespace Test.FileReadingTests
 {

--- a/mzLib/Test/FileReadingTests/TestPsmFromTsv.cs
+++ b/mzLib/Test/FileReadingTests/TestPsmFromTsv.cs
@@ -287,7 +287,7 @@ namespace Test.FileReadingTests
             Assert.That(modDict.Count == 2);
             Assert.That(modDict.ContainsKey(0) && modDict.ContainsKey(104));
             Assert.AreEqual(modDict[0], "UniProt:N-acetylserine on S");
-            Assert.That(modDict[104].Contains("UniProt:N5-methylglutamine on Q"));
+            Assert.AreEqual(modDict[104], "UniProt:N5-methylglutamine on Q");
 
             // test sequence with mods at all relevant positions. Mods include cation mod to test bracket selectivity when parsing mods. 
             string allPosSeq = "[mod type1: testmodW on N-term]S[mod type2: testmodX on S]TGTSQ[Common Artifact: Fe[II] on Q]ADDC[mod type3: testmodY on C]-[mod type4: testmodZ on C-Term]";

--- a/mzLib/Test/FileReadingTests/TestPsmFromTsv.cs
+++ b/mzLib/Test/FileReadingTests/TestPsmFromTsv.cs
@@ -286,7 +286,7 @@ namespace Test.FileReadingTests
             modDict = SpectrumMatchFromTsv.ParseModifications(twoMods.FullSequence);
             Assert.That(modDict.Count == 2);
             Assert.That(modDict.ContainsKey(0) && modDict.ContainsKey(104));
-            Assert.That(modDict[0].Contains("UniProt:N-acetylserine on S"));
+            Assert.AreEqual(modDict[0], "UniProt:N-acetylserine on S");
             Assert.That(modDict[104].Contains("UniProt:N5-methylglutamine on Q"));
 
             // test sequence with mods at all relevant positions. Mods include cation mod to test bracket selectivity when parsing mods. 

--- a/mzLib/Test/TestMzLibUtil.cs
+++ b/mzLib/Test/TestMzLibUtil.cs
@@ -144,6 +144,29 @@ namespace Test
             Assert.IsFalse(result);
         }
 
+        [Test]
+        public void TestRemoveSpecialCharacters()
+        {
+            // Test default pipe removal
+            string seqWithPipes = "PE|PTI|DE";
+            string seqNoPipes = seqWithPipes.ToString();
+            ClassExtensions.RemoveSpecialCharacters(ref seqNoPipes);
+            Assert.AreEqual("PEPTIDE", seqNoPipes);
+
+
+            // Test specified character replacement
+            string seqWithHash = seqWithPipes.ToString();
+            ClassExtensions.RemoveSpecialCharacters(ref seqWithHash, replacement: "#", specialCharacter: @"\|");
+            Assert.AreEqual("PE#PTI#DE", seqWithHash);
+
+            // Test specified character removal
+            string cleanSeq = seqWithHash.ToString();
+            ClassExtensions.RemoveSpecialCharacters(ref cleanSeq, specialCharacter: "#");
+            Assert.AreEqual("PEPTIDE", cleanSeq);
+
+
+        }
+
         public struct TestStruct
         {
             public int X { get; set; }


### PR DESCRIPTION
These are previous updates from another PR #839 that are now too stale. Breaking that PR into two for ease. This one primarily handles the ParseModifications method in SpectrumMatchFromTSV. Next PR will update C-terminus mod writing throughout MzLib.

Updates to modification parsing:
1) The method no longer takes ambiguous modifications and only outputs a mod per position. 
2) The C-terminus is detected with a "-", which will increment the position index by one. 
3) The regex is updated to include C-terminus mods and ignore closing brackets from cation artifact mods. 

Additional changes:
1) Moving ParseModifications implementation from SpectrumMatch FromTSV to MzLibUtils package along with RemoveSpecialCharacters method. 
2) SpectrumMatchFromTSV now just wraps/calls the util methods. Additionally, C-Terminus position recognizing is included. 