### PR TITLE
Small safeguard fixes models

### DIFF
--- a/mzLib/PredictionClients/Koina/AbstractClasses/FragmentIntensityModel.cs
+++ b/mzLib/PredictionClients/Koina/AbstractClasses/FragmentIntensityModel.cs
@@ -17,6 +17,8 @@ namespace PredictionClients.Koina.AbstractClasses
     /// m/z values, and predicted intensities from a fragment intensity model.
     /// </summary>
     /// <param name="FullSequence">Original peptide sequence provided by the user (mzLib format)</param>
+    /// <param name="ValidatedFullSequence">Validated and cleaned peptide sequence that was actually used for prediction (Unimod format). This may also differ from the original FullSequence if modifications were removed or if the sequence was deemed invalid for the model. This is the sequence that reflects the actual input to the model.</param>
+    /// <param name="PrecursorCharge">Charge state of the precursor ion used for prediction</param>
     /// <param name="FragmentAnnotations">Fragment ion annotations (e.g., "b5+1", "y3+2")</param>
     /// <param name="FragmentMZs">Theoretical m/z values for each fragment ion</param>
     /// <param name="FragmentIntensities">Predicted relative intensities (0-1 scale, -1 indicates impossible ions)</param>
@@ -98,6 +100,12 @@ namespace PredictionClients.Koina.AbstractClasses
 
         public abstract IncompatibleParameterHandlingMode ParameterHandlingMode { get; init; }
         public abstract FragmentIonMappingMode FragmentIonMappingMode { get; init; }
+        /// <summary>
+        /// Reusable static instance — no M ions, no M-ion losses. This is a safeguard when creating PeptideWithSetModifications objects,
+        /// such as in ResponseToPredictions() with MapToInputFullSequence mapping mode selected, since Koina does not return M-ions and 
+        /// any potential issues with generated M-ions would be inherited here.
+        /// </summary>
+        private static readonly FragmentationParams _noMIonParams = new() { GenerateMIon = false };
         #endregion
 
         #region Inputs and Outputs for internal processing 
@@ -312,7 +320,7 @@ namespace PredictionClients.Koina.AbstractClasses
                             fragmentMZs,
                             predictedIntensities
                         ) with
-                        { Warning = batchPeptides[i].SequenceWarning });
+                        { Warning = peptide.SequenceWarning });
                     }
                 }
                 else // FragmentIonMappingMode == FragmentIonMappingMode.MapToInputFullSequence
@@ -322,8 +330,8 @@ namespace PredictionClients.Koina.AbstractClasses
                         var peptide = batchPeptides[i];
                         var pwsm = new PeptideWithSetModifications(peptide.FullSequence);
                         List<Product> theoreticalProducts = new();
-                        pwsm.Fragment(MassSpectrometry.DissociationType.HCD, FragmentationTerminus.Both, theoreticalProducts);
-                        Dictionary<string, Product> tpLookup = theoreticalProducts.ToDictionary(tp => tp.Annotation);
+                        pwsm.Fragment(MassSpectrometry.DissociationType.HCD, FragmentationTerminus.Both, theoreticalProducts, fragmentationParams: _noMIonParams);
+                        Dictionary<string, Product> tpLookup = theoreticalProducts.DistinctBy(tp => tp.Annotation).ToDictionary(tp => tp.Annotation);
 
                         var fragmentIons = new List<string>();
                         var fragmentMZs = new List<double>();
@@ -351,7 +359,7 @@ namespace PredictionClients.Koina.AbstractClasses
                             fragmentMZs,
                             predictedIntensities
                         ) with
-                        { Warning = batchPeptides[i].SequenceWarning });
+                        { Warning = peptide.SequenceWarning });
                     }
                 }
             }
@@ -496,9 +504,9 @@ namespace PredictionClients.Koina.AbstractClasses
                 List<MatchedFragmentIon> fragmentIons = new();
 
                 List<Product> theoreticalProducts = new();
-                peptide.Fragment(MassSpectrometry.DissociationType.HCD, FragmentationTerminus.Both, theoreticalProducts); // Generate theoretical fragments to get the m/z values for the input sequence
+                peptide.Fragment(MassSpectrometry.DissociationType.HCD, FragmentationTerminus.Both, theoreticalProducts, fragmentationParams: _noMIonParams); // Generate theoretical fragments to get the m/z values for the input sequence
                 Dictionary<string, double> predictionAnnotationIntensityLookup = new();
-                Dictionary<string, Product> tpLookup = theoreticalProducts.ToDictionary(tp => tp.Annotation);
+                Dictionary<string, Product> tpLookup = theoreticalProducts.DistinctBy(tp => tp.Annotation).ToDictionary(tp => tp.Annotation);
 
                 for (int i = 0; i < prediction.FragmentAnnotations.Count; i++)
                 {

--- a/mzLib/PredictionClients/Koina/SupportedModels/FlyabilityModels/PFly2024FineTuned.cs
+++ b/mzLib/PredictionClients/Koina/SupportedModels/FlyabilityModels/PFly2024FineTuned.cs
@@ -74,11 +74,14 @@ namespace PredictionClients.Koina.SupportedModels.FlyabilityModels
         /// <summary>Minimum allowed peptide sequence length in amino acids</summary>
         public override int MinPeptideLength => 1;
         /// <summary>Uses primary sequence for modified peptides since this model does not support modifications</summary>
-        public override SequenceConversionHandlingMode ModHandlingMode { get; init; } = SequenceConversionHandlingMode.UsePrimarySequence;
+        public override SequenceConversionHandlingMode ModHandlingMode { get; init; }
 
-        public PFly2024FineTuned(int maxNumberOfBatchesPerRequest = 500, int throttlingDelayInMilliseconds = 100)
+        public PFly2024FineTuned(SequenceConversionHandlingMode modHandlingMode = SequenceConversionHandlingMode.ReturnNull, 
+            int maxNumberOfBatchesPerRequest = 500, 
+            int throttlingDelayInMilliseconds = 100)
             : base(Converter)
         {
+            ModHandlingMode = modHandlingMode;
             MaxNumberOfBatchesPerRequest = maxNumberOfBatchesPerRequest;
             ThrottlingDelayInMilliseconds = throttlingDelayInMilliseconds;
         }

--- a/mzLib/PredictionClients/Koina/SupportedModels/FragmentIntensityModels/Prosit2020IntensityHCD.cs
+++ b/mzLib/PredictionClients/Koina/SupportedModels/FragmentIntensityModels/Prosit2020IntensityHCD.cs
@@ -67,7 +67,7 @@ namespace PredictionClients.Koina.SupportedModels.FragmentIntensityModels
         public override FragmentIonMappingMode FragmentIonMappingMode { get; init; }
 
         public Prosit2020IntensityHCD(
-            SequenceConversionHandlingMode modHandlingMode = SequenceConversionHandlingMode.RemoveIncompatibleElements, 
+            SequenceConversionHandlingMode modHandlingMode = SequenceConversionHandlingMode.ReturnNull, 
             IncompatibleParameterHandlingMode parameterHandlingMode = IncompatibleParameterHandlingMode.ReturnNull,
             FragmentIonMappingMode fragmentIonMappingMode = FragmentIonMappingMode.MapToValidatedFullSequence,
             int maxNumberOfBatchesPerRequest = 250, 

--- a/mzLib/PredictionClients/Koina/SupportedModels/RetentionTimeModels/Prosit2019iRT.cs
+++ b/mzLib/PredictionClients/Koina/SupportedModels/RetentionTimeModels/Prosit2019iRT.cs
@@ -61,7 +61,7 @@ namespace PredictionClients.Koina.SupportedModels.RetentionTimeModels
         public override IReadOnlySet<int> AllowedUnimodIds => SupportedUnimodIds;
         public override SequenceConversionHandlingMode ModHandlingMode { get; init; }
 
-        public Prosit2019iRT(SequenceConversionHandlingMode modHandlingMode = SequenceConversionHandlingMode.RemoveIncompatibleElements, int maxNumberOfBatchesPerRequest = 500, int throttlingDelayInMilliseconds = 100)
+        public Prosit2019iRT(SequenceConversionHandlingMode modHandlingMode = SequenceConversionHandlingMode.ReturnNull, int maxNumberOfBatchesPerRequest = 500, int throttlingDelayInMilliseconds = 100)
             : base(Converter)
         {
             ModHandlingMode = modHandlingMode;

--- a/mzLib/Test/KoinaTests/FlyabilityPrediction/PFly2024FineTunedTests.cs
+++ b/mzLib/Test/KoinaTests/FlyabilityPrediction/PFly2024FineTunedTests.cs
@@ -51,7 +51,7 @@ namespace Test.KoinaTests
                 new DetectabilityPredictionInput("PEPTIDEPEPI")
             };
    
-            var model = new PFly2024FineTuned();
+            var model = new PFly2024FineTuned(modHandlingMode: SequenceConversionHandlingMode.UsePrimarySequence);
             var predictions = model.Predict(modelInputs);
 
             Assert.That(predictions.Count, Is.EqualTo(4), "Should return predictions for all inputs");
@@ -261,7 +261,7 @@ namespace Test.KoinaTests
             Assert.That(model.DetectabilityClasses[3], Is.EqualTo("High Detectability"));
             Assert.That(model.MaxPeptideLength, Is.EqualTo(40));
             Assert.That(model.MinPeptideLength, Is.EqualTo(1));
-            Assert.That(model.ModHandlingMode, Is.EqualTo(SequenceConversionHandlingMode.UsePrimarySequence));
+            Assert.That(model.ModHandlingMode, Is.EqualTo(SequenceConversionHandlingMode.ReturnNull));
             Assert.That(model.AllowedUnimodIds.Count, Is.EqualTo(0), "PFly does not support any modifications");
         }
 

--- a/mzLib/Test/KoinaTests/RetentionTimePrediction/Prosit2019iRTTests.cs
+++ b/mzLib/Test/KoinaTests/RetentionTimePrediction/Prosit2019iRTTests.cs
@@ -157,7 +157,7 @@ namespace Test.KoinaTests
                 new RetentionTimePredictionInput("SEQUENS") // Non-canonical amino acid 'U'
             };
 
-            var model = new Prosit2019iRT();
+            var model = new Prosit2019iRT(modHandlingMode: SequenceConversionHandlingMode.RemoveIncompatibleElements);
             var predictions = model.Predict(modelInputs);
 
             Assert.That(predictions.Count, Is.EqualTo(4), "Should return entries for all inputs");
@@ -263,7 +263,7 @@ namespace Test.KoinaTests
             Assert.That(model.MaxPeptideLength, Is.EqualTo(30));
             Assert.That(model.MinPeptideLength, Is.EqualTo(1));
             Assert.That(model.IsIndexedRetentionTimeModel, Is.True);
-            Assert.That(model.ModHandlingMode, Is.EqualTo(SequenceConversionHandlingMode.RemoveIncompatibleElements));
+            Assert.That(model.ModHandlingMode, Is.EqualTo(SequenceConversionHandlingMode.ReturnNull));
             Assert.That(model.AllowedUnimodIds, Is.Not.Null);
             Assert.That(model.AllowedUnimodIds.Count, Is.EqualTo(2), "Should support Oxidation and Carbamidomethyl");
             Assert.That(model.AllowedUnimodIds.Contains(35), Is.True);


### PR DESCRIPTION
1) Updates all models' initialization parameter `modHandlingMode` default to `SequenceConversionHandlingMode.ReturnNull` (user requested update), so predictions belong to the requested input sequence unless the user explicitly modifies the input restrictions. 

2) Added safeguards to `PeptideWithSetModifications.Fragment()` output. Koina does not output M-ions, and we should not parse through them when handling Koina responses. 