### PR TITLE
Isobaric Quant FileInfo and PlexAnnotation to achieve something analogous to SpectraFileInfo

### DIFF
--- a/mzLib/MassSpectrometry/IsobaricQuantFileInfo.cs
+++ b/mzLib/MassSpectrometry/IsobaricQuantFileInfo.cs
@@ -23,7 +23,7 @@ namespace MassSpectrometry
         /// <param name="annotations">Ordered list of channel annotations for the file's plex. May be null or empty.</param>
         public IsobaricQuantFileInfo(string fullFilePathWithExtension, string plex, int fraction, int technicalReplicate, IReadOnlyList<IsobaricQuantPlexAnnotation> annotations)
         {
-            FullFilePathWithExtension = fullFilePathWithExtension;
+            FullFilePathWithExtension = fullFilePathWithExtension ?? string.Empty;
             Plex = plex ?? string.Empty;
             Fraction = fraction;
             TechnicalReplicate = technicalReplicate;

--- a/mzLib/MassSpectrometry/IsobaricQuantFileInfo.cs
+++ b/mzLib/MassSpectrometry/IsobaricQuantFileInfo.cs
@@ -6,8 +6,10 @@ using System.IO;
 namespace MassSpectrometry
 {
     /// <summary>
-    /// Describes an isobaric-quantification input file and the plex annotations for that file.
-    /// Immutable for its core identity (path, plex, fraction, technical replicate and annotations).
+    /// Metadata describing a single isobaric-quantification input file and its plex channel annotations.
+    /// Instances encapsulate the file identity (path, plex, fraction, technical replicate) and an
+    /// ordered, read-only set of per-channel annotations used for mapping reporter channels to samples.
+    /// Designed as a small immutable value object for use as a dictionary key or in result tables.
     /// </summary>
     public class IsobaricQuantFileInfo
     {
@@ -15,10 +17,10 @@ namespace MassSpectrometry
         /// Create a new instance describing a single isobaric quantification file.
         /// </summary>
         /// <param name="fullFilePathWithExtension">Absolute or relative path to the spectra/quant file including extension.</param>
-        /// <param name="plex">The plex identifier (e.g., "TMT10", "TMTpro16") for this file. Null will be normalized to empty string.</param>
+        /// <param name="plex">The plex identifier (for example "TMT10" or "TMTpro16"). Null is normalized to an empty string.</param>
         /// <param name="fraction">Fraction index (1-based) for fractionated experiments.</param>
         /// <param name="technicalReplicate">Technical replicate index (1-based) for repeated injections/runs.</param>
-        /// <param name="annotations">Ordered list of channel annotations for the file's plex (may be empty).</param>
+        /// <param name="annotations">Ordered list of channel annotations for the file's plex. May be null or empty.</param>
         public IsobaricQuantFileInfo(string fullFilePathWithExtension, string plex, int fraction, int technicalReplicate, IReadOnlyList<IsobaricQuantPlexAnnotation> annotations)
         {
             FullFilePathWithExtension = fullFilePathWithExtension;
@@ -29,19 +31,19 @@ namespace MassSpectrometry
         }
 
         /// <summary>
-        /// The path to the data file (for example a .raw or .mzML) including the extension.
-        /// Used as the primary identity for equality and hashing.
+        /// Absolute or relative path to the data file (for example a .raw or .mzML), including extension.
+        /// This property forms the primary identity component used by <see cref="Equals(object)"/> and <see cref="GetHashCode"/>.
         /// </summary>
         public string FullFilePathWithExtension { get; }
 
         /// <summary>
         /// The plex identifier for this file (for example "TMT10" or "TMTpro16").
-        /// Empty string when not provided.
+        /// Returns an empty string when not provided.
         /// </summary>
         public string Plex { get; }
 
         /// <summary>
-        /// Fraction index for the file. Uses 1-based indexing to match experimental notation.
+        /// Fraction index for the file. Uses 1-based indexing to match common experimental notation.
         /// </summary>
         public int Fraction { get; }             // 1-based
 
@@ -51,54 +53,51 @@ namespace MassSpectrometry
         public int TechnicalReplicate { get; }   // 1-based
 
         /// <summary>
-        /// All channel annotations for this file's plex (one entry per reporter/tag).
-        /// Immutable reference to the provided read-only list (may be empty).
+        /// Ordered, read-only collection of per-channel annotations for this file's plex
+        /// (one entry per reporter/tag). May be empty but never null.
         /// </summary>
         public IReadOnlyList<IsobaricQuantPlexAnnotation> Annotations { get; } // All tags for this file's plex
 
         /// <summary>
-        /// Returns true when the other object represents the same file path.
-        /// Equality is based on <see cref="FullFilePathWithExtension"/>.
+        /// Equality compares the canonical file path. Two <see cref="IsobaricQuantFileInfo"/>
+        /// instances are considered equal when their <see cref="FullFilePathWithExtension"/>
+        /// strings are equal (ordinal comparison).
         /// </summary>
-        /// <param name="obj">Other object to compare.</param>
-        /// <returns>True when <paramref name="obj"/> is an <see cref="IsobaricQuantFileInfo"/> with the same file path.</returns>
+        /// <param name="obj">Object to compare.</param>
+        /// <returns>True when <paramref name="obj"/> is an <see cref="IsobaricQuantFileInfo"/> with the same file path; otherwise false.</returns>
         public override bool Equals(object obj)
         {
-            if (base.Equals(obj))
-            {
-                return ((IsobaricQuantFileInfo)obj).FullFilePathWithExtension.Equals(FullFilePathWithExtension);
-            }
-
-            return false;
+            return obj is IsobaricQuantFileInfo other && FullFilePathWithExtension.Equals(other.FullFilePathWithExtension);
         }
 
         /// <summary>
-        /// Returns a stable hash code based on <see cref="FullFilePathWithExtension"/>.
+        /// Returns a stable hash code derived from <see cref="FullFilePathWithExtension"/> using ordinal string hashing.
         /// </summary>
-        /// <returns>Hash code.</returns>
+        /// <returns>Hash code for the file identity.</returns>
         public override int GetHashCode()
         {
-            return FullFilePathWithExtension.GetHashCode();
+            return StringComparer.Ordinal.GetHashCode(FullFilePathWithExtension ?? string.Empty);
         }
 
         /// <summary>
-        /// Returns the file name (without directory) for display and logging.
+        /// Returns the file name portion (without directory) of <see cref="FullFilePathWithExtension"/>.
+        /// Suitable for display and logging.
         /// </summary>
-        /// <returns>File name portion of <see cref="FullFilePathWithExtension"/>.</returns>
+        /// <returns>File name portion of the file path, or empty string when the path is null/empty.</returns>
         public override string ToString()
         {
-            return Path.GetFileName(FullFilePathWithExtension);
+            return Path.GetFileName(FullFilePathWithExtension ?? string.Empty);
         }
     }
 
     /// <summary>
-    /// Annotation for a single isobaric reporter/tag within a plex.
-    /// Used to map reporter channels to sample/condition/biological replicate metadata.
+    /// Annotation describing a single reporter/tag within a plex.
+    /// Map a reporter channel to sample metadata: tag label, sample name, condition, and biological replicate.
     /// </summary>
     public class IsobaricQuantPlexAnnotation
     {
         /// <summary>
-        /// Reporter tag identifier (e.g., "126", "127N", "128C" or the channel label used by the reader).
+        /// Reporter tag identifier (for example "126", "127N", "128C" or reader-specific tag label).
         /// </summary>
         public string Tag { get; set; } = "";
 
@@ -108,12 +107,12 @@ namespace MassSpectrometry
         public string SampleName { get; set; } = "";
 
         /// <summary>
-        /// Experimental condition or group for this reporter channel (e.g., "Control" or "Treatment").
+        /// Experimental condition or group for this reporter channel (for example "Control" or "Treatment").
         /// </summary>
         public string Condition { get; set; } = "";
 
         /// <summary>
-        /// Biological replicate index for this channel (1-based). Zero or negative if not set.
+        /// Biological replicate index for this channel (1-based). Zero or negative indicates 'not set'.
         /// </summary>
         public int BiologicalReplicate { get; set; }
     }

--- a/mzLib/MassSpectrometry/IsobaricQuantFileInfo.cs
+++ b/mzLib/MassSpectrometry/IsobaricQuantFileInfo.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+
+namespace MassSpectrometry
+{
+    /// <summary>
+    /// Describes an isobaric-quantification input file and the plex annotations for that file.
+    /// Immutable for its core identity (path, plex, fraction, technical replicate and annotations).
+    /// </summary>
+    public class IsobaricQuantFileInfo
+    {
+        /// <summary>
+        /// Create a new instance describing a single isobaric quantification file.
+        /// </summary>
+        /// <param name="fullFilePathWithExtension">Absolute or relative path to the spectra/quant file including extension.</param>
+        /// <param name="plex">The plex identifier (e.g., "TMT10", "TMTpro16") for this file. Null will be normalized to empty string.</param>
+        /// <param name="fraction">Fraction index (1-based) for fractionated experiments.</param>
+        /// <param name="technicalReplicate">Technical replicate index (1-based) for repeated injections/runs.</param>
+        /// <param name="annotations">Ordered list of channel annotations for the file's plex (may be empty).</param>
+        public IsobaricQuantFileInfo(string fullFilePathWithExtension, string plex, int fraction, int technicalReplicate, IReadOnlyList<IsobaricQuantPlexAnnotation> annotations)
+        {
+            FullFilePathWithExtension = fullFilePathWithExtension;
+            Plex = plex ?? string.Empty;
+            Fraction = fraction;
+            TechnicalReplicate = technicalReplicate;
+            Annotations = annotations ?? Array.Empty<IsobaricQuantPlexAnnotation>();
+        }
+
+        /// <summary>
+        /// The path to the data file (for example a .raw or .mzML) including the extension.
+        /// Used as the primary identity for equality and hashing.
+        /// </summary>
+        public string FullFilePathWithExtension { get; }
+
+        /// <summary>
+        /// The plex identifier for this file (for example "TMT10" or "TMTpro16").
+        /// Empty string when not provided.
+        /// </summary>
+        public string Plex { get; }
+
+        /// <summary>
+        /// Fraction index for the file. Uses 1-based indexing to match experimental notation.
+        /// </summary>
+        public int Fraction { get; }             // 1-based
+
+        /// <summary>
+        /// Technical replicate index for the file. Uses 1-based indexing.
+        /// </summary>
+        public int TechnicalReplicate { get; }   // 1-based
+
+        /// <summary>
+        /// All channel annotations for this file's plex (one entry per reporter/tag).
+        /// Immutable reference to the provided read-only list (may be empty).
+        /// </summary>
+        public IReadOnlyList<IsobaricQuantPlexAnnotation> Annotations { get; } // All tags for this file's plex
+
+        /// <summary>
+        /// Returns true when the other object represents the same file path.
+        /// Equality is based on <see cref="FullFilePathWithExtension"/>.
+        /// </summary>
+        /// <param name="obj">Other object to compare.</param>
+        /// <returns>True when <paramref name="obj"/> is an <see cref="IsobaricQuantFileInfo"/> with the same file path.</returns>
+        public override bool Equals(object obj)
+        {
+            if (base.Equals(obj))
+            {
+                return ((IsobaricQuantFileInfo)obj).FullFilePathWithExtension.Equals(FullFilePathWithExtension);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns a stable hash code based on <see cref="FullFilePathWithExtension"/>.
+        /// </summary>
+        /// <returns>Hash code.</returns>
+        public override int GetHashCode()
+        {
+            return FullFilePathWithExtension.GetHashCode();
+        }
+
+        /// <summary>
+        /// Returns the file name (without directory) for display and logging.
+        /// </summary>
+        /// <returns>File name portion of <see cref="FullFilePathWithExtension"/>.</returns>
+        public override string ToString()
+        {
+            return Path.GetFileName(FullFilePathWithExtension);
+        }
+    }
+
+    /// <summary>
+    /// Annotation for a single isobaric reporter/tag within a plex.
+    /// Used to map reporter channels to sample/condition/biological replicate metadata.
+    /// </summary>
+    public class IsobaricQuantPlexAnnotation
+    {
+        /// <summary>
+        /// Reporter tag identifier (e.g., "126", "127N", "128C" or the channel label used by the reader).
+        /// </summary>
+        public string Tag { get; set; } = "";
+
+        /// <summary>
+        /// Human-readable sample name associated with this reporter channel.
+        /// </summary>
+        public string SampleName { get; set; } = "";
+
+        /// <summary>
+        /// Experimental condition or group for this reporter channel (e.g., "Control" or "Treatment").
+        /// </summary>
+        public string Condition { get; set; } = "";
+
+        /// <summary>
+        /// Biological replicate index for this channel (1-based). Zero or negative if not set.
+        /// </summary>
+        public int BiologicalReplicate { get; set; }
+    }
+}

--- a/mzLib/Test/Omics/IsobaricQuantFileAndSampleTests.cs
+++ b/mzLib/Test/Omics/IsobaricQuantFileAndSampleTests.cs
@@ -1,0 +1,49 @@
+﻿using MassSpectrometry;
+using NUnit.Framework;
+using Omics;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Test.Omics
+{
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    internal class IsobaricQuantFileAndSampleTests
+    {
+        [Test]
+        public void TestIsobaricQuantFileAndPlexAnnotationCreation()
+        {
+            // Create annotations for the plex
+            var annotations = new List<IsobaricQuantPlexAnnotation>
+            {
+                new IsobaricQuantPlexAnnotation
+                {
+                    Tag = "126",
+                    SampleName = "Sample1",
+                    Condition = "Control",
+                    BiologicalReplicate = 1
+                }
+            };
+
+            // Create an instance of IsobaricQuantFileInfo
+            var fileInfo = new IsobaricQuantFileInfo(
+                fullFilePathWithExtension: "SampleQuantFile.raw",
+                plex: "TMT10",
+                fraction: 1,
+                technicalReplicate: 1,
+                annotations: annotations);
+
+            // Assert that the properties are set correctly
+            Assert.That(fileInfo.FullFilePathWithExtension, Is.EqualTo("SampleQuantFile.raw"));
+            Assert.That(fileInfo.Plex, Is.EqualTo("TMT10"));
+            Assert.That(fileInfo.Fraction, Is.EqualTo(1));
+            Assert.That(fileInfo.TechnicalReplicate, Is.EqualTo(1));
+            Assert.That(fileInfo.Annotations, Is.Not.Null);
+            Assert.That(fileInfo.Annotations.Count, Is.EqualTo(1));
+            Assert.That(fileInfo.Annotations[0].Tag, Is.EqualTo("126"));
+            Assert.That(fileInfo.Annotations[0].SampleName, Is.EqualTo("Sample1"));
+            Assert.That(fileInfo.Annotations[0].Condition, Is.EqualTo("Control"));
+            Assert.That(fileInfo.Annotations[0].BiologicalReplicate, Is.EqualTo(1));
+        }
+    }
+}

--- a/mzLib/Test/Omics/IsobaricQuantFileAndSampleTests.cs
+++ b/mzLib/Test/Omics/IsobaricQuantFileAndSampleTests.cs
@@ -1,8 +1,8 @@
 ﻿using MassSpectrometry;
 using NUnit.Framework;
-using Omics;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 
 namespace Test.Omics
 {
@@ -10,6 +10,10 @@ namespace Test.Omics
     [ExcludeFromCodeCoverage]
     internal class IsobaricQuantFileAndSampleTests
     {
+        /// <summary>
+        /// Verify basic construction and that provided plex annotations are preserved.
+        /// Also documents the canonical visible properties that callers read back from the instance.
+        /// </summary>
         [Test]
         public void TestIsobaricQuantFileAndPlexAnnotationCreation()
         {
@@ -46,16 +50,53 @@ namespace Test.Omics
             Assert.That(fileInfo.Annotations[0].BiologicalReplicate, Is.EqualTo(1));
         }
 
+        /// <summary>
+        /// Ensure two instances with identical identity components (path, plex, fraction, techrep)
+        /// compare equal and produce the same hash code.
+        /// </summary>
         [Test]
-        public void TwoObjects_WithSameFilePath_AreEqual()
+        public void TwoObjects_WithSameIdentity_AreEqual()
         {
-            var a = new IsobaricQuantFileInfo("path/to/file.raw", "TMT10", 1, 1, new List<IsobaricQuantPlexAnnotation>());
-            var b = new IsobaricQuantFileInfo("path/to/file.raw", "TMT11", 2, 2, new List<IsobaricQuantPlexAnnotation>());
+            var a = new IsobaricQuantFileInfo("path/to/file.raw", "TMT10", 1, 1, new List<IsobaricQuantPlexAnnotation>
+            {
+                new IsobaricQuantPlexAnnotation { Tag = "126", SampleName = "A" }
+            });
 
-            Assert.That(a.Equals(b), Is.True, "Instances with identical FullFilePathWithExtension should be equal.");
+            var b = new IsobaricQuantFileInfo("path/to/file.raw", "TMT10", 1, 1, new List<IsobaricQuantPlexAnnotation>
+            {
+                new IsobaricQuantPlexAnnotation { Tag = "127", SampleName = "B" }
+            });
+
+            Assert.That(a.Equals(b), Is.True, "Instances with identical identity fields should be equal.");
             Assert.That(b.Equals(a), Is.True);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()), "Equal instances must have same hash code.");
+
+            // operator overloads
+            Assert.That(a == b, Is.True);
+            Assert.That(a != b, Is.False);
         }
 
+        /// <summary>
+        /// When the identity differs by plex, fraction or technical replicate the instances must not be equal.
+        /// </summary>
+        [Test]
+        public void TwoObjects_SamePathButDifferentMetadata_NotEqual()
+        {
+            var a = new IsobaricQuantFileInfo("path/to/file.raw", "TMT10", 1, 1, new List<IsobaricQuantPlexAnnotation>());
+            var bDifferentPlex = new IsobaricQuantFileInfo("path/to/file.raw", "TMT11", 1, 1, new List<IsobaricQuantPlexAnnotation>());
+            var bDifferentFraction = new IsobaricQuantFileInfo("path/to/file.raw", "TMT10", 2, 1, new List<IsobaricQuantPlexAnnotation>());
+            var bDifferentTechRep = new IsobaricQuantFileInfo("path/to/file.raw", "TMT10", 1, 2, new List<IsobaricQuantPlexAnnotation>());
+
+            Assert.That(a.Equals(bDifferentPlex), Is.False);
+            Assert.That(a.Equals(bDifferentFraction), Is.False);
+            Assert.That(a.Equals(bDifferentTechRep), Is.False);
+
+            Assert.That(a != bDifferentPlex, Is.True);
+        }
+
+        /// <summary>
+        /// Instances with different file paths should not be equal (path is part of identity).
+        /// </summary>
         [Test]
         public void Objects_WithDifferentFilePaths_AreNotEqual()
         {
@@ -64,25 +105,157 @@ namespace Test.Omics
 
             Assert.That(a.Equals(b), Is.False, "Instances with different FullFilePathWithExtension should not be equal.");
             Assert.That(b.Equals(a), Is.False);
+            Assert.That(a != b, Is.True);
         }
 
+        /// <summary>
+        /// Two equal objects must produce identical hash codes.
+        /// </summary>
         [Test]
         public void GetHashCode_ReturnsSameValue_ForEqualObjects()
         {
             var a = new IsobaricQuantFileInfo("same/path/file.raw", "TMT10", 1, 1, new List<IsobaricQuantPlexAnnotation>());
-            var b = new IsobaricQuantFileInfo("same/path/file.raw", "TMTpro16", 2, 3, new List<IsobaricQuantPlexAnnotation>());
+            var b = new IsobaricQuantFileInfo("same/path/file.raw", "TMT10", 1, 1, new List<IsobaricQuantPlexAnnotation>());
 
             Assert.That(a.Equals(b), Is.True);
             Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
         }
 
+        /// <summary>
+        /// ToString should return the filename portion (no directory). Tests Windows-style path here.
+        /// </summary>
         [Test]
         public void ToString_ReturnsFileNamePortion()
         {
-            var filePath = @"C:\data\experiments\SampleQuantFile.raw";
+            var filePath = Path.Combine("C:", "data", "experiments", "SampleQuantFile.raw");
             var fi = new IsobaricQuantFileInfo(filePath, "TMT10", 1, 1, new List<IsobaricQuantPlexAnnotation>());
 
             Assert.That(fi.ToString(), Is.EqualTo("SampleQuantFile.raw"));
+        }
+
+        // Edge cases
+
+        /// <summary>
+        /// Null and empty paths are normalized to empty string and treated equal.
+        /// Also asserts that Annotations is never null even when passed null.
+        /// </summary>
+        [Test]
+        public void NullAndEmptyPath_AreTreatedEquivalently()
+        {
+            var a = new IsobaricQuantFileInfo(null, "TMT10", 1, 1, null);
+            var b = new IsobaricQuantFileInfo(string.Empty, "TMT10", 1, 1, null);
+
+            Assert.That(a.FullFilePathWithExtension, Is.EqualTo(string.Empty));
+            Assert.That(b.FullFilePathWithExtension, Is.EqualTo(string.Empty));
+            Assert.That(a.Equals(b), Is.True);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+
+            Assert.That(a.Annotations, Is.Not.Null);
+            Assert.That(b.Annotations, Is.Not.Null);
+            Assert.That(a.Annotations.Count, Is.EqualTo(0));
+            Assert.That(b.Annotations.Count, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Constructor should normalize null plex and annotations inputs to non-null defaults.
+        /// </summary>
+        [Test]
+        public void Constructor_NormalizesNullPlexAndAnnotations()
+        {
+            var fi = new IsobaricQuantFileInfo("p", null, 1, 1, null);
+
+            Assert.That(fi.Plex, Is.EqualTo(string.Empty));
+            Assert.That(fi.Annotations, Is.Not.Null);
+            Assert.That(fi.Annotations.Count, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Equals(object) with null should return false; typed IEquatable also should return false.
+        /// </summary>
+        [Test]
+        public void Equals_WithNullObject_ReturnsFalse()
+        {
+            var a = new IsobaricQuantFileInfo("p", "TMT", 1, 1, null);
+
+            Assert.That(a.Equals(null), Is.False);
+            Assert.That(a == null, Is.False);
+            Assert.That(null == a, Is.False);
+        }
+
+        /// <summary>
+        /// Paths that differ only by separator style should be treated as equal because the implementation
+        /// canonicalizes paths via Path.GetFullPath where possible.
+        /// Also verify ToString still extracts the filename.
+        /// </summary>
+        [Test]
+        public void PathSeparatorDifference_BecomesEqualAfterCanonicalization()
+        {
+            var forward = "dir/sub/file.raw";
+            var back = @"dir\sub\file.raw";
+
+            var f = new IsobaricQuantFileInfo(forward, "TMT", 1, 1, null);
+            var b = new IsobaricQuantFileInfo(back, "TMT", 1, 1, null);
+
+            // canonicalization with Path.GetFullPath should make these equivalent on most platforms
+            Assert.That(f.Equals(b), Is.True, "Canonicalization should normalize separators and make the paths equal when they resolve to the same file.");
+            Assert.That(f.ToString(), Is.EqualTo("file.raw"));
+            Assert.That(b.ToString(), Is.EqualTo("file.raw"));
+        }
+
+        /// <summary>
+        /// Paths that end with a directory separator yield an empty ToString() filename portion.
+        /// Tests both forward and back slash behavior.
+        /// </summary>
+        [Test]
+        public void PathEndingWithSlash_ToStringReturnsEmpty()
+        {
+            // Forward-slash ending
+            var trailingForward = new IsobaricQuantFileInfo("dir/sub/", "TMT", 1, 1, null);
+            Assert.That(trailingForward.ToString(), Is.EqualTo(string.Empty));
+
+            // Backslash ending
+            var trailingBack = new IsobaricQuantFileInfo(@"dir\sub\", "TMT", 1, 1, null);
+            Assert.That(trailingBack.ToString(), Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// If only a filename is provided, ToString returns that filename and equality behaves as expected.
+        /// </summary>
+        [Test]
+        public void FilenameOnly_PathBehaves()
+        {
+            var fileOnly = new IsobaricQuantFileInfo("onlyfile.raw", "TMT", 1, 1, null);
+            Assert.That(fileOnly.ToString(), Is.EqualTo("onlyfile.raw"));
+
+            var fileOnly2 = new IsobaricQuantFileInfo("onlyfile.raw", "TMT", 1, 1, null);
+            Assert.That(fileOnly.Equals(fileOnly2), Is.True);
+            Assert.That(fileOnly == fileOnly2, Is.True);
+        }
+
+        /// <summary>
+        /// Canonicalization does not change case; equality remains ordinal (case-sensitive).
+        /// </summary>
+        [Test]
+        public void PathComparison_IsCaseSensitive()
+        {
+            var a = new IsobaricQuantFileInfo("PATH/To/File.RAW", "TMT10", 1, 1, null);
+            var b = new IsobaricQuantFileInfo("path/to/file.raw", "TMT10", 1, 1, null);
+
+            Assert.That(a.Equals(b), Is.False, "Ordinal comparison should treat different casing as not equal.");
+        }
+
+        /// <summary>
+        /// Differences in fraction or technical replicate must make objects unequal.
+        /// </summary>
+        [Test]
+        public void DifferentFractionOrTechnicalReplicate_AreNotEqual()
+        {
+            var baseInfo = new IsobaricQuantFileInfo("p.raw", "TMT10", 1, 1, null);
+            var diffFraction = new IsobaricQuantFileInfo("p.raw", "TMT10", 2, 1, null);
+            var diffTech = new IsobaricQuantFileInfo("p.raw", "TMT10", 1, 2, null);
+
+            Assert.That(baseInfo.Equals(diffFraction), Is.False);
+            Assert.That(baseInfo.Equals(diffTech), Is.False);
         }
     }
 }

--- a/mzLib/Test/Omics/IsobaricQuantFileAndSampleTests.cs
+++ b/mzLib/Test/Omics/IsobaricQuantFileAndSampleTests.cs
@@ -45,5 +45,44 @@ namespace Test.Omics
             Assert.That(fileInfo.Annotations[0].Condition, Is.EqualTo("Control"));
             Assert.That(fileInfo.Annotations[0].BiologicalReplicate, Is.EqualTo(1));
         }
+
+        [Test]
+        public void TwoObjects_WithSameFilePath_AreEqual()
+        {
+            var a = new IsobaricQuantFileInfo("path/to/file.raw", "TMT10", 1, 1, new List<IsobaricQuantPlexAnnotation>());
+            var b = new IsobaricQuantFileInfo("path/to/file.raw", "TMT11", 2, 2, new List<IsobaricQuantPlexAnnotation>());
+
+            Assert.That(a.Equals(b), Is.True, "Instances with identical FullFilePathWithExtension should be equal.");
+            Assert.That(b.Equals(a), Is.True);
+        }
+
+        [Test]
+        public void Objects_WithDifferentFilePaths_AreNotEqual()
+        {
+            var a = new IsobaricQuantFileInfo("path/to/fileA.raw", "TMT10", 1, 1, new List<IsobaricQuantPlexAnnotation>());
+            var b = new IsobaricQuantFileInfo("path/to/fileB.raw", "TMT10", 1, 1, new List<IsobaricQuantPlexAnnotation>());
+
+            Assert.That(a.Equals(b), Is.False, "Instances with different FullFilePathWithExtension should not be equal.");
+            Assert.That(b.Equals(a), Is.False);
+        }
+
+        [Test]
+        public void GetHashCode_ReturnsSameValue_ForEqualObjects()
+        {
+            var a = new IsobaricQuantFileInfo("same/path/file.raw", "TMT10", 1, 1, new List<IsobaricQuantPlexAnnotation>());
+            var b = new IsobaricQuantFileInfo("same/path/file.raw", "TMTpro16", 2, 3, new List<IsobaricQuantPlexAnnotation>());
+
+            Assert.That(a.Equals(b), Is.True);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+        }
+
+        [Test]
+        public void ToString_ReturnsFileNamePortion()
+        {
+            var filePath = @"C:\data\experiments\SampleQuantFile.raw";
+            var fi = new IsobaricQuantFileInfo(filePath, "TMT10", 1, 1, new List<IsobaricQuantPlexAnnotation>());
+
+            Assert.That(fi.ToString(), Is.EqualTo("SampleQuantFile.raw"));
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces a new value object, `IsobaricQuantFileInfo`, to encapsulate metadata about isobaric quantification files and their channel annotations. It also adds a supporting class `IsobaricQuantPlexAnnotation` and comprehensive unit tests to validate construction, equality, hash code, and edge-case behavior. These changes improve the handling and comparison of isobaric quantification file metadata, ensuring robust dictionary key usage and result table representation.

**New value object for file metadata and annotations:**

* Added `IsobaricQuantFileInfo` class in `mzLib/MassSpectrometry/IsobaricQuantFileInfo.cs` to represent a single isobaric quantification input file, including its canonical path, plex identifier, fraction, technical replicate, and an ordered set of per-channel annotations. Paths are normalized for robust identity comparison.
* Added `IsobaricQuantPlexAnnotation` class to describe individual reporter/tag metadata within a plex, including tag, sample name, condition, and biological replicate index.

**Testing and validation:**

* Added `IsobaricQuantFileAndSampleTests` in `mzLib/Test/Omics/IsobaricQuantFileAndSampleTests.cs` to verify construction, equality, hash code stability, edge cases (null/empty/filename-only paths), and correct ToString behavior.

**Robustness and edge case handling:**

* Ensured normalization of null/empty input values for file path, plex, and annotations, guaranteeing non-null and consistent property values. [[1]](diffhunk://#diff-2d16ef3b4f3cf6242437a05da69c23845afd463a6b6fd480d14a260b4cf6bca4R1-R194) [[2]](diffhunk://#diff-9c4cfc19db2806d5b9e9e8e5f0ff02669fa1eada15ef46724c2dd74998c3f6a5R1-R261)
* Implemented equality and hash code logic based on canonical file path, plex, fraction, and technical replicate, with operator overloads for value semantics. [[1]](diffhunk://#diff-2d16ef3b4f3cf6242437a05da69c23845afd463a6b6fd480d14a260b4cf6bca4R1-R194) [[2]](diffhunk://#diff-9c4cfc19db2806d5b9e9e8e5f0ff02669fa1eada15ef46724c2dd74998c3f6a5R1-R261)This pull request introduces a new value object, `IsobaricQuantFileInfo`, to encapsulate metadata for isobaric quantification input files, along with its associated per-channel annotation class. Additionally, a new test suite validates the correct behavior and equality logic of these classes.

New isobaric quantification file metadata classes:

* Added `IsobaricQuantFileInfo` class in `mzLib/MassSpectrometry/IsobaricQuantFileInfo.cs` to represent a single quantification file, including file path, plex identifier, fraction, technical replicate, and an ordered, read-only list of per-channel annotations. This class is designed to be immutable and suitable for use as a dictionary key or in result tables.
* Added `IsobaricQuantPlexAnnotation` class in `mzLib/MassSpectrometry/IsobaricQuantFileInfo.cs` to describe a single reporter/tag within a plex, mapping reporter channels to sample metadata such as tag label, sample name, condition, and biological replicate.

Unit tests for new value objects:

* Added `IsobaricQuantFileAndSampleTests` in `mzLib/Test/Omics/IsobaricQuantFileAndSampleTests.cs` to verify correct construction, property assignment, equality logic, hash code stability, and string representation for `IsobaricQuantFileInfo` and its annotations.This pull request introduces new support for representing isobaric quantification input files and their associated channel annotations, along with corresponding unit tests to ensure correct construction and property assignment. The main changes are the addition of new data model classes for isobaric quantification and a test suite to validate their behavior.

**Isobaric Quantification Data Model:**

* Added new class `IsobaricQuantFileInfo` in `mzLib/MassSpectrometry/IsobaricQuantFileInfo.cs` to encapsulate metadata about isobaric quantification files, including file path, plex type, fraction, technical replicate, and channel annotations.
* Added supporting class `IsobaricQuantPlexAnnotation` to represent metadata for individual reporter channels, such as tag, sample name, condition, and biological replicate.

**Unit Testing:**

* Added test class `IsobaricQuantFileAndSampleTests` in `mzLib/Test/Omics/IsobaricQuantFileAndSampleTests.cs` to verify correct instantiation and property assignment for `IsobaricQuantFileInfo` and `IsobaricQuantPlexAnnotation`.