### PR TITLE
Bugfix: Averatide now includes phospate

### DIFF
--- a/mzLib/MassSpectrometry/Deconvolution/AverageResidue/OxyriboAveragine.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/AverageResidue/OxyriboAveragine.cs
@@ -27,10 +27,26 @@ public sealed class OxyriboAveragine : AverageResidue
         // This is not the best approach and future work should refine these numbers. 
         // One possible approach is to also incorporate the residue frequency in RNA sequences. 
 
-        double averageC = 9.5;
-        double averageH = 12.75;
-        double averageO = 3.75;
-        double averageN = 5;
+        var water = ChemicalFormula.ParseFormula("H2O");
+        var phosphate = ChemicalFormula.ParseFormula("H3PO4");
+        var ribose = ChemicalFormula.ParseFormula("C5H10O5");
+        var a = ChemicalFormula.ParseFormula("C5H5N5");
+        var c = ChemicalFormula.ParseFormula("C4H5N3O");
+        var g = ChemicalFormula.ParseFormula("C5H5N5O");
+        var u = ChemicalFormula.ParseFormula("C4H4N2O2");
+
+        var amp = a + ribose - water + phosphate - water;
+        var cmp = c + ribose - water + phosphate - water;
+        var gmp = g + ribose - water + phosphate - water;
+        var ump = u + ribose - water + phosphate - water;
+
+        var combined = amp + cmp + gmp + ump;
+
+        var averageC = combined.CountWithIsotopes(PeriodicTable.GetElement("C")) / 4.0;
+        var averageH = combined.CountWithIsotopes(PeriodicTable.GetElement("H")) / 4.0;
+        var averageO = combined.CountWithIsotopes(PeriodicTable.GetElement("O")) / 4.0;
+        var averageN = combined.CountWithIsotopes(PeriodicTable.GetElement("N")) / 4.0;
+        var averageP = combined.CountWithIsotopes(PeriodicTable.GetElement("P")) / 4.0;
 
         for (int i = 0; i < NumAveraginesToGenerate; i++)
         {
@@ -40,6 +56,7 @@ public sealed class OxyriboAveragine : AverageResidue
             chemicalFormula.Add("H", Convert.ToInt32(averageH * averagineMultiplier));
             chemicalFormula.Add("O", Convert.ToInt32(averageO * averagineMultiplier));
             chemicalFormula.Add("N", Convert.ToInt32(averageN * averagineMultiplier));
+            chemicalFormula.Add("P", Convert.ToInt32(averageP * averagineMultiplier));
 
             {
                 var chemicalFormulaReg = chemicalFormula;

--- a/mzLib/Omics/EmpiricalAverageResidue.cs
+++ b/mzLib/Omics/EmpiricalAverageResidue.cs
@@ -5,7 +5,7 @@ using Omics.Modifications;
 
 namespace Omics;
 
-public record struct AverageResidueComposition(double C, double H, double O, double N, double P);
+public record struct AverageResidueComposition(double C, double H, double O, double N, double P, double S, double Se);
 
 public class EmpiricalAverageResidue : AverageResidue
 {
@@ -41,6 +41,8 @@ public class EmpiricalAverageResidue : AverageResidue
             chemicalFormulaReg.Add("O", Convert.ToInt32(composition.O * averagineMultiplier));
             chemicalFormulaReg.Add("N", Convert.ToInt32(composition.N * averagineMultiplier));
             chemicalFormulaReg.Add("P", Convert.ToInt32(composition.P * averagineMultiplier));
+            chemicalFormulaReg.Add("S", Convert.ToInt32(composition.S * averagineMultiplier));
+            chemicalFormulaReg.Add("Se", Convert.ToInt32(composition.Se * averagineMultiplier));
 
             IsotopicDistribution ye = IsotopicDistribution.GetDistribution(chemicalFormulaReg, FineRes, MinRes);
             var masses = ye.Masses.ToArray();
@@ -77,7 +79,9 @@ public class EmpiricalAverageResidue : AverageResidue
         double averageO = totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("O")) / (double)totalResidues;
         double averageN = totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("N")) / (double)totalResidues;
         double averageP = totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("P")) / (double)totalResidues;
+        double averageS = totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("S")) / (double)totalResidues;
+        double averageSe = totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("Se")) / (double)totalResidues;
 
-        return new AverageResidueComposition(averageC, averageH, averageO, averageN, averageP);
+        return new AverageResidueComposition(averageC, averageH, averageO, averageN, averageP, averageS, averageSe);
     }
 }

--- a/mzLib/Omics/EmpiricalAverageResidue.cs
+++ b/mzLib/Omics/EmpiricalAverageResidue.cs
@@ -1,0 +1,83 @@
+﻿using Chemistry;
+using MassSpectrometry;
+using Omics.Digestion;
+using Omics.Modifications;
+
+namespace Omics;
+
+public record struct AverageResidueComposition(double C, double H, double O, double N, double P);
+
+public class EmpiricalAverageResidue : AverageResidue
+{
+    public readonly double[][] AllMasses = new double[NumAveraginesToGenerate][];
+    public readonly double[][] AllIntensities = new double[NumAveraginesToGenerate][];
+    public readonly double[] MostIntenseMasses = new double[NumAveraginesToGenerate];
+    public readonly double[] DiffToMonoisotopic = new double[NumAveraginesToGenerate];
+    public override int GetMostIntenseMassIndex(double testMass) => MostIntenseMasses.GetClosestIndex(testMass);
+
+    public override double[] GetAllTheoreticalMasses(int index) => AllMasses[index];
+
+    public override double[] GetAllTheoreticalIntensities(int index) => AllIntensities[index];
+
+    public override double GetDiffToMonoisotopic(int index) => DiffToMonoisotopic[index];
+
+    public EmpiricalAverageResidue(IEnumerable<IBioPolymerWithSetMods> withSetMods) : this(GetAverageChemicalFormula(withSetMods))
+    {
+    }
+
+    public EmpiricalAverageResidue(IEnumerable<IBioPolymer> bioPolymers, IDigestionParams digParams, List<Modification> fixedMods, List<Modification> variableMods) : this(GetAverageChemicalFormula(bioPolymers, digParams, fixedMods, variableMods))
+    {
+    }
+
+    public EmpiricalAverageResidue(AverageResidueComposition composition)
+    {
+        for (int i = 0; i < NumAveraginesToGenerate; i++)
+        {
+            double averagineMultiplier = (i + 1) / 4.0;
+
+            var chemicalFormulaReg = new ChemicalFormula();
+            chemicalFormulaReg.Add("C", Convert.ToInt32(composition.C * averagineMultiplier));
+            chemicalFormulaReg.Add("H", Convert.ToInt32(composition.H * averagineMultiplier));
+            chemicalFormulaReg.Add("O", Convert.ToInt32(composition.O * averagineMultiplier));
+            chemicalFormulaReg.Add("N", Convert.ToInt32(composition.N * averagineMultiplier));
+            chemicalFormulaReg.Add("P", Convert.ToInt32(composition.P * averagineMultiplier));
+
+            IsotopicDistribution ye = IsotopicDistribution.GetDistribution(chemicalFormulaReg, FineRes, MinRes);
+            var masses = ye.Masses.ToArray();
+            var intensities = ye.Intensities.ToArray();
+            Array.Sort(intensities, masses);
+            Array.Reverse(intensities);
+            Array.Reverse(masses);
+    
+            MostIntenseMasses[i] = masses[0];
+            DiffToMonoisotopic[i] = masses[0] - chemicalFormulaReg.MonoisotopicMass;
+            AllMasses[i] = masses;
+            AllIntensities[i] = intensities;
+        }
+    }
+
+    private static AverageResidueComposition GetAverageChemicalFormula(IEnumerable<IBioPolymer> bioPolymers, IDigestionParams digParams, List<Modification> fixedMods, List<Modification> variableMods)
+    {
+        var withSetMods = bioPolymers.SelectMany(b => b.Digest(digParams, fixedMods, variableMods));
+        return GetAverageChemicalFormula(withSetMods);
+    }
+
+    private static AverageResidueComposition GetAverageChemicalFormula(IEnumerable<IBioPolymerWithSetMods> withSetMods)
+    {
+        var totalChemicalFormula = new ChemicalFormula();
+        long totalResidues = 0;
+        foreach (var bioPolymer in withSetMods)
+        {
+            totalChemicalFormula += bioPolymer.ThisChemicalFormula;
+            totalResidues += bioPolymer.Length;
+        }
+
+        double averageC = totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("C")) / (double)totalResidues;
+        double averageH = totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("H")) / (double)totalResidues;
+        double averageO = totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("O")) / (double)totalResidues;
+        double averageN = totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("N")) / (double)totalResidues;
+        double averageP = totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("P")) / (double)totalResidues;
+
+        return new AverageResidueComposition(averageC, averageH, averageO, averageN, averageP);
+    }
+}

--- a/mzLib/Test/Omics/EmpiricalAverageResidueTests.cs
+++ b/mzLib/Test/Omics/EmpiricalAverageResidueTests.cs
@@ -1,0 +1,114 @@
+using Chemistry;
+using NUnit.Framework;
+using Omics;
+using Omics.Modifications;
+using Proteomics;
+using Proteomics.ProteolyticDigestion;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace Test.Omics;
+
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class EmpiricalAverageResidueTests
+{
+    [Test]
+    public void Constructor_Composition_PopulatesExpectedCollectionsAndAccessors()
+    {
+        var composition = new AverageResidueComposition(4.8, 7.7, 1.4, 1.3, 0.2);
+        var model = new EmpiricalAverageResidue(composition);
+
+        Assert.That(model.AllMasses.Length, Is.EqualTo(1500));
+        Assert.That(model.AllIntensities.Length, Is.EqualTo(1500));
+        Assert.That(model.MostIntenseMasses.Length, Is.EqualTo(1500));
+        Assert.That(model.DiffToMonoisotopic.Length, Is.EqualTo(1500));
+
+        int index = 300;
+        double[] masses = model.GetAllTheoreticalMasses(index);
+        double[] intensities = model.GetAllTheoreticalIntensities(index);
+
+        Assert.That(masses, Is.Not.Null.And.Not.Empty);
+        Assert.That(intensities, Is.Not.Null.And.Not.Empty);
+        Assert.That(masses.Length, Is.EqualTo(intensities.Length));
+        Assert.That(intensities.First(), Is.GreaterThanOrEqualTo(intensities.Last()));
+        Assert.That(masses[0], Is.EqualTo(model.MostIntenseMasses[index]).Within(1e-9));
+        Assert.That(model.GetDiffToMonoisotopic(index), Is.GreaterThanOrEqualTo(0));
+        Assert.That(model.GetMostIntenseMassIndex(model.MostIntenseMasses[index]), Is.EqualTo(index));
+    }
+
+    [Test]
+    public void Constructor_WithSetMods_MatchesModelFromManuallyComputedAverageComposition()
+    {
+        var precursors = new List<IBioPolymerWithSetMods>
+        {
+            new PeptideWithSetModifications("PEPTIDE", new Dictionary<string, Modification>()),
+            new PeptideWithSetModifications("MKWVTFISLL", new Dictionary<string, Modification>()),
+            new PeptideWithSetModifications("ACDEFGHIK", new Dictionary<string, Modification>())
+        };
+
+        AverageResidueComposition expectedComposition = ComputeAverageComposition(precursors);
+        var fromSetMods = new EmpiricalAverageResidue(precursors);
+        var fromComposition = new EmpiricalAverageResidue(expectedComposition);
+
+        AssertModelsMatchAtIndices(fromSetMods, fromComposition, new[] { 0, 10, 100, 500, 1499 });
+    }
+
+    [Test]
+    public void Constructor_BioPolymersAndDigestionParams_MatchesConstructorFromDigestedSetMods()
+    {
+        var proteins = new List<IBioPolymer>
+        {
+            new Protein("MPEPTIDER", "P1"),
+            new Protein("ACDEFGHIKLMNPQRST", "P2")
+        };
+
+        var digestionParams = new DigestionParams("top-down");
+        var fixedMods = new List<Modification>();
+        var variableMods = new List<Modification>();
+
+        var fromBioPolymers = new EmpiricalAverageResidue(proteins, digestionParams, fixedMods, variableMods);
+        IEnumerable<IBioPolymerWithSetMods> digested = proteins.SelectMany(p => p.Digest(digestionParams, fixedMods, variableMods));
+        var fromSetMods = new EmpiricalAverageResidue(digested);
+
+        AssertModelsMatchAtIndices(fromBioPolymers, fromSetMods, new[] { 1, 25, 250, 1000, 1499 });
+    }
+
+    private static AverageResidueComposition ComputeAverageComposition(IEnumerable<IBioPolymerWithSetMods> withSetMods)
+    {
+        var totalChemicalFormula = new ChemicalFormula();
+        long totalResidues = 0;
+
+        foreach (IBioPolymerWithSetMods bioPolymer in withSetMods)
+        {
+            totalChemicalFormula += bioPolymer.ThisChemicalFormula;
+            totalResidues += bioPolymer.Length;
+        }
+
+        return new AverageResidueComposition(
+            totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("C")) / (double)totalResidues,
+            totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("H")) / (double)totalResidues,
+            totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("O")) / (double)totalResidues,
+            totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("N")) / (double)totalResidues,
+            totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("P")) / (double)totalResidues);
+    }
+
+    private static void AssertModelsMatchAtIndices(
+        EmpiricalAverageResidue expected,
+        EmpiricalAverageResidue observed,
+        IEnumerable<int> indices)
+    {
+        foreach (int index in indices)
+        {
+            Assert.That(observed.MostIntenseMasses[index], Is.EqualTo(expected.MostIntenseMasses[index]).Within(1e-9));
+            Assert.That(observed.GetDiffToMonoisotopic(index), Is.EqualTo(expected.GetDiffToMonoisotopic(index)).Within(1e-9));
+
+            double[] expectedIntensities = expected.GetAllTheoreticalIntensities(index);
+            double[] observedIntensities = observed.GetAllTheoreticalIntensities(index);
+            Assert.That(observedIntensities.Length, Is.EqualTo(expectedIntensities.Length));
+            Assert.That(observedIntensities[0], Is.EqualTo(expectedIntensities[0]).Within(1e-9));
+            Assert.That(observedIntensities[^1], Is.EqualTo(expectedIntensities[^1]).Within(1e-9));
+        }
+    }
+}

--- a/mzLib/Test/Omics/EmpiricalAverageResidueTests.cs
+++ b/mzLib/Test/Omics/EmpiricalAverageResidueTests.cs
@@ -7,6 +7,7 @@ using Proteomics.ProteolyticDigestion;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using UsefulProteomicsDatabases;
 
 namespace Test.Omics;
 
@@ -17,7 +18,7 @@ public class EmpiricalAverageResidueTests
     [Test]
     public void Constructor_Composition_PopulatesExpectedCollectionsAndAccessors()
     {
-        var composition = new AverageResidueComposition(4.8, 7.7, 1.4, 1.3, 0.2);
+        var composition = new AverageResidueComposition(4.8, 7.7, 1.4, 1.3, 0.2, 0, 0);
         var model = new EmpiricalAverageResidue(composition);
 
         Assert.That(model.AllMasses.Length, Is.EqualTo(1500));
@@ -91,7 +92,9 @@ public class EmpiricalAverageResidueTests
             totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("H")) / (double)totalResidues,
             totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("O")) / (double)totalResidues,
             totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("N")) / (double)totalResidues,
-            totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("P")) / (double)totalResidues);
+            totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("P")) / (double)totalResidues,
+            totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("S")) / (double)totalResidues,
+            totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("Se")) / (double)totalResidues);
     }
 
     private static void AssertModelsMatchAtIndices(


### PR DESCRIPTION
### The Problem
Averatide did not include phosphate in it's calculation, resulting in bad math. 

### Characterization of the problem

To evaluate this, I plotted the 
BLUE: theoretical averagine Mono Mass vs. Diff to Monoisotopic 
RED:  empirical envelopes constructed from peptides/oligos after digestion. 

<img width="1781" height="518" alt="image" src="https://github.com/user-attachments/assets/cd0b970e-1e53-4b5d-babb-bf8f02458a84" />

### The Fix - After adding Phosphate to RNA averagine

<img width="1024" height="535" alt="image" src="https://github.com/user-attachments/assets/9e3bd686-3f57-4531-8199-e20db8599d1e" />

### Empirical AverageResidue - A new model based upon database. 

I also created an empirical average residue model that takes in your `IBioPolymer` or `IBioPolymerWithSetMods` to determine average residue composition. With oligos it makes a perfect fit. 

<img width="494" height="503" alt="image" src="https://github.com/user-attachments/assets/f7b3b8ed-9cf6-4fb8-b00e-1eab19a176e9" />

When sending in the entire human (fasta) proteome, we get these numbers: 

<img width="616" height="146" alt="image" src="https://github.com/user-attachments/assets/a6359eac-76f6-4d81-bd0a-4f42fed8ac66" />

Which matches really close to the averagine hard-coded numbers. 

<img width="844" height="183" alt="image" src="https://github.com/user-attachments/assets/6506c70d-89a9-45d0-bf3c-257f737f3548" />
