### PR TITLE
Check if statically loaded before dynamic access

### DIFF
--- a/mzLib/Readers/Bruker/BrukerFileReader.cs
+++ b/mzLib/Readers/Bruker/BrukerFileReader.cs
@@ -95,7 +95,7 @@ namespace Readers
 
         public override MsDataScan GetOneBasedScanFromDynamicConnection(int oneBasedScanNumber, IFilteringParams? filterParams = null)
 		{
-            if (CheckIfScansLoaded())
+            if (CheckIfScansLoaded() && oneBasedScanNumber <= Scans.Length)
                 return GetOneBasedScan(oneBasedScanNumber);
 
             lock (DynamicReadingLock)

--- a/mzLib/Readers/Bruker/BrukerFileReader.cs
+++ b/mzLib/Readers/Bruker/BrukerFileReader.cs
@@ -95,6 +95,9 @@ namespace Readers
 
         public override MsDataScan GetOneBasedScanFromDynamicConnection(int oneBasedScanNumber, IFilteringParams? filterParams = null)
 		{
+            if (CheckIfScansLoaded())
+                return GetOneBasedScan(oneBasedScanNumber);
+
             lock (DynamicReadingLock)
             {
                 return GetMsDataScanDynamic(oneBasedScanNumber, filterParams);

--- a/mzLib/Readers/Mgf/Mgf.cs
+++ b/mzLib/Readers/Mgf/Mgf.cs
@@ -82,6 +82,9 @@ namespace Readers
 
         public override MsDataScan GetOneBasedScanFromDynamicConnection(int scanNumber, IFilteringParams filterParams = null)
         {
+            if (CheckIfScansLoaded())
+                return GetOneBasedScan(scanNumber);
+
             lock (DynamicReadingLock)
             {
                 if (_streamReader == null)

--- a/mzLib/Readers/Mgf/Mgf.cs
+++ b/mzLib/Readers/Mgf/Mgf.cs
@@ -82,7 +82,7 @@ namespace Readers
 
         public override MsDataScan GetOneBasedScanFromDynamicConnection(int scanNumber, IFilteringParams filterParams = null)
         {
-            if (CheckIfScansLoaded())
+            if (CheckIfScansLoaded() && scanNumber <= IndexedScans.Length)
                 return GetOneBasedScan(scanNumber);
 
             lock (DynamicReadingLock)

--- a/mzLib/Readers/MsAlign/MsAlign.cs
+++ b/mzLib/Readers/MsAlign/MsAlign.cs
@@ -186,6 +186,9 @@ public class MsAlign : MsDataFile
 
     public override MsDataScan GetOneBasedScanFromDynamicConnection(int oneBasedScanNumber, IFilteringParams filterParams = null)
     {
+        if (CheckIfScansLoaded())
+            return GetOneBasedScan(oneBasedScanNumber);
+
         lock (DynamicReadingLock)
         {
             if (_streamReader == null)

--- a/mzLib/Readers/MsAlign/MsAlign.cs
+++ b/mzLib/Readers/MsAlign/MsAlign.cs
@@ -186,7 +186,7 @@ public class MsAlign : MsDataFile
 
     public override MsDataScan GetOneBasedScanFromDynamicConnection(int oneBasedScanNumber, IFilteringParams filterParams = null)
     {
-        if (CheckIfScansLoaded())
+        if (CheckIfScansLoaded() && oneBasedScanNumber <= IndexedScans.Length)
             return GetOneBasedScan(oneBasedScanNumber);
 
         lock (DynamicReadingLock)

--- a/mzLib/Readers/MzML/Mzml.cs
+++ b/mzLib/Readers/MzML/Mzml.cs
@@ -309,7 +309,7 @@ namespace Readers
         /// </summary>
         public override MsDataScan GetOneBasedScanFromDynamicConnection(int oneBasedScanNumber, IFilteringParams filterParams = null)
         {
-            if (CheckIfScansLoaded())
+            if (CheckIfScansLoaded() && oneBasedScanNumber <= Scans.Length)
                 return GetOneBasedScan(oneBasedScanNumber);
 
             MsDataScan scan = null;

--- a/mzLib/Readers/MzML/Mzml.cs
+++ b/mzLib/Readers/MzML/Mzml.cs
@@ -21,6 +21,7 @@ using MzLibUtil;
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.IO.Compression;
+using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -308,8 +309,10 @@ namespace Readers
         /// </summary>
         public override MsDataScan GetOneBasedScanFromDynamicConnection(int oneBasedScanNumber, IFilteringParams filterParams = null)
         {
-            MsDataScan scan = null;
+            if (CheckIfScansLoaded())
+                return GetOneBasedScan(oneBasedScanNumber);
 
+            MsDataScan scan = null;
             lock (DynamicReadingLock)
             {
                 if (ScanNumberToByteOffset.TryGetValue(oneBasedScanNumber, out long byteOffset))

--- a/mzLib/Readers/Thermo/ThermoRawFileReader.cs
+++ b/mzLib/Readers/Thermo/ThermoRawFileReader.cs
@@ -161,7 +161,7 @@ namespace Readers
         /// </summary>
         public override MsDataScan GetOneBasedScanFromDynamicConnection(int oneBasedScanNumber, IFilteringParams filterParams = null)
         {
-            if (CheckIfScansLoaded())
+            if (CheckIfScansLoaded() && oneBasedScanNumber <= Scans.Length)
                 return GetOneBasedScan(oneBasedScanNumber);
 
             var dymConnection = RawFileReaderAdapter.FileFactory(FilePath);

--- a/mzLib/Readers/Thermo/ThermoRawFileReader.cs
+++ b/mzLib/Readers/Thermo/ThermoRawFileReader.cs
@@ -161,6 +161,9 @@ namespace Readers
         /// </summary>
         public override MsDataScan GetOneBasedScanFromDynamicConnection(int oneBasedScanNumber, IFilteringParams filterParams = null)
         {
+            if (CheckIfScansLoaded())
+                return GetOneBasedScan(oneBasedScanNumber);
+
             var dymConnection = RawFileReaderAdapter.FileFactory(FilePath);
             dymConnection.SelectInstrument(Device.MS, 1);
 

--- a/mzLib/Test/FileReadingTests/TestBruker.cs
+++ b/mzLib/Test/FileReadingTests/TestBruker.cs
@@ -104,6 +104,23 @@ namespace Test.FileReadingTests
         }
 
         [Test]
+        public void TestDynamicConnection_AfterStaticLoading()
+        {
+            MsDataFile brukerReader = MsDataFileReader.GetDataFile(_centroidPath);
+            brukerReader.LoadAllStaticData();
+            brukerReader.InitiateDynamicConnection();
+            var scan = brukerReader.GetOneBasedScanFromDynamicConnection(2);
+
+            Assert.That(scan.Polarity == Polarity.Positive);
+            Assert.That(scan.DissociationType == DissociationType.CID);
+            Assert.That(scan.TotalIonCurrent == 346d);
+            Assert.That(scan.NativeId == "scan=2");
+            Assert.That(scan.SelectedIonMZ, Is.EqualTo(721.86865).Within(0.001));
+            Assert.That(scan.MsnOrder == 2);
+            Assert.That(scan.IsCentroid);
+        }
+
+        [Test]
         public void TestDynamicConnectionToAllScans()
         {
             MsDataFile brukerReader = MsDataFileReader.GetDataFile(_centroidPath);

--- a/mzLib/Test/FileReadingTests/TestMgf.cs
+++ b/mzLib/Test/FileReadingTests/TestMgf.cs
@@ -108,6 +108,16 @@ namespace Test.FileReadingTests
         }
 
         [Test]
+        public void TestMgfDynamicConnection_AfterStaticLoading()
+        {
+            var filter = new FilteringParams(1, 0.01);
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "DataFiles", "tester.mgf");
+            var readerReal = MsDataFileReader.GetDataFile(path).LoadAllStaticData(filter);
+            readerReal.InitiateDynamicConnection();
+            readerReal.GetOneBasedScanFromDynamicConnection(2, filter);
+        }
+
+        [Test]
         public void EliminateZeroIntensityPeaksFromMgfOnFileLoad()
         {
             //read the mgf file. zero intensity peaks should be eliminated during read

--- a/mzLib/Test/FileReadingTests/TestMsAlign.cs
+++ b/mzLib/Test/FileReadingTests/TestMsAlign.cs
@@ -244,6 +244,19 @@ namespace Test.FileReadingTests
         }
 
         [Test]
+        public void GetOneBasedScanFromDynamicConnection_ExistingScanNumberOnLoadedData_ReturnsMsDataScan()
+        {
+            var msAlign = MsAlignTestFiles.First().Value;
+            msAlign.LoadAllStaticData();
+            msAlign.InitiateDynamicConnection();
+
+            var scan = msAlign.GetOneBasedScanFromDynamicConnection(1);
+
+            Assert.That(scan, Is.Not.Null);
+            Assert.That(1, Is.EqualTo(scan.OneBasedScanNumber));
+        }
+
+        [Test]
         public void GetOneBasedScanFromDynamicConnection_NonExistingScanNumber_ThrowsException()
         {
             var msAlign = MsAlignTestFiles.First().Value;

--- a/mzLib/Test/FileReadingTests/TestRawFileReader.cs
+++ b/mzLib/Test/FileReadingTests/TestRawFileReader.cs
@@ -135,6 +135,39 @@ namespace Test.FileReadingTests
             Assert.That(a == null);
         }
 
+        [Test]
+        public static void TestDynamicConnectionRawFileReader_AfterStaticLoading()
+        {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            var path1 = Path.Combine(TestContext.CurrentContext.TestDirectory, "DataFiles", "small.raw");
+            var thermoDynamic1 = MsDataFileReader.GetDataFile(path1).LoadAllStaticData();
+            thermoDynamic1.InitiateDynamicConnection();
+
+            var path2 = Path.Combine(TestContext.CurrentContext.TestDirectory, "DataFiles", "testFileWMS2.raw");
+            var thermoDynamic2 = MsDataFileReader.GetDataFile(path2).LoadAllStaticData();
+            thermoDynamic2.InitiateDynamicConnection();
+
+            var msOrders = thermoDynamic1.GetMsOrderByScanInDynamicConnection();
+            Assert.That(msOrders != null && msOrders.Length > 0);
+
+            var a = thermoDynamic1.GetOneBasedScanFromDynamicConnection(1);
+            Assert.That(a != null);
+
+            var b = thermoDynamic2.GetOneBasedScanFromDynamicConnection(1);
+            Assert.That(b != null);
+
+            Assert.That(a.MassSpectrum.XArray.Length != b.MassSpectrum.XArray.Length);
+
+            a = thermoDynamic1.GetOneBasedScanFromDynamicConnection(10000);
+            thermoDynamic1.CloseDynamicConnection();
+            thermoDynamic2.CloseDynamicConnection();
+
+            Console.WriteLine($"Analysis time for TestDynamicConnectionRawFileReader: {stopwatch.Elapsed.Hours}h {stopwatch.Elapsed.Minutes}m {stopwatch.Elapsed.Seconds}s");
+            Assert.That(a == null);
+        }
+
         /// <summary>
         /// Tests peak filtering for ThermoRawFileReader
         /// </summary>

--- a/mzLib/Test/FileReadingTests/TestReaders.cs
+++ b/mzLib/Test/FileReadingTests/TestReaders.cs
@@ -141,5 +141,25 @@ namespace Test.FileReadingTests
             Assert.That(results.Values.All(scan => scan != null), Is.True, "Null scan(s) returned.");
         }
 
+        [Test]
+        [TestCase("DataFiles/small.RAW", 48, "Thermo nativeID format")]
+        [TestCase("DataFiles/sliced_ethcd.raw", 6, "Thermo nativeID format")]
+        [TestCase("DataFiles/SmallCalibratibleYeast.mzml", 142, "Thermo nativeID format")]
+        [TestCase("DataFiles/tester.mzML", 7, null)]
+        public static void TestLoadingDynamicAfterStaticLoading(string filePath, int expectedScanCount, string sourceFormat)
+        {
+            string spectraPath = Path.Combine(TestContext.CurrentContext.TestDirectory, filePath);
+            MsDataFile datafile = MsDataFileReader.GetDataFile(spectraPath);
+            datafile.InitiateDynamicConnection();
+            var dynScan = datafile.GetOneBasedScanFromDynamicConnection(1);
+            datafile.CloseDynamicConnection();
+
+            datafile.LoadAllStaticData();
+            var staticScan = datafile.GetOneBasedScan(1);
+            var dynScanAfterLoad = datafile.GetOneBasedScanFromDynamicConnection(1);
+
+            Assert.That(dynScan.MassSpectrum, Is.EqualTo(dynScanAfterLoad.MassSpectrum));
+            Assert.That(dynScan.MassSpectrum, Is.EqualTo(staticScan.MassSpectrum));
+        }
     }
 }


### PR DESCRIPTION
If a data file is requested to get a scan dynamically, we first check if it has already been statically loaded before dynamic access. 