### PR TITLE
Add interface IHasIsobaricQuantReporters so that SpectralMatch can optionally have reporter ion intensities

### DIFF
--- a/mzLib/Omics/IHasIsobaricQuantReporters.cs
+++ b/mzLib/Omics/IHasIsobaricQuantReporters.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Omics
+{
+    /// <summary>
+    /// Capability interface for objects that can expose isobaric-quantification reporter intensities
+    /// (for example TMT or iTRAQ reporter channels) and be ordered for comparisons.
+    /// Implementers provide a fixed-order array of reporter intensities and a boolean indicating
+    /// whether meaningful reporter data is present.
+    /// </summary>
+    internal interface IHasIsobaricQuantReporters : IComparable<IHasIsobaricQuantReporters>
+    {
+        /// <summary>
+        /// True when the object contains valid isobaric reporter intensities that can be used
+        /// for quantification. When false, <see cref="IsobaricQuantReporterIntensities"/> should
+        /// be ignored by quantification logic.
+        /// </summary>
+        bool HasIsobaricQuantReporters { get; }
+
+        /// <summary>
+        /// Per-channel reporter intensities for isobaric quantification.
+        /// The array is ordered by reporter channel index (implementations must document the
+        /// channel ordering they use). Values are raw or pre-processed intensity values
+        /// (implementers should document whether values are normalized).
+        /// If a channel has no measured intensity, implementations may return 0.0 for that index.
+        /// </summary>
+        double[] IsobaricQuantReporterIntensities { get; }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new capability interface, `IHasIsobaricQuantReporters`, to the `Omics` namespace. This interface is intended for objects that can expose isobaric quantification reporter intensities (such as TMT or iTRAQ channels) and can be ordered for comparisons. The interface provides properties for accessing reporter intensities and a flag indicating whether valid data is present.

New interface for isobaric quantification support:

* Added the `IHasIsobaricQuantReporters` interface, which exposes a fixed-order array of reporter intensities and a boolean property to indicate the presence of valid reporter data. The interface also inherits from `IComparable<IHasIsobaricQuantReporters>` to support ordering and comparisons.This pull request introduces a new internal interface, `IHasIsobaricQuantReporters`, to the `Omics` namespace. This interface standardizes how objects expose isobaric quantification reporter intensities (such as TMT or iTRAQ channels) and supports ordering for comparisons. The interface ensures that implementers provide both a fixed-order array of reporter intensities and a flag indicating the presence of valid data.

Isobaric quantification support:

* Added the `IHasIsobaricQuantReporters` interface, which requires implementers to expose a boolean property `HasIsobaricQuantReporters` and a fixed-order array property `IsobaricQuantReporterIntensities`, and to support ordering via `IComparable<IHasIsobaricQuantReporters>`.