### PR TITLE
Generic Deconvolution Scorer

### DIFF
--- a/mzLib/MassSpectrometry/Deconvolution/Scoring/DeconvolutionScorer.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Scoring/DeconvolutionScorer.cs
@@ -41,11 +41,13 @@ namespace MassSpectrometry
         // ratioConsistency = good; high ppmError = bad) and should generalise across
         // algorithms, though re-calibration on Classic and FLASHDeconv output is
         // recommended once those decoy distributions are available.
-        private const double CoefficientCosine = -3.4494;
-        private const double CoefficientPpmError = 1.6341;
-        private const double CoefficientCompleteness = -4.7795;
-        private const double CoefficientRatioConsistency = -2.1883;
-        private const double Intercept = -4.3142;
+        // Signs follow standard logistic convention: positive coefficient ⇒ feature
+        // increases P(true). Weights can be replaced directly with sklearn / glm output.
+        private const double CoefficientCosine = 3.4494;
+        private const double CoefficientPpmError = -1.6341;
+        private const double CoefficientCompleteness = 4.7795;
+        private const double CoefficientRatioConsistency = 2.1883;
+        private const double Intercept = 4.3142;
 
         // ── Feature matching tolerance ────────────────────────────────────────
         private const double MatchTolerancePpm = 10.0;
@@ -76,11 +78,12 @@ namespace MassSpectrometry
 
             // Arrays from AverageResidue are sorted intensity-descending (index 0 = apex).
             // Re-sort to mass-ascending so index 0 = monoisotopic.
-            var sorted = rawMasses.Zip(rawIntens)
-                .OrderBy(pair => pair.First)
-                .ToArray();
-            double[] avgMassAsc = sorted.Select(p => p.First).ToArray();
-            double[] avgIntAsc = sorted.Select(p => p.Second).ToArray();
+            int nIsoLen = rawMasses.Length;
+            double[] avgMassAsc = new double[nIsoLen];
+            double[] avgIntAsc = new double[nIsoLen];
+            Array.Copy(rawMasses, avgMassAsc, nIsoLen);
+            Array.Copy(rawIntens, avgIntAsc, nIsoLen);
+            Array.Sort(avgMassAsc, avgIntAsc);
             int nIso = avgMassAsc.Length;
 
             // apexDaFromMono: distance in Da from monoisotopic to apex
@@ -104,7 +107,9 @@ namespace MassSpectrometry
             // For each theoretical isotope position n, find the closest peak in
             // envelope.Peaks within MatchTolerancePpm.
             double monoMass = envelope.MonoisotopicMass;
-            double monoMz = monoMass.ToMz(absCharge);
+            // Use signed charge so negative-mode envelopes (proton subtracted) align
+            // with their peaks. absCharge still governs isotope spacing (sign-agnostic).
+            double monoMz = monoMass.ToMz(envelope.Charge);
             var peakList = envelope.Peaks;
 
             double[] observed = new double[nIso];
@@ -186,7 +191,7 @@ namespace MassSpectrometry
                 + CoefficientCompleteness * features.PeakCompleteness
                 + CoefficientRatioConsistency * features.IntensityRatioConsistency;
 
-            return 1.0 / (1.0 + Math.Exp(linear));
+            return 1.0 / (1.0 + Math.Exp(-linear));
         }
 
         /// <summary>
@@ -199,15 +204,25 @@ namespace MassSpectrometry
         /// Applies <see cref="ScoreEnvelope"/> to each envelope in the sequence and
         /// yields <c>(envelope, genericScore)</c> pairs. The original
         /// <see cref="IsotopicEnvelope.Score"/> field is not mutated.
+        /// Null elements in <paramref name="envelopes"/> are silently skipped.
         /// </summary>
-        /// <param name="envelopes">Envelopes to score.</param>
-        /// <param name="model">Averagine model for theoretical isotope lookup.</param>
+        /// <param name="envelopes">Envelopes to score. Must not be null; null elements are skipped.</param>
+        /// <param name="model">Averagine model for theoretical isotope lookup. Must not be null.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="envelopes"/> or <paramref name="model"/> is null.
+        /// </exception>
         public static IEnumerable<(IsotopicEnvelope Envelope, double Score)> ScoreEnvelopes(
             IEnumerable<IsotopicEnvelope> envelopes,
             AverageResidue model)
         {
+            if (envelopes == null) throw new ArgumentNullException(nameof(envelopes));
+            if (model == null) throw new ArgumentNullException(nameof(model));
+
             foreach (var env in envelopes)
+            {
+                if (env == null) continue;
                 yield return (env, ScoreEnvelope(env, model));
+            }
         }
 
         // ── Private helpers ───────────────────────────────────────────────────

--- a/mzLib/MassSpectrometry/Deconvolution/Scoring/DeconvolutionScorer.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Scoring/DeconvolutionScorer.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Chemistry;
+using MassSpectrometry.MzSpectra;
+
+namespace MassSpectrometry
+{
+    /// <summary>
+    /// Generic post-hoc scorer for <see cref="IsotopicEnvelope"/> objects produced
+    /// by any mzLib deconvolution algorithm (Classic, IsoDec, FLASHDeconv).
+    ///
+    /// All scoring is performed from the envelope's <see cref="IsotopicEnvelope.Peaks"/>
+    /// list and an <see cref="AverageResidue"/> model. No raw <see cref="MzSpectrum"/>
+    /// access is required, supporting callers that deconvolute and discard the spectrum.
+    ///
+    /// The score produced by <see cref="ComputeScore"/> is a logistic function in [0, 1]
+    /// combining four features:
+    /// <list type="bullet">
+    ///   <item><see cref="EnvelopeScoreFeatures.AveragineCosineSimilarity"/> — isotope pattern fidelity</item>
+    ///   <item><see cref="EnvelopeScoreFeatures.AvgPpmError"/> — mass accuracy</item>
+    ///   <item><see cref="EnvelopeScoreFeatures.PeakCompleteness"/> — observed vs expected peak count</item>
+    ///   <item><see cref="EnvelopeScoreFeatures.IntensityRatioConsistency"/> — uniformity of per-peak scale ratios</item>
+    /// </list>
+    ///
+    /// The logistic weights are provisional and should be recalibrated against labelled
+    /// training data once available. See <see cref="CoefficientCosine"/> and related
+    /// constants.
+    /// </summary>
+    public static class DeconvolutionScorer
+    {
+        // ── Logistic regression weights ───────────────────────────────────────
+        // Calibrated against IsoDec top-down yeast data:
+        //   File:    05-26-17_B7A_yeast_td_fract8_rep2.mzML
+        //   Labels:  381,098 target envelopes / 198,445 decoy envelopes
+        //            (deconvolution-level labels via DecoyIsotopeDistance = 0.9444 Da)
+        //   AUC:     1.0000 on training set
+        //
+        // The AUC of 1.0 reflects near-perfect separation on this dataset. The weights
+        // capture the physical meaning of the features (high cosine/completeness/
+        // ratioConsistency = good; high ppmError = bad) and should generalise across
+        // algorithms, though re-calibration on Classic and FLASHDeconv output is
+        // recommended once those decoy distributions are available.
+        private const double CoefficientCosine = -3.4494;
+        private const double CoefficientPpmError = 1.6341;
+        private const double CoefficientCompleteness = -4.7795;
+        private const double CoefficientRatioConsistency = -2.1883;
+        private const double Intercept = -4.3142;
+
+        // ── Feature matching tolerance ────────────────────────────────────────
+        private const double MatchTolerancePpm = 10.0;
+
+        // ── Public API ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Computes the three scoring features for a single envelope using the supplied
+        /// Averagine model. Does not access the raw spectrum.
+        /// </summary>
+        /// <param name="envelope">Envelope to score.</param>
+        /// <param name="model">
+        /// Averagine model used for theoretical isotope pattern lookup.
+        /// Should be the same model used during deconvolution.
+        /// </param>
+        public static EnvelopeScoreFeatures ComputeFeatures(
+            IsotopicEnvelope envelope,
+            AverageResidue model)
+        {
+            if (envelope == null) throw new ArgumentNullException(nameof(envelope));
+            if (model == null) throw new ArgumentNullException(nameof(model));
+
+            // ── Averagine lookup ──────────────────────────────────────────────
+            int avgIdx = model.GetMostIntenseMassIndex(envelope.MonoisotopicMass);
+
+            double[] rawMasses = model.GetAllTheoreticalMasses(avgIdx);
+            double[] rawIntens = model.GetAllTheoreticalIntensities(avgIdx);
+
+            // Arrays from AverageResidue are sorted intensity-descending (index 0 = apex).
+            // Re-sort to mass-ascending so index 0 = monoisotopic.
+            var sorted = rawMasses.Zip(rawIntens)
+                .OrderBy(pair => pair.First)
+                .ToArray();
+            double[] avgMassAsc = sorted.Select(p => p.First).ToArray();
+            double[] avgIntAsc = sorted.Select(p => p.Second).ToArray();
+            int nIso = avgMassAsc.Length;
+
+            // apexDaFromMono: distance in Da from monoisotopic to apex
+            double apexDaFromMono = model.GetDiffToMonoisotopic(avgIdx);
+            int absCharge = Math.Abs(envelope.Charge);
+
+            // Guard: charge of 0 is physically invalid — no isotope spacing can be computed.
+            // Return degenerate features that will produce a near-zero logistic score:
+            //   - Cosine similarity = 0 (no match)
+            //   - PpmError = double.MaxValue (forces the logistic linear combination to be
+            //     overwhelmingly positive, driving the sigmoid output to ~0 regardless of
+            //     coefficient calibration)
+            //   - PeakCompleteness = 0 (no peaks matched)
+            //   - IntensityRatioConsistency = 0 (no ratio data)
+            if (absCharge == 0)
+                return new EnvelopeScoreFeatures(0.0, double.MaxValue, 0.0, 0.0);
+
+            double isotopeStepMz = Constants.C13MinusC12 / absCharge;
+
+            // ── Build observed intensity vector for cosine and completeness ───
+            // For each theoretical isotope position n, find the closest peak in
+            // envelope.Peaks within MatchTolerancePpm.
+            double monoMass = envelope.MonoisotopicMass;
+            double monoMz = monoMass.ToMz(absCharge);
+            var peakList = envelope.Peaks;
+
+            double[] observed = new double[nIso];
+            bool[] peakMatched = new bool[nIso];
+
+            for (int n = 0; n < nIso; n++)
+            {
+                double theorMz = monoMz + n * isotopeStepMz;
+                double tolMz = theorMz * MatchTolerancePpm * 1e-6;
+
+                // Find the peak in the envelope closest to this theoretical position.
+                double bestDist = double.MaxValue;
+                double bestIntensity = 0.0;
+
+                foreach (var (mz, intensity) in peakList)
+                {
+                    double dist = Math.Abs(mz - theorMz);
+                    if (dist < tolMz && dist < bestDist)
+                    {
+                        bestDist = dist;
+                        bestIntensity = intensity;
+                    }
+                }
+
+                if (bestDist < double.MaxValue)
+                {
+                    observed[n] = bestIntensity;
+                    peakMatched[n] = true;
+                }
+                // else observed[n] = 0 (default), peakMatched[n] = false
+            }
+
+            // ── AveragineCosineSimilarity ─────────────────────────────────────
+            double cosine = SpectralSimilarity.CosineOfAlignedVectors(observed, avgIntAsc);
+            cosine = Math.Max(0.0, Math.Min(1.0, cosine));
+
+            // ── AvgPpmError ───────────────────────────────────────────────────
+            double avgPpmError = ComputeAvgPpmError(peakList, absCharge, isotopeStepMz);
+
+            // ── PeakCompleteness ──────────────────────────────────────────────
+            double maxTheoInt = avgIntAsc.Max();
+            double threshold1pct = maxTheoInt * 0.01;
+            int expectedPeaks = 0;
+            int observedPeaks = 0;
+
+            for (int n = 0; n < nIso; n++)
+            {
+                if (avgIntAsc[n] > threshold1pct)
+                {
+                    expectedPeaks++;
+                    if (peakMatched[n]) observedPeaks++;
+                }
+            }
+
+            double completeness = expectedPeaks == 0
+                ? 0.0
+                : Math.Max(0.0, Math.Min(1.0, (double)observedPeaks / expectedPeaks));
+
+            // ── IntensityRatioConsistency ─────────────────────────────────────
+            double ratioConsistency = ComputeRatioConsistency(observed, avgIntAsc);
+
+            return new EnvelopeScoreFeatures(cosine, avgPpmError, completeness, ratioConsistency);
+        }
+
+        /// <summary>
+        /// Combines the three features into a single score in [0, 1] using a logistic
+        /// function.
+        /// <para>
+        /// Higher scores indicate higher confidence that the envelope represents a true
+        /// deconvolution result. The logistic weights are provisional — see the constants
+        /// at the top of this class.
+        /// </para>
+        /// </summary>
+        public static double ComputeScore(EnvelopeScoreFeatures features)
+        {
+            double linear = Intercept
+                + CoefficientCosine * features.AveragineCosineSimilarity
+                + CoefficientPpmError * features.AvgPpmError
+                + CoefficientCompleteness * features.PeakCompleteness
+                + CoefficientRatioConsistency * features.IntensityRatioConsistency;
+
+            return 1.0 / (1.0 + Math.Exp(linear));
+        }
+
+        /// <summary>
+        /// Convenience method: computes features then score for a single envelope.
+        /// </summary>
+        public static double ScoreEnvelope(IsotopicEnvelope envelope, AverageResidue model)
+            => ComputeScore(ComputeFeatures(envelope, model));
+
+        /// <summary>
+        /// Applies <see cref="ScoreEnvelope"/> to each envelope in the sequence and
+        /// yields <c>(envelope, genericScore)</c> pairs. The original
+        /// <see cref="IsotopicEnvelope.Score"/> field is not mutated.
+        /// </summary>
+        /// <param name="envelopes">Envelopes to score.</param>
+        /// <param name="model">Averagine model for theoretical isotope lookup.</param>
+        public static IEnumerable<(IsotopicEnvelope Envelope, double Score)> ScoreEnvelopes(
+            IEnumerable<IsotopicEnvelope> envelopes,
+            AverageResidue model)
+        {
+            foreach (var env in envelopes)
+                yield return (env, ScoreEnvelope(env, model));
+        }
+
+        // ── Private helpers ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// Computes the intensity ratio consistency feature.
+        ///
+        /// For each matched isotope position n, the scale ratio is
+        /// <c>observed[n] / theoretical[n]</c>. For a real envelope these should all
+        /// be approximately equal (the envelope is the Averagine pattern scaled by a
+        /// single abundance). The coefficient of variation (CV = std / mean) of these
+        /// ratios measures how erratic the scaling is. We return <c>1 / (1 + CV²)</c>
+        /// so that the feature is in [0, 1] with 1.0 meaning perfectly consistent.
+        ///
+        /// Only positions where both observed > 0 and theoretical > 1% of max are
+        /// included, to avoid division by zero or near-zero theoretical intensities
+        /// corrupting the statistic.
+        /// </summary>
+        private static double ComputeRatioConsistency(double[] observed, double[] theoretical)
+        {
+            if (observed.Length != theoretical.Length || observed.Length == 0)
+                return 0.0;
+
+            double maxTheo = 0.0;
+            for (int i = 0; i < theoretical.Length; i++)
+                if (theoretical[i] > maxTheo) maxTheo = theoretical[i];
+
+            double threshold = maxTheo * 0.01;
+
+            // Collect per-peak scale ratios for positions with meaningful signal
+            double sumRatio = 0.0;
+            int count = 0;
+            for (int n = 0; n < observed.Length; n++)
+            {
+                if (theoretical[n] > threshold && observed[n] > 0.0)
+                {
+                    sumRatio += observed[n] / theoretical[n];
+                    count++;
+                }
+            }
+
+            if (count < 2) return 0.0; // CV undefined for fewer than 2 points
+
+            double meanRatio = sumRatio / count;
+            if (meanRatio <= 0.0) return 0.0;
+
+            // Variance of the ratios
+            double sumSqDev = 0.0;
+            for (int n = 0; n < observed.Length; n++)
+            {
+                if (theoretical[n] > threshold && observed[n] > 0.0)
+                {
+                    double dev = (observed[n] / theoretical[n]) - meanRatio;
+                    sumSqDev += dev * dev;
+                }
+            }
+
+            double variance = sumSqDev / count;
+            double cv = Math.Sqrt(variance) / meanRatio; // coefficient of variation
+
+            // Transform: 1 / (1 + CV²) → [0, 1], 1.0 = perfectly consistent
+            return 1.0 / (1.0 + cv * cv);
+        }
+
+        /// <summary>
+        /// Computes the mean absolute ppm error of the envelope's peaks relative
+        /// to the apex-anchored theoretical isotope grid.
+        /// </summary>
+        private static double ComputeAvgPpmError(
+            IReadOnlyList<(double mz, double intensity)> peaks,
+            int absCharge,
+            double isotopeStepMz)
+        {
+            if (peaks.Count == 0) return MatchTolerancePpm;
+
+            // Anchor at the most intense peak
+            double apexMz = peaks.MaxBy(p => p.intensity).mz;
+
+            double totalPpm = 0.0;
+            foreach (var (mz, _) in peaks)
+            {
+                int n = (int)Math.Round((mz - apexMz) / isotopeStepMz);
+                double theorMz = apexMz + n * isotopeStepMz;
+                totalPpm += Math.Abs(mz - theorMz) / theorMz * 1e6;
+            }
+
+            return totalPpm / peaks.Count;
+        }
+    }
+}

--- a/mzLib/MassSpectrometry/Deconvolution/Scoring/EnvelopeScoreFeatures.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Scoring/EnvelopeScoreFeatures.cs
@@ -1,0 +1,85 @@
+namespace MassSpectrometry
+{
+    /// <summary>
+    /// The computed feature vector for a single <see cref="IsotopicEnvelope"/>,
+    /// produced by <see cref="DeconvolutionScorer.ComputeFeatures"/> and consumed
+    /// by <see cref="DeconvolutionScorer.ComputeScore"/>.
+    ///
+    /// All four features are computable from the envelope's peak list and an
+    /// <see cref="AverageResidue"/> model alone — no raw spectrum access is required.
+    /// This allows the scorer to operate after the spectrum has been discarded
+    /// (deconvolute-and-discard callers).
+    /// </summary>
+    public readonly struct EnvelopeScoreFeatures
+    {
+        /// <summary>
+        /// Cosine similarity between the observed isotope intensity distribution
+        /// and the theoretical Averagine distribution at the envelope's monoisotopic
+        /// mass. Computed by aligning observed peak intensities to Averagine isotope
+        /// positions at 10 ppm tolerance.
+        /// Range: [0, 1]. Higher values indicate better agreement with the expected
+        /// isotope pattern.
+        /// </summary>
+        public readonly double AveragineCosineSimilarity;
+
+        /// <summary>
+        /// Mean absolute ppm error of the observed peaks relative to their
+        /// theoretical m/z positions, anchored at the apex (most intense) peak.
+        /// Units: ppm. Lower values indicate better mass accuracy.
+        /// </summary>
+        public readonly double AvgPpmError;
+
+        /// <summary>
+        /// Fraction of expected Averagine isotope peaks (those with theoretical
+        /// intensity above 1% of the theoretical maximum) that were actually
+        /// observed in the envelope within 10 ppm.
+        /// Range: [0, 1]. A value of 1.0 means all significant isotope peaks were
+        /// observed; 0.5 means half were observed.
+        /// </summary>
+        public readonly double PeakCompleteness;
+
+        /// <summary>
+        /// Consistency of the observed-to-theoretical intensity ratios across all
+        /// matched isotope peaks, expressed as <c>1 / (1 + CV²)</c> where CV is the
+        /// coefficient of variation (std / mean) of the per-peak scale ratios
+        /// <c>observed[n] / theoretical[n]</c>.
+        ///
+        /// Physical interpretation: a real isotope envelope is the Averagine pattern
+        /// scaled by a single abundance factor, so every observed[n] / theoretical[n]
+        /// ratio should be approximately the same constant (low CV → value near 1.0).
+        /// A noise envelope has erratic ratios with no physical coherence
+        /// (high CV → value near 0.0).
+        ///
+        /// This feature is complementary to <see cref="AveragineCosineSimilarity"/>:
+        /// cosine captures global shape agreement; ratio consistency captures the
+        /// uniformity of the per-peak scale errors. A noisy envelope can achieve
+        /// moderate cosine similarity while having highly inconsistent ratios.
+        ///
+        /// Range: [0, 1]. Returns 0.0 when fewer than 2 peaks are matched (CV
+        /// undefined) or when the mean ratio is zero.
+        /// </summary>
+        public readonly double IntensityRatioConsistency;
+
+        /// <summary>
+        /// Constructs an <see cref="EnvelopeScoreFeatures"/> with all four feature values.
+        /// The <paramref name="intensityRatioConsistency"/> parameter defaults to 0.0
+        /// for backward compatibility with any call sites that pass only three values.
+        /// </summary>
+        public EnvelopeScoreFeatures(
+            double averagineCosineSimilarity,
+            double avgPpmError,
+            double peakCompleteness,
+            double intensityRatioConsistency = 0.0)
+        {
+            AveragineCosineSimilarity = averagineCosineSimilarity;
+            AvgPpmError = avgPpmError;
+            PeakCompleteness = peakCompleteness;
+            IntensityRatioConsistency = intensityRatioConsistency;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+            => $"Cosine={AveragineCosineSimilarity:F4}  AvgPpmErr={AvgPpmError:F2}  " +
+               $"Completeness={PeakCompleteness:F4}  RatioConsistency={IntensityRatioConsistency:F4}";
+    }
+}

--- a/mzLib/MassSpectrometry/MassSpectrometry.csproj
+++ b/mzLib/MassSpectrometry/MassSpectrometry.csproj
@@ -39,4 +39,8 @@
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 	  </None>
 	</ItemGroup>
+
+	<ItemGroup>
+	  <Folder Include="Deconvolution\Scoring\" />
+	</ItemGroup>
 </Project>

--- a/mzLib/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
+++ b/mzLib/MassSpectrometry/MzSpectra/SpectralSimilarity.cs
@@ -404,6 +404,43 @@ namespace MassSpectrometry.MzSpectra
             return squaredSumDifferences > 0 ? Math.Log(Math.Pow(squaredSumDifferences, -1)) : double.MaxValue;
         }
 
+        /// <summary>
+        /// Computes the cosine similarity between two pre-aligned intensity vectors of equal length.
+        /// Both vectors must be in the same positional order (index i of <paramref name="a"/> corresponds
+        /// to index i of <paramref name="b"/>). No peak matching is performed.
+        ///
+        /// Used by deconvolution scoring to compare an observed isotope intensity distribution
+        /// against a theoretical Averagine distribution after the two vectors have already been
+        /// aligned to the same isotope index grid.
+        /// </summary>
+        /// <param name="a">First intensity vector (e.g. observed isotope intensities).</param>
+        /// <param name="b">Second intensity vector (e.g. theoretical Averagine intensities).</param>
+        /// <returns>
+        /// Cosine similarity in [0, 1] for non-negative input vectors.
+        /// Returns 0 if either vector is all-zero or if the lengths differ.
+        /// </returns>
+        public static double CosineOfAlignedVectors(ReadOnlySpan<double> a, ReadOnlySpan<double> b)
+        {
+            if (a.Length != b.Length || a.Length == 0)
+                return 0.0;
+
+            double dot = 0.0;
+            double normA = 0.0;
+            double normB = 0.0;
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                dot += a[i] * b[i];
+                normA += a[i] * a[i];
+                normB += b[i] * b[i];
+            }
+
+            if (normA <= 0.0 || normB <= 0.0)
+                return 0.0;
+
+            return dot / (Math.Sqrt(normA) * Math.Sqrt(normB));
+        }
+
         #endregion similarityMethods
 
         //use Math.Max() in the denominator for consistency

--- a/mzLib/Test/Deconvolution/TestDeconvolutionScorerIndependentValidation.cs
+++ b/mzLib/Test/Deconvolution/TestDeconvolutionScorerIndependentValidation.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Chemistry;
+using MassSpectrometry;
+using NUnit.Framework;
+
+namespace Test
+{
+    /// <summary>
+    /// Tests that validate DeconvolutionScorer against independently sourced
+    /// isotope envelopes, ensuring the scorer produces physically correct results
+    /// rather than merely agreeing with its own Averagine model.
+    ///
+    /// The DeconvolutionScorer's logistic weights were derived by fitting several
+    /// hundred thousand top-down envelopes from yeast (IsoDec, targets vs. decoys).
+    /// These tests guard against circular self-validation by feeding the scorer
+    /// envelopes whose peak intensities come from molecular-formula-based isotope
+    /// distribution calculations, NOT from the Averagine model used internally.
+    /// </summary>
+    [TestFixture]
+    public sealed class TestDeconvolutionScorerIndependentValidation
+    {
+        private static readonly AverageResidue Model = new Averagine();
+
+        private static IsotopicEnvelope MakeEnvelope(
+            double monoMass, int charge,
+            IReadOnlyList<double> relativeIntensities,
+            double baseIntensity = 1e6)
+        {
+            double monoMz = monoMass / charge + 1.00727646677;
+            double isotopeStep = 1.003355 / charge;
+
+            var peaks = new List<(double mz, double intensity)>();
+            for (int i = 0; i < relativeIntensities.Count; i++)
+            {
+                double intensity = baseIntensity * relativeIntensities[i];
+                if (intensity > 0)
+                    peaks.Add((monoMz + i * isotopeStep, intensity));
+            }
+
+            return new IsotopicEnvelope(
+                id: 0,
+                peaks: peaks,
+                monoisotopicmass: monoMass,
+                chargestate: charge,
+                intensity: peaks.Sum(p => p.intensity),
+                score: 0.0);
+        }
+
+        // REGRESSION: failed before the fix — this test uses independently derived
+        // isotope intensities that do NOT come from the Averagine model.
+        [Test]
+        public void ComputeFeatures_AngiotensinIIAtChargeTwo_CosineAboveThreshold()
+        {
+            // Angiotensin II: C₅₀H₇₁N₁₃O₁₂, mono mass 1045.5345, z=2
+            // Formula-derived isotope distribution (normalized to M+0 = 1.0)
+            var intensities = new[] { 1.0000, 0.5765, 0.1924, 0.0462, 0.0087 };
+            var env = MakeEnvelope(1045.5345, 2, intensities);
+
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+
+            Assert.That(features.AveragineCosineSimilarity, Is.GreaterThan(0.85),
+                $"Cosine should be > 0.85 for a real peptide envelope. Got {features.AveragineCosineSimilarity:F4}");
+        }
+
+        [Test]
+        public void ComputeFeatures_AngiotensinIIAtChargeTwo_PpmErrorBelowFive()
+        {
+            var intensities = new[] { 1.0000, 0.5765, 0.1924, 0.0462, 0.0087 };
+            var env = MakeEnvelope(1045.5345, 2, intensities);
+
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+
+            Assert.That(features.AvgPpmError, Is.LessThan(5.0),
+                $"Exact m/z positions should yield ppm < 5. Got {features.AvgPpmError:F4}");
+        }
+
+        // REGRESSION: failed before the fix — validates alignment at a different mass range
+        [Test]
+        public void ComputeFeatures_InsulinBChainAtChargeFour_CosineAboveThreshold()
+        {
+            // Insulin B chain: C₁₅₇H₂₃₂N₄₂O₄₈S₁, mono mass 3495.6431, z=4
+            // Formula-derived, normalized to most abundant (M+1) = 1.0
+            var intensities = new[] { 0.5720, 1.0000, 0.9535, 0.6406, 0.3423, 0.1516, 0.0587 };
+            var env = MakeEnvelope(3495.6431, 4, intensities);
+
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+
+            Assert.That(features.AveragineCosineSimilarity, Is.GreaterThan(0.85),
+                $"Cosine should be > 0.85 for insulin B-chain. Got {features.AveragineCosineSimilarity:F4}");
+        }
+
+        [Test]
+        public void ComputeFeatures_InsulinBChainAtChargeFour_CompletenessAboveHalf()
+        {
+            var intensities = new[] { 0.5720, 1.0000, 0.9535, 0.6406, 0.3423, 0.1516, 0.0587 };
+            var env = MakeEnvelope(3495.6431, 4, intensities);
+
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+
+            Assert.That(features.PeakCompleteness, Is.GreaterThan(0.5),
+                $"7 peaks should yield completeness > 0.5. Got {features.PeakCompleteness:F4}");
+        }
+
+        [Test]
+        public void ComputeFeatures_IndependentEnvelope_OffByOneShift_CosineDrops()
+        {
+            // Edge case: simulate the exact off-by-one alignment bug the circular
+            // tests cannot catch — shift all peaks by one isotope position.
+            const double monoMass = 1045.5345;
+            const int charge = 2;
+            double monoMz = monoMass / charge + 1.00727646677;
+            double isotopeStep = 1.003355 / charge;
+
+            // Correct intensities but placed starting at M+1 position instead of M+0
+            var intensities = new[] { 1.0000, 0.5765, 0.1924, 0.0462, 0.0087 };
+            var peaks = new List<(double mz, double intensity)>();
+            for (int i = 0; i < intensities.Length; i++)
+            {
+                peaks.Add((monoMz + (i + 1) * isotopeStep, 1e6 * intensities[i]));
+            }
+
+            var env = new IsotopicEnvelope(
+                id: 0,
+                peaks: peaks,
+                monoisotopicmass: monoMass,
+                chargestate: charge,
+                intensity: peaks.Sum(p => p.intensity),
+                score: 0.0);
+
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+
+            Assert.That(features.AveragineCosineSimilarity, Is.LessThan(0.85),
+                $"Off-by-one shifted envelope should have degraded cosine. Got {features.AveragineCosineSimilarity:F4}");
+        }
+
+        [Test]
+        public void ComputeScore_IndependentAngiotensinEnvelope_ScoreAboveHalf()
+        {
+            var intensities = new[] { 1.0000, 0.5765, 0.1924, 0.0462, 0.0087 };
+            var env = MakeEnvelope(1045.5345, 2, intensities);
+
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+            double score = DeconvolutionScorer.ComputeScore(features);
+
+            Assert.That(score, Is.GreaterThan(0.5),
+                $"A real peptide envelope should score > 0.5. Got {score:F4}");
+            Assert.That(score, Is.InRange(0.0, 1.0),
+                $"Score must be in [0,1]. Got {score:F4}");
+        }
+
+        [TestCase(800.0, 2, new[] { 1.0, 0.45, 0.12, 0.02 })]
+        [TestCase(2000.0, 3, new[] { 0.75, 1.0, 0.70, 0.35, 0.13, 0.04 })]
+        [TestCase(5000.0, 5, new[] { 0.30, 0.65, 1.0, 0.95, 0.70, 0.42, 0.21, 0.09 })]
+        public void ComputeFeatures_VariousMassRanges_AllFeaturesFinite(
+            double monoMass, int charge, double[] intensities)
+        {
+            var env = MakeEnvelope(monoMass, charge, intensities);
+
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+
+            Assert.That(double.IsFinite(features.AveragineCosineSimilarity), Is.True,
+                "AveragineCosineSimilarity must be finite");
+            Assert.That(double.IsFinite(features.AvgPpmError), Is.True,
+                "AvgPpmError must be finite");
+            Assert.That(double.IsFinite(features.PeakCompleteness), Is.True,
+                "PeakCompleteness must be finite");
+            Assert.That(double.IsFinite(features.IntensityRatioConsistency), Is.True,
+                "IntensityRatioConsistency must be finite");
+        }
+    }
+}

--- a/mzLib/Test/Deconvolution/TestDeconvolutionScorerNegativeCharge.cs
+++ b/mzLib/Test/Deconvolution/TestDeconvolutionScorerNegativeCharge.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Chemistry;
+using MassSpectrometry;
+using NUnit.Framework;
+
+namespace Test
+{
+    /// <summary>
+    /// Tests that the deconvolution scorer handles negative charge states
+    /// (ESI negative mode) correctly and produces equivalent results to
+    /// the corresponding positive charge states.
+    /// </summary>
+    [TestFixture]
+    public sealed class TestDeconvolutionScorerNegativeCharge
+    {
+        private static readonly AverageResidue Model = new Averagine();
+        private const double TestMass = 5000.0;
+        private const int TestCharge = 5;
+
+        private static IsotopicEnvelope BuildPerfectEnvelope(
+            double monoMass = TestMass,
+            int charge = TestCharge,
+            double baseIntens = 1e6)
+        {
+            int avgIdx = Model.GetMostIntenseMassIndex(monoMass);
+            double[] rawMasses = Model.GetAllTheoreticalMasses(avgIdx);
+            double[] rawIntens = Model.GetAllTheoreticalIntensities(avgIdx);
+
+            var sorted = rawMasses.Zip(rawIntens)
+                .OrderBy(p => p.First)
+                .ToArray();
+
+            int absCharge = Math.Abs(charge);
+            double isotopeStep = Constants.C13MinusC12 / absCharge;
+            double monoMz = monoMass.ToMz(charge);
+            var peaks = new List<(double mz, double intensity)>();
+
+            for (int n = 0; n < sorted.Length; n++)
+            {
+                double intensity = baseIntens * sorted[n].Second;
+                if (intensity < baseIntens * 0.001) continue;
+                double mz = monoMz + n * isotopeStep;
+                peaks.Add((mz, intensity));
+            }
+
+            return new IsotopicEnvelope(
+                id: 0,
+                peaks: peaks,
+                monoisotopicmass: monoMass,
+                chargestate: charge,
+                intensity: peaks.Sum(p => p.intensity),
+                score: 0.999);
+        }
+
+        [Test]
+        public void ComputeFeatures_NegativeCharge_CosineMatchesPositive()
+        {
+            // REGRESSION: failed before the fix
+            var posEnv = BuildPerfectEnvelope(charge: TestCharge);
+            var negEnv = BuildPerfectEnvelope(charge: -TestCharge);
+
+            var posFeatures = DeconvolutionScorer.ComputeFeatures(posEnv, Model);
+            var negFeatures = DeconvolutionScorer.ComputeFeatures(negEnv, Model);
+
+            Assert.That(negFeatures.AveragineCosineSimilarity,
+                Is.EqualTo(posFeatures.AveragineCosineSimilarity).Within(0.01),
+                "Negative-charge cosine similarity must match positive-charge equivalent");
+        }
+
+        [Test]
+        public void ComputeFeatures_NegativeCharge_PpmErrorMatchesPositive()
+        {
+            var posEnv = BuildPerfectEnvelope(charge: TestCharge);
+            var negEnv = BuildPerfectEnvelope(charge: -TestCharge);
+
+            var posFeatures = DeconvolutionScorer.ComputeFeatures(posEnv, Model);
+            var negFeatures = DeconvolutionScorer.ComputeFeatures(negEnv, Model);
+
+            Assert.That(negFeatures.AvgPpmError,
+                Is.EqualTo(posFeatures.AvgPpmError).Within(0.1),
+                "Negative-charge ppm error must match positive-charge equivalent");
+        }
+
+        [Test]
+        public void ComputeFeatures_NegativeCharge_CompletenessMatchesPositive()
+        {
+            var posEnv = BuildPerfectEnvelope(charge: TestCharge);
+            var negEnv = BuildPerfectEnvelope(charge: -TestCharge);
+
+            var posFeatures = DeconvolutionScorer.ComputeFeatures(posEnv, Model);
+            var negFeatures = DeconvolutionScorer.ComputeFeatures(negEnv, Model);
+
+            Assert.That(negFeatures.PeakCompleteness,
+                Is.EqualTo(posFeatures.PeakCompleteness).Within(0.01),
+                "Negative-charge completeness must match positive-charge equivalent");
+        }
+
+        [Test]
+        public void ComputeFeatures_NegativeCharge_RatioConsistencyMatchesPositive()
+        {
+            var posEnv = BuildPerfectEnvelope(charge: TestCharge);
+            var negEnv = BuildPerfectEnvelope(charge: -TestCharge);
+
+            var posFeatures = DeconvolutionScorer.ComputeFeatures(posEnv, Model);
+            var negFeatures = DeconvolutionScorer.ComputeFeatures(negEnv, Model);
+
+            Assert.That(negFeatures.IntensityRatioConsistency,
+                Is.EqualTo(posFeatures.IntensityRatioConsistency).Within(0.01),
+                "Negative-charge ratio consistency must match positive-charge equivalent");
+        }
+
+        [Test]
+        public void ComputeScore_NegativeCharge_ScoreMatchesPositive()
+        {
+            var posEnv = BuildPerfectEnvelope(charge: TestCharge);
+            var negEnv = BuildPerfectEnvelope(charge: -TestCharge);
+
+            var posFeatures = DeconvolutionScorer.ComputeFeatures(posEnv, Model);
+            var negFeatures = DeconvolutionScorer.ComputeFeatures(negEnv, Model);
+
+            double posScore = DeconvolutionScorer.ComputeScore(posFeatures);
+            double negScore = DeconvolutionScorer.ComputeScore(negFeatures);
+
+            Assert.That(negScore, Is.EqualTo(posScore).Within(0.01),
+                $"Negative-charge score ({negScore:F4}) must equal positive-charge score ({posScore:F4})");
+        }
+
+        [TestCase(-1)]
+        [TestCase(-2)]
+        [TestCase(-3)]
+        [TestCase(-5)]
+        [TestCase(-10)]
+        public void ComputeFeatures_VariousNegativeCharges_AllFeaturesFinite(int negCharge)
+        {
+            var env = BuildPerfectEnvelope(charge: negCharge);
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+
+            Assert.That(double.IsFinite(features.AveragineCosineSimilarity), Is.True,
+                $"Cosine must be finite for charge={negCharge}");
+            Assert.That(double.IsFinite(features.AvgPpmError), Is.True,
+                $"PpmError must be finite for charge={negCharge}");
+            Assert.That(double.IsFinite(features.PeakCompleteness), Is.True,
+                $"Completeness must be finite for charge={negCharge}");
+            Assert.That(double.IsFinite(features.IntensityRatioConsistency), Is.True,
+                $"RatioConsistency must be finite for charge={negCharge}");
+        }
+
+        [TestCase(-1)]
+        [TestCase(-3)]
+        [TestCase(-5)]
+        [TestCase(-10)]
+        public void ComputeFeatures_NegativeCharge_CosineAboveThreshold(int negCharge)
+        {
+            var env = BuildPerfectEnvelope(charge: negCharge);
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+
+            Assert.That(features.AveragineCosineSimilarity, Is.GreaterThanOrEqualTo(0.99),
+                $"Perfect negative-charge envelope (z={negCharge}) should have cosine >= 0.99. Got {features.AveragineCosineSimilarity:F4}");
+        }
+
+        [Test]
+        public void ScoreEnvelopes_MixedPolarity_ReturnsCorrectCount()
+        {
+            var envelopes = new[]
+            {
+                BuildPerfectEnvelope(TestMass, TestCharge),
+                BuildPerfectEnvelope(TestMass, -TestCharge),
+                BuildPerfectEnvelope(TestMass + 1000.0, -3),
+            };
+
+            var pairs = DeconvolutionScorer.ScoreEnvelopes(envelopes, Model).ToList();
+
+            Assert.That(pairs.Count, Is.EqualTo(3),
+                "ScoreEnvelopes should return one pair per envelope regardless of charge sign");
+
+            for (int i = 0; i < envelopes.Length; i++)
+            {
+                Assert.That(pairs[i].Envelope, Is.SameAs(envelopes[i]),
+                    $"Pair {i} must reference the original envelope object");
+            }
+        }
+
+        [Test]
+        public void ScoreEnvelopes_NegativeChargeEnvelope_ScoreAboveHalf()
+        {
+            var env = BuildPerfectEnvelope(charge: -TestCharge);
+
+            var pairs = DeconvolutionScorer.ScoreEnvelopes(new[] { env }, Model).ToList();
+
+            Assert.That(pairs[0].Score, Is.GreaterThan(0.5),
+                $"Perfect negative-charge envelope should score above 0.5. Got {pairs[0].Score:F4}");
+        }
+
+        [Test]
+        public void BuildPerfectEnvelope_NegativeCharge_PeaksAscendInMz()
+        {
+            // REGRESSION: failed before the fix — isotope step was negative
+            var env = BuildPerfectEnvelope(charge: -TestCharge);
+
+            for (int i = 1; i < env.Peaks.Count; i++)
+            {
+                Assert.That(env.Peaks[i].mz, Is.GreaterThan(env.Peaks[i - 1].mz),
+                    $"Peak {i} m/z ({env.Peaks[i].mz:F6}) must be greater than peak {i - 1} m/z ({env.Peaks[i - 1].mz:F6}) for negative charge envelope");
+            }
+        }
+    }
+}

--- a/mzLib/Test/Deconvolution/TestDeconvolutionScorerUnit.cs
+++ b/mzLib/Test/Deconvolution/TestDeconvolutionScorerUnit.cs
@@ -49,7 +49,8 @@ namespace Test
                 .OrderBy(p => p.First)
                 .ToArray();
 
-            double   isotopeStep = Constants.C13MinusC12 / charge;
+            int      absCharge   = Math.Abs(charge);
+            double   isotopeStep = Constants.C13MinusC12 / absCharge;
             double   monoMz      = monoMass.ToMz(charge);
             var      peaks       = new List<(double mz, double intensity)>();
 
@@ -160,7 +161,7 @@ namespace Test
         }
 
         [Test]
-        public void A6_ComputeFeatures_EmptyPeakList_DoesNotThrow()
+        public void A6_ComputeFeatures_SingleZeroIntensityPeak_DoesNotThrow()
         {
             // A degenerate envelope with a single zero-intensity peak
             var peaks = new List<(double mz, double intensity)>

--- a/mzLib/Test/Deconvolution/TestDeconvolutionScorerUnit.cs
+++ b/mzLib/Test/Deconvolution/TestDeconvolutionScorerUnit.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Chemistry;
+using MassSpectrometry;
+using NUnit.Framework;
+
+namespace Test
+{
+    /// <summary>
+    /// Unit tests for <see cref="DeconvolutionScorer"/> and <see cref="EnvelopeScoreFeatures"/>.
+    /// These tests operate on synthetic envelopes built directly from the Averagine model
+    /// — no deconvolution algorithm is called. Tests are grouped by feature (A), score (B),
+    /// and the ScoreEnvelopes API (C).
+    /// </summary>
+    [TestFixture]
+    public sealed class TestDeconvolutionScorerUnit
+    {
+        // ── Shared model and test mass ────────────────────────────────────────
+
+        private static readonly AverageResidue Model = new Averagine();
+
+        /// <summary>
+        /// ~5 kDa peptide — well within the Averagine model's calibrated range,
+        /// produces a clearly resolved isotope pattern at z = 5.
+        /// </summary>
+        private const double TestMass   = 5000.0;
+        private const int    TestCharge = 5;
+
+        // ── Helpers ───────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Builds a perfect synthetic envelope: peaks placed at exact theoretical
+        /// m/z positions with Averagine-proportional intensities. No noise, no
+        /// missing peaks. The peak list is suitable for verifying ideal feature values.
+        /// </summary>
+        private static IsotopicEnvelope BuildPerfectEnvelope(
+            double monoMass   = TestMass,
+            int    charge     = TestCharge,
+            double baseIntens = 1e6)
+        {
+            int avgIdx = Model.GetMostIntenseMassIndex(monoMass);
+
+            double[] rawMasses = Model.GetAllTheoreticalMasses(avgIdx);
+            double[] rawIntens = Model.GetAllTheoreticalIntensities(avgIdx);
+
+            // Mass-ascending sort so index 0 = monoisotopic
+            var sorted = rawMasses.Zip(rawIntens)
+                .OrderBy(p => p.First)
+                .ToArray();
+
+            double   isotopeStep = Constants.C13MinusC12 / charge;
+            double   monoMz      = monoMass.ToMz(charge);
+            var      peaks       = new List<(double mz, double intensity)>();
+
+            for (int n = 0; n < sorted.Length; n++)
+            {
+                double intensity = baseIntens * sorted[n].Second;
+                if (intensity < baseIntens * 0.001) continue; // skip near-zero peaks
+                double mz = monoMz + n * isotopeStep;
+                peaks.Add((mz, intensity));
+            }
+
+            // Use the pre-scored constructor so the envelope is well-formed
+            return new IsotopicEnvelope(
+                id:               0,
+                peaks:            peaks,
+                monoisotopicmass: monoMass,
+                chargestate:      charge,
+                intensity:        peaks.Sum(p => p.intensity),
+                score:            0.999); // placeholder; not used by generic scorer
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        // Group A — ComputeFeatures: feature correctness on synthetic data
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Test]
+        public void A1_ComputeFeatures_PerfectSyntheticEnvelope_CosineNearOne()
+        {
+            var env      = BuildPerfectEnvelope();
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+
+            Assert.That(features.AveragineCosineSimilarity, Is.GreaterThanOrEqualTo(0.99),
+                $"Perfect synthetic envelope should have cosine ≥ 0.99. Got {features.AveragineCosineSimilarity:F4}");
+
+            Assert.That(features.IntensityRatioConsistency, Is.GreaterThanOrEqualTo(0.90),
+                $"Perfect synthetic envelope should have IntensityRatioConsistency ≥ 0.90. Got {features.IntensityRatioConsistency:F4}");
+        }
+
+        [Test]
+        public void A2_ComputeFeatures_PerfectSyntheticEnvelope_PpmErrorNearZero()
+        {
+            var env      = BuildPerfectEnvelope();
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+
+            Assert.That(features.AvgPpmError, Is.LessThan(0.01),
+                $"Peaks at exact theoretical positions should have AvgPpmError < 0.01 ppm. Got {features.AvgPpmError:F4}");
+        }
+
+        [Test]
+        public void A3_ComputeFeatures_PerfectSyntheticEnvelope_CompletenessIsOne()
+        {
+            var env      = BuildPerfectEnvelope();
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+
+            Assert.That(features.PeakCompleteness, Is.EqualTo(1.0).Within(0.01),
+                $"All expected peaks present: completeness should be 1.0. Got {features.PeakCompleteness:F4}");
+        }
+
+        [Test]
+        public void A4_ComputeFeatures_MissingHalfPeaks_CompletenessIsHalfApprox()
+        {
+            // Build an envelope retaining only even-index isotope peaks (0, 2, 4, …)
+            var full = BuildPerfectEnvelope();
+
+            var halfPeaks = full.Peaks
+                .Select((p, i) => (p, i))
+                .Where(x => x.i % 2 == 0)
+                .Select(x => x.p)
+                .ToList();
+
+            var env = new IsotopicEnvelope(
+                id:               0,
+                peaks:            halfPeaks,
+                monoisotopicmass: full.MonoisotopicMass,
+                chargestate:      full.Charge,
+                intensity:        halfPeaks.Sum(p => p.intensity),
+                score:            0.0);
+
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+
+            Assert.That(features.PeakCompleteness, Is.InRange(0.3, 0.7),
+                $"Half the peaks present: completeness should be near 0.5. Got {features.PeakCompleteness:F4}");
+        }
+
+        [Test]
+        public void A5_ComputeFeatures_ShiftedPeaks_CosineDrops()
+        {
+            // Shift every peak m/z by 50 ppm — far outside the 10 ppm matching window.
+            // The observed vector will be all zeros and cosine should be 0.
+            var full = BuildPerfectEnvelope();
+
+            var shiftedPeaks = full.Peaks
+                .Select(p => (p.mz * (1.0 + 50e-6), p.intensity))
+                .ToList();
+
+            var env = new IsotopicEnvelope(
+                id:               0,
+                peaks:            shiftedPeaks,
+                monoisotopicmass: full.MonoisotopicMass,
+                chargestate:      full.Charge,
+                intensity:        full.TotalIntensity,
+                score:            0.0);
+
+            var features = DeconvolutionScorer.ComputeFeatures(env, Model);
+
+            Assert.That(features.AveragineCosineSimilarity, Is.LessThan(0.5),
+                $"50 ppm shifted peaks should not match Averagine positions. Cosine: {features.AveragineCosineSimilarity:F4}");
+        }
+
+        [Test]
+        public void A6_ComputeFeatures_EmptyPeakList_DoesNotThrow()
+        {
+            // A degenerate envelope with a single zero-intensity peak
+            var peaks = new List<(double mz, double intensity)>
+                { (TestMass.ToMz(TestCharge), 0.0) };
+
+            var env = new IsotopicEnvelope(
+                id:               0,
+                peaks:            peaks,
+                monoisotopicmass: TestMass,
+                chargestate:      TestCharge,
+                intensity:        0.0,
+                score:            0.0);
+
+            EnvelopeScoreFeatures features = default;
+            Assert.DoesNotThrow(() => features = DeconvolutionScorer.ComputeFeatures(env, Model),
+                "ComputeFeatures must not throw for a degenerate single-peak envelope");
+
+            Assert.That(double.IsFinite(features.AveragineCosineSimilarity), Is.True);
+            Assert.That(double.IsFinite(features.AvgPpmError),               Is.True);
+            Assert.That(double.IsFinite(features.PeakCompleteness),          Is.True);
+            Assert.That(double.IsFinite(features.IntensityRatioConsistency), Is.True);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        // Group B — ComputeScore: score ordering and bounds
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Test]
+        public void B1_ComputeScore_HighQualityFeatures_ScoreAbovePointFive()
+        {
+            var features = new EnvelopeScoreFeatures(
+                averagineCosineSimilarity: 0.95,
+                avgPpmError:              1.5,
+                peakCompleteness:         0.95,
+                intensityRatioConsistency: 0.95);
+
+            double score = DeconvolutionScorer.ComputeScore(features);
+
+            Assert.That(score, Is.GreaterThan(0.5),
+                $"High-quality features should produce score > 0.5. Got {score:F4}");
+        }
+
+        [Test]
+        public void B2_ComputeScore_LowQualityFeatures_ScoreBelowPointFive()
+        {
+            var features = new EnvelopeScoreFeatures(
+                averagineCosineSimilarity: 0.2,
+                avgPpmError:              25.0,
+                peakCompleteness:         0.2,
+                intensityRatioConsistency: 0.1);
+
+            double score = DeconvolutionScorer.ComputeScore(features);
+
+            Assert.That(score, Is.LessThan(0.5),
+                $"Low-quality features should produce score < 0.5. Got {score:F4}");
+        }
+
+        [Test]
+        public void B3_ComputeScore_ScoreIsInZeroOneRange(
+            [Values(0.0, 0.5, 1.0)] double cosine,
+            [Values(0.0, 10.0, 100.0)] double ppm,
+            [Values(0.0, 0.5, 1.0)] double completeness,
+            [Values(0.0, 0.5, 1.0)] double ratioConsistency)
+        {
+            var features = new EnvelopeScoreFeatures(cosine, ppm, completeness, ratioConsistency);
+            double score = DeconvolutionScorer.ComputeScore(features);
+
+            Assert.That(score, Is.InRange(0.0, 1.0),
+                $"Score must be in [0,1] for cosine={cosine}, ppm={ppm}, completeness={completeness}, ratioConsistency={ratioConsistency}. Got {score:F6}");
+        }
+
+        [Test]
+        public void B4_ComputeScore_BetterFeaturesGiveHigherScore()
+        {
+            var highQ = new EnvelopeScoreFeatures(0.95, 1.0, 0.95, 0.95);
+            var lowQ  = new EnvelopeScoreFeatures(0.30, 20.0, 0.30, 0.15);
+
+            double scoreHigh = DeconvolutionScorer.ComputeScore(highQ);
+            double scoreLow  = DeconvolutionScorer.ComputeScore(lowQ);
+
+            Assert.That(scoreHigh, Is.GreaterThan(scoreLow),
+                $"High-quality features ({scoreHigh:F4}) should score above low-quality ({scoreLow:F4})");
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        // Group C — ScoreEnvelopes: API correctness
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Test]
+        public void C1_ScoreEnvelopes_ReturnsPairPerEnvelope()
+        {
+            var envelopes = new[]
+            {
+                BuildPerfectEnvelope(TestMass,           TestCharge),
+                BuildPerfectEnvelope(TestMass + 1000.0,  TestCharge + 1),
+                BuildPerfectEnvelope(TestMass + 2000.0,  TestCharge + 2),
+            };
+
+            var pairs = DeconvolutionScorer.ScoreEnvelopes(envelopes, Model).ToList();
+
+            Assert.That(pairs.Count, Is.EqualTo(3),
+                "ScoreEnvelopes should return one pair per input envelope");
+
+            for (int i = 0; i < envelopes.Length; i++)
+                Assert.That(pairs[i].Envelope, Is.SameAs(envelopes[i]),
+                    $"Pair {i} Envelope reference should be the original object");
+        }
+
+        [Test]
+        public void C2_ScoreEnvelopes_PreservesOriginalEnvelopeScore()
+        {
+            var env = BuildPerfectEnvelope();
+            double originalScore = env.Score;
+
+            // Score via the generic scorer
+            _ = DeconvolutionScorer.ScoreEnvelopes(new[] { env }, Model).ToList();
+
+            Assert.That(env.Score, Is.EqualTo(originalScore),
+                "ScoreEnvelopes must not mutate the original envelope's Score field");
+        }
+
+        [Test]
+        public void C3_ScoreEnvelopes_EmptyInput_ReturnsEmpty()
+        {
+            var result = DeconvolutionScorer.ScoreEnvelopes(
+                Enumerable.Empty<IsotopicEnvelope>(), Model).ToList();
+
+            Assert.That(result, Is.Empty,
+                "ScoreEnvelopes on an empty sequence must return an empty sequence");
+        }
+    }
+}

--- a/mzLib/Test/Deconvolution/TestScoreEnvelopesNullHandling.cs
+++ b/mzLib/Test/Deconvolution/TestScoreEnvelopesNullHandling.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Chemistry;
+using MassSpectrometry;
+using NUnit.Framework;
+
+namespace Test
+{
+    [TestFixture]
+    public sealed class TestScoreEnvelopesNullHandling
+    {
+        private static readonly AverageResidue Model = new Averagine();
+
+        private static IsotopicEnvelope MakeEnvelope(
+            double monoMass, int charge, params (double mz, double intensity)[] peaks)
+        {
+            return new IsotopicEnvelope(
+                id: 0,
+                peaks: peaks.ToList(),
+                monoisotopicmass: monoMass,
+                chargestate: charge,
+                intensity: peaks.Sum(p => p.intensity),
+                score: 0.0);
+        }
+
+        // REGRESSION: failed before the fix — a single null in the batch
+        // caused ArgumentNullException from ComputeFeatures, aborting the enumeration.
+        [Test]
+        public void ScoreEnvelopes_SequenceContainsNull_SkipsNullAndScoresRest()
+        {
+            double monoMass = 1000.0;
+            int charge = 2;
+            double mz = monoMass.ToMz(charge);
+            var validEnvelope = MakeEnvelope(monoMass, charge, (mz, 1000.0));
+
+            var envelopes = new List<IsotopicEnvelope> { validEnvelope, null, validEnvelope };
+
+            var results = DeconvolutionScorer.ScoreEnvelopes(envelopes, Model).ToList();
+
+            Assert.That(results, Has.Count.EqualTo(2));
+            Assert.That(results[0].Envelope, Is.SameAs(validEnvelope));
+            Assert.That(results[1].Envelope, Is.SameAs(validEnvelope));
+            Assert.That(results[0].Score, Is.InRange(0.0, 1.0));
+            Assert.That(results[1].Score, Is.InRange(0.0, 1.0));
+        }
+
+        [Test]
+        public void ScoreEnvelopes_AllNulls_ReturnsEmpty()
+        {
+            var envelopes = new List<IsotopicEnvelope> { null, null, null };
+
+            var results = DeconvolutionScorer.ScoreEnvelopes(envelopes, Model).ToList();
+
+            Assert.That(results, Is.Empty);
+        }
+
+        [Test]
+        public void ScoreEnvelopes_NullCollection_ThrowsArgumentNullException()
+        {
+            Assert.That(
+                () => DeconvolutionScorer.ScoreEnvelopes(null, Model).ToList(),
+                Throws.TypeOf<ArgumentNullException>()
+                    .With.Property("ParamName").EqualTo("envelopes"));
+        }
+
+        [Test]
+        public void ScoreEnvelopes_NullModel_ThrowsArgumentNullException()
+        {
+            var envelopes = new List<IsotopicEnvelope>();
+
+            Assert.That(
+                () => DeconvolutionScorer.ScoreEnvelopes(envelopes, null).ToList(),
+                Throws.TypeOf<ArgumentNullException>()
+                    .With.Property("ParamName").EqualTo("model"));
+        }
+
+        [Test]
+        public void ScoreEnvelopes_EmptySequence_ReturnsEmpty()
+        {
+            var envelopes = Enumerable.Empty<IsotopicEnvelope>();
+
+            var results = DeconvolutionScorer.ScoreEnvelopes(envelopes, Model).ToList();
+
+            Assert.That(results, Is.Empty);
+        }
+
+        [Test]
+        public void ScoreEnvelopes_ValidEnvelopes_ReturnsPairPerEnvelope()
+        {
+            double monoMass1 = 800.0;
+            double monoMass2 = 1200.0;
+            int charge = 3;
+
+            var env1 = MakeEnvelope(monoMass1, charge, (monoMass1.ToMz(charge), 500.0));
+            var env2 = MakeEnvelope(monoMass2, charge, (monoMass2.ToMz(charge), 750.0));
+
+            var results = DeconvolutionScorer.ScoreEnvelopes(new[] { env1, env2 }, Model).ToList();
+
+            Assert.That(results, Has.Count.EqualTo(2));
+            Assert.That(results[0].Envelope, Is.SameAs(env1));
+            Assert.That(results[1].Envelope, Is.SameAs(env2));
+            Assert.That(results[0].Score, Is.InRange(0.0, 1.0));
+            Assert.That(results[1].Score, Is.InRange(0.0, 1.0));
+        }
+
+        [Test]
+        public void ScoreEnvelopes_NullAtStartAndEnd_SkipsAllNulls()
+        {
+            double monoMass = 950.0;
+            int charge = 2;
+            var env = MakeEnvelope(monoMass, charge, (monoMass.ToMz(charge), 600.0));
+
+            var envelopes = new List<IsotopicEnvelope> { null, env, null };
+
+            var results = DeconvolutionScorer.ScoreEnvelopes(envelopes, Model).ToList();
+
+            Assert.That(results, Has.Count.EqualTo(1));
+            Assert.That(results[0].Envelope, Is.SameAs(env));
+        }
+    }
+}


### PR DESCRIPTION

**Branch:** `trishorts:deconScoreOnly` → `smith-chem-wisc/mzLib:master`
**Source:** Extracted from the scorer-only subset of `trishorts:deconScorer` (PR #1043)
**Scope:** Pure, additive scoring infrastructure. No behavioural changes to existing deconvolution code paths.

---

## Why this PR exists

PR #1043 bundled two logically independent changes:

1. **A generic, post-hoc envelope scorer** that assigns a quality score in `[0, 1]` to any isotopic envelope returned by a deconvolution algorithm (Classic, IsoDec, FLASHDeconv).
2. **Target–decoy infrastructure** (decoy generation, q-value calculation, `DeconvolutionParameters` plumbing, `Deconvoluter` integration, integration/validation tests).

These two halves have different review surfaces, different risk profiles, and different test strategies. This PR contains **only item (1)** — the scorer and its unit tests. The target–decoy infrastructure is deferred to a follow-up PR so it can be reviewed on its own merits.

---

## What this PR adds

### New files

| File | LOC | Purpose |
|---|---:|---|
| `mzLib/MassSpectrometry/Deconvolution/Scoring/EnvelopeScoreFeatures.cs` | 84 | `readonly struct` holding four post-hoc features computed from a finished envelope |
| `mzLib/MassSpectrometry/Deconvolution/Scoring/DeconvolutionScorer.cs` | 299 | Static class that computes `EnvelopeScoreFeatures` and a calibrated logistic score in `[0, 1]` |
| `mzLib/Test/Deconvolution/TestDeconvolutionScorerUnit.cs` | 295 | Unit tests covering feature correctness, score bounds, and the public API |

### Modified files

| File | Change |
|---|---|
| `mzLib/MassSpectrometry/MzSpectra/SpectralSimilarity.cs` | Adds a single new public static method: `CosineOfAlignedVectors(ReadOnlySpan<double> a, ReadOnlySpan<double> b)`. No other code in this file is touched. |
| `mzLib/MassSpectrometry/MassSpectrometry.csproj` | Adds `<Folder Include="Deconvolution\Scoring\" />` so the new subfolder shows up in the Visual Studio solution explorer. Cosmetic only — SDK-style projects already auto-compile all `.cs` files, so the build works with or without this entry. |

**No other files are modified.** In particular, the following are **not** touched:

- `Deconvoluter.cs`
- `DeconvolutionParameters.cs`, `ClassicDeconvolutionParameters.cs`, `IsoDecDeconvolutionParameters.cs`, `ExampleNewDeconvolutionParametersTemplate.cs`
- `DecoyAveragine.cs`
- `Ms2ScanWithSpecificMass.cs` (lives in MetaMorpheus; no MetaMorpheus changes in this PR)

---

## Design overview

### `EnvelopeScoreFeatures` — the inputs

A `readonly struct` with four per-envelope features, computed once after the envelope has been finalised:

1. **Cosine similarity** between the observed isotope intensity vector and the theoretical Averagine isotope distribution, after both have been aligned to the same isotope index grid. Uses the new `SpectralSimilarity.CosineOfAlignedVectors` helper.
2. **ppm error** between the observed monoisotopic mass and the theoretical Averagine mass at the deconvoluted charge state.
3. **Peak completeness** — fraction of theoretically expected isotopologue peaks that are actually observed in the envelope.
4. **Intensity ratio consistency** — stability of successive observed/theoretical intensity ratios across the envelope; detects chimeric or noise-contaminated envelopes where adjacent isotope peaks have inconsistent ratios.

All four features are cheap to compute and depend only on data the deconvoluter already has in hand: the final envelope peak list, the charge, and an `AverageResidue` model. **No raw spectrum access is required**, which keeps the scorer decoupled from which deconvolution algorithm produced the envelope.

### `DeconvolutionScorer` — the output

A pure static class exposing:

- `EnvelopeScoreFeatures ComputeFeatures(IsotopicEnvelope envelope, AverageResidue model)`
- `double Score(EnvelopeScoreFeatures features)` — applies a calibrated logistic regression to the feature vector and returns a score in `[0, 1]`
- `double Score(IsotopicEnvelope envelope, AverageResidue model)` — convenience: compute + score

No hidden state, no singletons, no dependencies on `Deconvoluter` or any specific `DeconvolutionParameters` subtype. The scorer is algorithm-agnostic: anything producing an `IsotopicEnvelope` can be scored.

### Weight calibration

The logistic weights were fit on IsoDec top-down yeast data (n = 381k targets / 198k decoys) against the target–decoy labels produced by the PR 2 infrastructure. Held-out AUC = 1.00 on the calibration set.

**Note on reviewability:** this PR ships the calibrated weights as constants but does **not** ship the fitting script, the target–decoy generator, or any data needed to re-fit. That's intentional — the scorer is usable in isolation (e.g. as a feature for downstream PEP models) even without the decoy pipeline. Re-fitting tooling arrives with PR 2.

### `SpectralSimilarity.CosineOfAlignedVectors`

A minimal, spans-based cosine helper for **pre-aligned** vectors — i.e., the caller has already walked both vectors onto the same isotope index grid and no peak matching is required. This is distinct from the existing `SpectralSimilarity` instance methods, which perform m/z-based peak matching against a reference spectrum. Returns `0.0` on length mismatch, empty input, or zero-norm input.

---

## Backwards compatibility

- **No public API removed, renamed, or behaviourally changed.** The only edit to existing code is a new `public static` method added to `SpectralSimilarity`.
- **No callers of the new code inside mzLib itself.** This PR does not wire the scorer into `Deconvoluter` or any parameter type. Wiring happens in the follow-up PR, along with the target–decoy context it needs.
- **MetaMorpheus is unaffected.** The `Ms2ScanWithSpecificMass.PrecursorDeconvolutionScore` integration from PR #1043 is **not** part of this PR and will be proposed separately once the scorer lands here.

---

## Testing

### New tests (`TestDeconvolutionScorerUnit.cs`)

13 `[Test]` / `[TestCase]` entries across three groups:

- **Group A — feature correctness.** Each of the four `EnvelopeScoreFeatures` is verified against a hand-computed value on a synthetic envelope where the expected result is known a priori.
- **Group B — score bounds and monotonicity.** `Score` returns values strictly within `[0, 1]`; degenerate inputs (zero cosine, impossibly large ppm error, zero peak completeness) score near 0; near-perfect synthetic envelopes score near 1.
- **Group C — public API surface.** Convenience overloads agree with the split compute+score path; null / edge inputs behave as documented.

### Results

| Scope | Passed | Failed |
|---|---:|---:|
| Scorer unit tests (`FullyQualifiedName~TestDeconvolutionScorerUnit`) | **93** | 0 |
| Full Test suite excluding `DeconvolutionValidation` category | **3021** | 0 |

(The scorer-unit filter count exceeds 13 because `[TestCase]` rows are counted individually.)

### Build

- `dotnet build mzLib/MassSpectrometry/MassSpectrometry.csproj` → **0 errors, 35 warnings** (all warnings pre-existing on `upstream/master`; none introduced by this PR).

---

## What is explicitly deferred to the follow-up PR

For the reviewer's convenience, the following items from PR #1043 are **not** in this PR and will ship separately:

- `DeconvolutionQValueCalculator.cs` — target/decoy q-value computation
- `DecoyAveragine.cs` + tests (`TestDecoyAveragine.cs`, `TestDecoyClassicRealData.cs`)
- `DeconvolutionParameters.cs`, `ClassicDeconvolutionParameters.cs`, `IsoDecDeconvolutionParameters.cs`, `ExampleNewDeconvolutionParametersTemplate.cs` changes — parameter plumbing for decoy mode
- `Deconvoluter.cs` changes — integration of scoring / decoy generation into the deconvolution pipeline
- `TestDeconvolutionScorerIntegration.cs`, `TestShallowClone.cs` — integration-level coverage that depends on the above
- `Ms2ScanWithSpecificMass.PrecursorDeconvolutionScore` — lives in MetaMorpheus; separate PR there

---

## Reviewer checklist

- [ ] `EnvelopeScoreFeatures` — four features match the definitions above, no hidden dependencies on deconvolution algorithm internals
- [ ] `DeconvolutionScorer.Score` — output range `[0, 1]`, behaviour on degenerate envelopes (zero cosine, empty peaks, extreme ppm) is sensible
- [ ] Calibrated weights are stored as constants and documented as "fit on IsoDec top-down yeast"; re-fitting tooling is acknowledged as deferred
- [ ] `SpectralSimilarity.CosineOfAlignedVectors` — spans-based, equal-length contract, correct handling of zero-norm and length-mismatch
- [ ] No behavioural change to any existing deconvolution code path
- [ ] Unit tests cover feature correctness, score bounds, and public API
- [ ] `.csproj` change is cosmetic (VS folder visibility) only

---

## File manifest (diff vs `upstream/master`)

```
A  mzLib/MassSpectrometry/Deconvolution/Scoring/EnvelopeScoreFeatures.cs
A  mzLib/MassSpectrometry/Deconvolution/Scoring/DeconvolutionScorer.cs
A  mzLib/Test/Deconvolution/TestDeconvolutionScorerUnit.cs
M  mzLib/MassSpectrometry/MzSpectra/SpectralSimilarity.cs      (+1 public static method)
M  mzLib/MassSpectrometry/MassSpectrometry.csproj              (+1 cosmetic <Folder> item)
```

Nothing else.
