### PR TITLE
Specify *.csproj filepaths in dotnet.yml to patch failing integration workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -65,18 +65,18 @@ jobs:
     - name: Change MetaMorpheus mzLib version and restore
       run: |
         cd ./MetaMorpheus/MetaMorpheus;
-        dotnet remove CMD package mzLib;
-        dotnet add CMD package mzLib -v 9.9.9;
-        dotnet remove GUI package mzLib;
-        dotnet add GUI package mzLib -v 9.9.9;
-        dotnet remove GuiFunctions package mzLib;
-        dotnet add GuiFunctions package mzLib -v 9.9.9;
-        dotnet remove EngineLayer package mzLib;
-        dotnet add EngineLayer package mzLib -v 9.9.9;
-        dotnet remove Test package mzLib;
-        dotnet add Test package mzLib -v 9.9.9;
-        dotnet remove TaskLayer package mzLib;
-        dotnet add TaskLayer package mzLib -v 9.9.9;
+        dotnet remove CMD/CMD.csproj package mzLib;
+        dotnet add CMD/CMD.csproj package mzLib -v 9.9.9;
+        dotnet remove GUI/GUI.csproj package mzLib;
+        dotnet add GUI/GUI.csproj package mzLib -v 9.9.9;
+        dotnet remove GuiFunctions/GuiFunctions.csproj package mzLib;
+        dotnet add GuiFunctions/GuiFunctions.csproj package mzLib -v 9.9.9;
+        dotnet remove EngineLayer/EngineLayer.csproj package mzLib;
+        dotnet add EngineLayer/EngineLayer.csproj package mzLib -v 9.9.9;
+        dotnet remove Test/Test.csproj package mzLib;
+        dotnet add Test/Test.csproj package mzLib -v 9.9.9;
+        dotnet remove TaskLayer/TaskLayer.csproj package mzLib;
+        dotnet add TaskLayer/TaskLayer.csproj package mzLib -v 9.9.9;
         dotnet restore;
     - name: Build MetaMorpheus
       run: cd ./MetaMorpheus/MetaMorpheus && dotnet build --no-restore


### PR DESCRIPTION
mzLib integration tests are failing when re-versioning mzlib in metamorpheus during the integration workflow. There is some issue with dotnet remove/add that silently fails some updates, and the GUI project seems to be the first one throwing the issue. There may be issues elsewhere but it seems to be fixed by instead of using `dotnet add GUI ...` specifying instead `dotnet add GUI/GUI.csproj ...`. All of the reversioning lines are updated to reflect that.