### PR TITLE
M ion losses

### DIFF
--- a/mzLib/Chemistry/ChemicalFormula.cs
+++ b/mzLib/Chemistry/ChemicalFormula.cs
@@ -564,7 +564,24 @@ namespace Chemistry
             ChemicalFormula newFormula = new ChemicalFormula(left);
             newFormula.Add(right);
             return newFormula;
+        }
 
+        public static ChemicalFormula operator *(ChemicalFormula formula, int multiplier)
+        {
+            if (formula == null)
+                return null;
+            ChemicalFormula newFormula = new ChemicalFormula(formula);
+            newFormula.Multiply(multiplier);
+            return newFormula;
+        }
+
+        public static ChemicalFormula operator *(int multiplier, ChemicalFormula formula)
+        {
+            if (formula == null)
+                return null;
+            ChemicalFormula newFormula = new ChemicalFormula(formula);
+            newFormula.Multiply(multiplier);
+            return newFormula;
         }
     }
 }

--- a/mzLib/Omics/BioPolymerWithSetModsExtensions.cs
+++ b/mzLib/Omics/BioPolymerWithSetModsExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using Chemistry;
+using Omics.Fragmentation;
 using Omics.Modifications;
 
 namespace Omics;
@@ -110,4 +111,19 @@ public static class BioPolymerWithSetModsExtensions
 
     public static string DetermineFullSequence(this IBioPolymerWithSetMods withSetMods) => IBioPolymerWithSetMods
         .DetermineFullSequence(withSetMods.BaseSequence, withSetMods.AllModsOneIsNterminus);
+
+    public static IEnumerable<Product> GetMIons(this IBioPolymerWithSetMods withSetMods, FragmentationParams? fragmentParams)
+    {
+        // Normal intact molecular ion
+        yield return new CustomMProduct("", withSetMods.MonoisotopicMass);
+
+        if (fragmentParams is null)
+            yield break;
+
+        // Molecular ion with neutral losses
+        foreach (var ionLoss in fragmentParams.MIonLosses)
+        {
+            yield return new CustomMProduct(ionLoss.Annotation, withSetMods.MonoisotopicMass - ionLoss.MonoisotopicMass);
+        }
+    }
 }

--- a/mzLib/Omics/Fragmentation/FragmentationParams.cs
+++ b/mzLib/Omics/Fragmentation/FragmentationParams.cs
@@ -1,0 +1,7 @@
+﻿namespace Omics.Fragmentation;
+
+public class FragmentationParams
+{
+    public bool GenerateMIon { get; set; } = false;
+    public List<MIonLoss> MIonLosses { get; set; } = new();
+}

--- a/mzLib/Omics/Fragmentation/MIonLoss.cs
+++ b/mzLib/Omics/Fragmentation/MIonLoss.cs
@@ -26,4 +26,6 @@ public class MIonLoss(string name, string annotation, ChemicalFormula chemicalFo
     public string Annotation { get; init; } = annotation;
     public double MonoisotopicMass => ThisChemicalFormula.MonoisotopicMass;
     public ChemicalFormula ThisChemicalFormula { get; set; } = chemicalFormula;
+
+    public override string ToString() => Annotation;
 }

--- a/mzLib/Omics/Fragmentation/MIonLoss.cs
+++ b/mzLib/Omics/Fragmentation/MIonLoss.cs
@@ -1,0 +1,29 @@
+﻿using Chemistry;
+
+namespace Omics.Fragmentation;
+
+public class MIonLoss(string name, string annotation, ChemicalFormula chemicalFormula) : IHasChemicalFormula
+{
+    public static MIonLoss PhosphoLoss;
+    public static MIonLoss WaterLoss;
+    public static MIonLoss PhosphoWaterLoss;
+    public static readonly Dictionary<string, MIonLoss> AllMIonLosses;
+
+    static MIonLoss()
+    {
+        PhosphoLoss = new MIonLoss("Phosphate Loss", "-P", ChemicalFormula.ParseFormula("H-1P-1O-3"));
+        WaterLoss = new MIonLoss("Water Loss", "-H2O", ChemicalFormula.ParseFormula("H-2O-1"));
+        PhosphoWaterLoss = new MIonLoss("Phosphate and Water Loss", "-P-H2O", ChemicalFormula.ParseFormula("H-3P-1O-4"));
+        AllMIonLosses  = new Dictionary<string, MIonLoss>
+        {
+            { "-P", PhosphoLoss },
+            { "-H2O", WaterLoss },
+            { "-P-H2O", PhosphoWaterLoss }
+        };
+    }
+
+    public string Name { get; init; } = name;
+    public string Annotation { get; init; } = annotation;
+    public double MonoisotopicMass => ThisChemicalFormula.MonoisotopicMass;
+    public ChemicalFormula ThisChemicalFormula { get; set; } = chemicalFormula;
+}

--- a/mzLib/Omics/Fragmentation/Product.cs
+++ b/mzLib/Omics/Fragmentation/Product.cs
@@ -124,4 +124,14 @@ namespace Omics.Fragmentation
         private string? _annotation;
         public override string Annotation => _annotation ??= base.Annotation;
     }
+
+    /// <summary>
+    /// Allows the addition of a string to the end of the product type and before fragment number in the annotation. 
+    /// </summary>
+    public class CustomMProduct(string customAnnotation, double neutralMass)
+        : Product(ProductType.M, FragmentationTerminus.None, neutralMass, 0, 0, 0)
+    {
+        public override string Annotation => $"M{customAnnotation}";
+        public override string ToString() => Annotation;
+    }
 }

--- a/mzLib/Omics/IBioPolymerWithSetMods.cs
+++ b/mzLib/Omics/IBioPolymerWithSetMods.cs
@@ -46,10 +46,10 @@ namespace Omics
         IBioPolymer Parent { get; }
 
         public void Fragment(DissociationType dissociationType, FragmentationTerminus fragmentationTerminus,
-            List<Product> products);
+            List<Product> products, FragmentationParams? fragmentationParams = null);
 
         public void FragmentInternally(DissociationType dissociationType, int minLengthOfFragments,
-            List<Product> products);
+            List<Product> products, FragmentationParams? fragmentationParams = null);
 
         /// <summary>
         /// Outputs a duplicate IBioPolymerWithSetMods with a localized mass shift, replacing a modification when present

--- a/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -215,7 +215,7 @@ namespace Proteomics.ProteolyticDigestion
         /// Generates theoretical fragments for given dissociation type for this peptide. 
         /// The "products" parameter is filled with these fragments.
         /// </summary>
-        public void Fragment(DissociationType dissociationType, FragmentationTerminus fragmentationTerminus, List<Product> products)
+        public void Fragment(DissociationType dissociationType, FragmentationTerminus fragmentationTerminus, List<Product> products, FragmentationParams? fragmentationParams = null)
         {
             // This code is specifically written to be memory- and CPU -efficient because it is 
             // called millions of times for a typical search (i.e., at least once per peptide). 
@@ -226,6 +226,9 @@ namespace Proteomics.ProteolyticDigestion
             // memory issues).
 
             products.Clear();
+
+            if (fragmentationParams is { GenerateMIon: true})
+                products.AddRange(this.GetMIons(fragmentationParams));
 
             var massCaps = DissociationTypeCollection.GetNAndCTerminalMassShiftsForDissociationType(dissociationType);
 
@@ -549,7 +552,7 @@ namespace Proteomics.ProteolyticDigestion
         /// TODO: Implement neutral losses (e.g. phospho)
         /// TODO: Implement Star/Degree ions from CID
         /// </summary>
-        public void FragmentInternally(DissociationType dissociationType, int minLengthOfFragments, List<Product> products)
+        public void FragmentInternally(DissociationType dissociationType, int minLengthOfFragments, List<Product> products, FragmentationParams? fragmentationParams = null)
         {
             products.Clear();
 

--- a/mzLib/Test/TestChemicalFormula.cs
+++ b/mzLib/Test/TestChemicalFormula.cs
@@ -1030,6 +1030,25 @@ namespace Test
         }
 
         [Test]
+        public static void TestMultiplyChemicalFormulaOperator()
+        {
+            ChemicalFormula formula = ChemicalFormula.ParseFormula("C3");
+
+            var multipliedFormula = formula * 3;
+            Assert.AreEqual("C9", multipliedFormula.Formula);
+
+            multipliedFormula = 3 * formula;
+            Assert.AreEqual("C9", multipliedFormula.Formula);
+
+            ChemicalFormula nullFormula = null;
+            var leftNull = nullFormula * 3;
+            Assert.AreEqual(null, leftNull);
+
+            var rightNull = 3 * nullFormula;
+            Assert.AreEqual(null, rightNull);
+        }
+
+        [Test]
         [TestCase("C", "N", "CN-1")]
         [TestCase(null, "N", "N-1")]
         [TestCase("C", null, "C")]

--- a/mzLib/Test/Transcriptomics/MIonLossTests.cs
+++ b/mzLib/Test/Transcriptomics/MIonLossTests.cs
@@ -1,0 +1,80 @@
+using NUnit.Framework;
+using Omics.Fragmentation;
+using Chemistry;
+
+namespace Test.Transcriptomics
+{
+    [TestFixture]
+    public class MIonLossTests
+    {
+        [Test]
+        public void PhosphoLoss_StaticInstance_IsInitializedCorrectly()
+        {
+            // Arrange
+            var expectedName = "Phosphate Loss";
+            var expectedAnnotation = "-P";
+            var expectedFormula = ChemicalFormula.ParseFormula("H-1P-1O-3");
+
+            // Act
+            var phosphoLoss = MIonLoss.PhosphoLoss;
+
+            // Assert
+            Assert.That(phosphoLoss, Is.Not.Null);
+            Assert.That(phosphoLoss.Annotation, Is.EqualTo(expectedAnnotation));
+            Assert.That(phosphoLoss.Name, Is.EqualTo(expectedName));
+            Assert.That(phosphoLoss.ThisChemicalFormula, Is.EqualTo(expectedFormula));
+            Assert.That(phosphoLoss.MonoisotopicMass, Is.EqualTo(expectedFormula.MonoisotopicMass));
+        }
+
+        [Test]
+        public void WaterLoss_StaticInstance_IsInitializedCorrectly()
+        {
+            // Arrange
+            var expectedName = "Water Loss";
+            var expectedAnnotation = "-H2O";
+            var expectedFormula = ChemicalFormula.ParseFormula("H-2O-1");
+
+            // Act
+            var waterLoss = MIonLoss.WaterLoss;
+
+            // Assert
+            Assert.That(waterLoss, Is.Not.Null);
+            Assert.That(waterLoss.Name, Is.EqualTo(expectedName));
+            Assert.That(waterLoss.Annotation, Is.EqualTo(expectedAnnotation));
+            Assert.That(waterLoss.ThisChemicalFormula, Is.EqualTo(expectedFormula));
+            Assert.That(waterLoss.MonoisotopicMass, Is.EqualTo(expectedFormula.MonoisotopicMass));
+        }
+
+        [Test]
+        public void Constructor_InitializesPropertiesCorrectly()
+        {
+            // Arrange
+            var name = "TestLoss";
+            var annotation = "-Test";
+            var formula = ChemicalFormula.ParseFormula("C2H4O2");
+
+            // Act
+            var loss = new MIonLoss(name, annotation, formula);
+
+            // Assert
+            Assert.That(loss.Name, Is.EqualTo(name));
+            Assert.That(loss.ThisChemicalFormula, Is.EqualTo(formula));
+            Assert.That(loss.MonoisotopicMass, Is.EqualTo(formula.MonoisotopicMass));
+        }
+
+        [Test]
+        public void ThisChemicalFormula_Setter_UpdatesFormulaAndMass()
+        {
+            // Arrange
+            var loss = new MIonLoss("TestLoss", "TestLoss", ChemicalFormula.ParseFormula("H2O"));
+            var newFormula = ChemicalFormula.ParseFormula("CO2");
+
+            // Act
+            loss.ThisChemicalFormula = newFormula;
+
+            // Assert
+            Assert.That(loss.ThisChemicalFormula, Is.EqualTo(newFormula));
+            Assert.That(loss.MonoisotopicMass, Is.EqualTo(newFormula.MonoisotopicMass));
+        }
+    }
+}

--- a/mzLib/Transcriptomics/RnaFragmentationParams.cs
+++ b/mzLib/Transcriptomics/RnaFragmentationParams.cs
@@ -1,0 +1,13 @@
+﻿using Omics.Fragmentation;
+
+namespace Transcriptomics;
+
+public class RnaFragmentationParams : FragmentationParams
+{
+    public static readonly RnaFragmentationParams Default = new();
+    public RnaFragmentationParams()
+    {
+        GenerateMIon = true;
+        MIonLosses = new List<MIonLoss>();
+    }
+}

--- a/mzLib/Transcriptomics/RnaFragmentationParams.cs
+++ b/mzLib/Transcriptomics/RnaFragmentationParams.cs
@@ -1,10 +1,91 @@
-﻿using Omics.Fragmentation;
+﻿using Chemistry;
+using Omics.Fragmentation;
 
 namespace Transcriptomics;
 
 public class RnaFragmentationParams : FragmentationParams
 {
-    public static readonly RnaFragmentationParams Default = new();
+    static RnaFragmentationParams()
+    {
+        Default = new();
+
+        // Initialize common RNA M-Ion Losses
+        var phosphoLossFomula = MIonLoss.PhosphoLoss.ThisChemicalFormula;
+        var waterLossFormula = MIonLoss.WaterLoss.ThisChemicalFormula;
+
+        // Adenine Base Loss
+        var aLossFormula = Nucleotide.AdenineBase.BaseChemicalFormula - 2 * Nucleotide.AdenineBase.BaseChemicalFormula;
+        var aLoss = new MIonLoss("Adenine Base Loss", "-A", aLossFormula);
+        MIonLoss.AllMIonLosses.Add(aLoss.Annotation, aLoss);
+
+        // Cytosine Base Loss
+        var cLossFormula = Nucleotide.CytosineBase.BaseChemicalFormula - 2 * Nucleotide.CytosineBase.BaseChemicalFormula;
+        var cLoss = new MIonLoss("Cytosine Base Loss", "-C", cLossFormula);
+        MIonLoss.AllMIonLosses.Add(cLoss.Annotation, cLoss);
+
+        // Guanine Base Loss
+        var gLossFormula = Nucleotide.GuanineBase.BaseChemicalFormula - 2 * Nucleotide.GuanineBase.BaseChemicalFormula;
+        var gLoss = new MIonLoss("Guanine Base Loss", "-G", gLossFormula);
+        MIonLoss.AllMIonLosses.Add(gLoss.Annotation, gLoss);
+
+        // Uracil Base Loss
+        var uLossFormula = Nucleotide.UracilBase.BaseChemicalFormula - 2 * Nucleotide.UracilBase.BaseChemicalFormula;
+        var uLoss = new MIonLoss("Uracil Base Loss", "-U", uLossFormula);
+        MIonLoss.AllMIonLosses.Add(uLoss.Annotation, uLoss);
+
+        // Water Losses
+        var aWaterLossFormula = aLossFormula + waterLossFormula;
+        var aWaterLoss = new MIonLoss("Adenine Base Water Loss", "-A-H2O", aWaterLossFormula);
+        MIonLoss.AllMIonLosses.Add(aWaterLoss.Annotation, aWaterLoss);
+
+        var cWaterLossFormula = cLossFormula + waterLossFormula;
+        var cWaterLoss = new MIonLoss("Cytosine Base Water Loss", "-C-H2O", cWaterLossFormula);
+        MIonLoss.AllMIonLosses.Add(cWaterLoss.Annotation, cWaterLoss);
+
+        var gWaterLossFormula = gLossFormula + waterLossFormula;
+        var gWaterLoss = new MIonLoss("Guanine Base Water Loss", "-G-H2O", gWaterLossFormula);
+        MIonLoss.AllMIonLosses.Add(gWaterLoss.Annotation, gWaterLoss);
+
+        var uWaterLossFormula = uLossFormula + waterLossFormula;
+        var uWaterLoss = new MIonLoss("Uracil Base Water Loss", "-U-H2O", uWaterLossFormula);
+        MIonLoss.AllMIonLosses.Add(uWaterLoss.Annotation, uWaterLoss);
+
+        // Phospho Losses
+        var aPhosphoLossFormula = aLossFormula + phosphoLossFomula;
+        var aPhosphoLoss = new MIonLoss("Adenine Base Phospho Loss", "-A-P", aPhosphoLossFormula);
+        MIonLoss.AllMIonLosses.Add(aPhosphoLoss.Annotation, aPhosphoLoss);
+
+        var cPhosphoLossFormula = cLossFormula + phosphoLossFomula;
+        var cPhosphoLoss = new MIonLoss("Cytosine Base Phospho Loss", "-C-P", cPhosphoLossFormula);
+        MIonLoss.AllMIonLosses.Add(cPhosphoLoss.Annotation, cPhosphoLoss);
+
+        var gPhosphoLossFormula = gLossFormula + phosphoLossFomula;
+        var gPhosphoLoss = new MIonLoss("Guanine Base Phospho Loss", "-G-P", gPhosphoLossFormula);
+        MIonLoss.AllMIonLosses.Add(gPhosphoLoss.Annotation, gPhosphoLoss);
+
+        var uPhosphoLossFormula = uLossFormula + phosphoLossFomula;
+        var uPhosphoLoss = new MIonLoss("Uracil Base Phospho Loss", "-U-P", uPhosphoLossFormula);
+        MIonLoss.AllMIonLosses.Add(uPhosphoLoss.Annotation, uPhosphoLoss);
+
+        // Phospho Water Losses
+        var aPhosphoWaterLossFormula = aLossFormula + phosphoLossFomula + waterLossFormula;
+        var aPhosphoWaterLoss = new MIonLoss("Adenine Base Phospho Water Loss", "-A-P-H2O", aPhosphoWaterLossFormula);
+        MIonLoss.AllMIonLosses.Add(aPhosphoWaterLoss.Annotation, aPhosphoWaterLoss);
+
+        var cPhosphoWaterLossFormula = cLossFormula + phosphoLossFomula + waterLossFormula;
+        var cPhosphoWaterLoss = new MIonLoss("Cytosine Base Phospho Water Loss", "-C-P-H2O", cPhosphoWaterLossFormula);
+        MIonLoss.AllMIonLosses.Add(cPhosphoWaterLoss.Annotation, cPhosphoWaterLoss);
+
+        var gPhosphoWaterLossFormula = gLossFormula + phosphoLossFomula + waterLossFormula;
+        var gPhosphoWaterLoss = new MIonLoss("Guanine Base Phospho Water Loss", "-G-P-H2O", gPhosphoWaterLossFormula);
+        MIonLoss.AllMIonLosses.Add(gPhosphoWaterLoss.Annotation, gPhosphoWaterLoss);
+
+        var uPhosphoWaterLossFormula = uLossFormula + phosphoLossFomula + waterLossFormula;
+        var uPhosphoWaterLoss = new MIonLoss("Uracil Base Phospho Water Loss", "-U-P-H2O", uPhosphoWaterLossFormula);
+        MIonLoss.AllMIonLosses.Add(uPhosphoWaterLoss.Annotation, uPhosphoWaterLoss);
+    }
+
+    public static readonly RnaFragmentationParams Default;
     public RnaFragmentationParams()
     {
         GenerateMIon = true;


### PR DESCRIPTION
This pull request adds support for generating molecular (M) ions and their neutral loss variants during fragmentation in both proteomics and transcriptomics workflows. It introduces a new `FragmentationParams` class to control M ion generation and defines standard neutral losses via the new `MIonLoss` class. The relevant APIs are updated to accept these parameters without breaking previous implementations, and comprehensive tests are added to validate the new functionality.

**Fragmentation and M Ion Generation Enhancements**

* Added `FragmentationParams` class with options to generate M ions and specify neutral losses (`MIonLoss`), and updated the fragmentation methods in `IBioPolymerWithSetMods`, `PeptideWithSetModifications`, and `OligoWithSetMods` to accept these parameters. [[1]](diffhunk://#diff-60eb524a46847cef0d483ff2857cf2b5cf896d6c0ed0111170608bd8ad22c315R1-R7) [[2]](diffhunk://#diff-17a815e3e0dc3dbf03b2c3cb2d3cd4cd547df91bc3e048ad51b81cdd4a9c0c6aL49-R52) [[3]](diffhunk://#diff-ae2f041492e3614a144811274af772c9ca0bde119902790b5670ca3e597a9bf0L218-R218) [[4]](diffhunk://#diff-94d2742c3c1f7daa1e3cbe94051cfbcf7c17a8c27f1a34ca97e52a6ad7fe1a01L189-R192)
* Implemented logic to generate intact molecular ions (`M`) and their neutral loss variants using the new `CustomMProduct` class and the `GetMIons` extension method. [[1]](diffhunk://#diff-1269973d04d4dbe5b7b7608012783db934689c91145d3071c4a53964125efbd8R114-R128) [[2]](diffhunk://#diff-4be9b7da1b1603c560ba6e091640c5d47acba2de8fbe14166ec15aba8a078dc9R127-R136) [[3]](diffhunk://#diff-94d2742c3c1f7daa1e3cbe94051cfbcf7c17a8c27f1a34ca97e52a6ad7fe1a01L214-R216)

**Standardization of Neutral Losses**

* Added the `MIonLoss` class with static instances for common losses (phosphate, water, phosphate+water), and a dictionary of all supported losses for easy lookup.

**Operator Overload and Utility Improvements**

* Added multiplication operator overloads for `ChemicalFormula` to allow easy scaling of formulas, with corresponding unit tests. [[1]](diffhunk://#diff-b23c3b12b8386565683ff953fcb0f139126eac333c6e70f35a5125a60df27e4bR567-R584) [[2]](diffhunk://#diff-2b1eae4c667e13d70db35a052bebbbbbf5bc03e68b16ed01bb87d540109ae5efR1032-R1050)

**Testing and Validation**

* Added extensive unit tests for M ion generation, neutral loss handling, and the `MIonLoss` class, covering both proteomics and transcriptomics scenarios. [[1]](diffhunk://#diff-f3ede7b749ad3f55c1f5be4b457633b98cd920cbf84c32fea2a114b53e327e1fR1268-R1310) [[2]](diffhunk://#diff-7d0c97a784e5539167f974bec2857cbd317f9f6395f67c17641b1d7f36268ae3R1-R80) [[3]](diffhunk://#diff-ef4d14c68ca0e0e5ee43ddc99284b9781cc6cc12b3fd868cd3381d4bba4054e5R242-R328)

These changes collectively enhance the fragmentation framework to support flexible and extensible M ion generation for mass spectrometry applications.