### PR TITLE
Add MS:1000516 charge array support to MsDataScan + mzML I/O

### DIFF
--- a/mzLib/MassSpectrometry/MsDataScan.cs
+++ b/mzLib/MassSpectrometry/MsDataScan.cs
@@ -25,30 +25,31 @@ namespace MassSpectrometry
 {
     public class MsDataScan
     {
-        public MsDataScan(MzSpectrum massSpectrum, 
-            int oneBasedScanNumber, 
-            int msnOrder, 
-            bool isCentroid, 
-            Polarity polarity, 
-            double retentionTime, 
-            MzRange scanWindowRange, 
-            string scanFilter, 
+        public MsDataScan(MzSpectrum massSpectrum,
+            int oneBasedScanNumber,
+            int msnOrder,
+            bool isCentroid,
+            Polarity polarity,
+            double retentionTime,
+            MzRange scanWindowRange,
+            string scanFilter,
             MZAnalyzerType mzAnalyzer,
-            double totalIonCurrent, 
-            double? injectionTime, 
-            double[,] noiseData, 
-            string nativeId, 
-            double? selectedIonMz = null, 
-            int? selectedIonChargeStateGuess = null, 
-            double? selectedIonIntensity = null, 
+            double totalIonCurrent,
+            double? injectionTime,
+            double[,] noiseData,
+            string nativeId,
+            double? selectedIonMz = null,
+            int? selectedIonChargeStateGuess = null,
+            double? selectedIonIntensity = null,
             double? isolationMZ = null,
-            double? isolationWidth = null, 
-            DissociationType? dissociationType = null, 
-            int? oneBasedPrecursorScanNumber = null, 
-            double? selectedIonMonoisotopicGuessMz = null, 
+            double? isolationWidth = null,
+            DissociationType? dissociationType = null,
+            int? oneBasedPrecursorScanNumber = null,
+            double? selectedIonMonoisotopicGuessMz = null,
             string hcdEnergy = null,
-            string scanDescription = null, 
-            double? compensationVoltage = null)
+            string scanDescription = null,
+            double? compensationVoltage = null,
+            int[] chargeArray = null)
         {
             OneBasedScanNumber = oneBasedScanNumber;
             MsnOrder = msnOrder;
@@ -72,9 +73,10 @@ namespace MassSpectrometry
             SelectedIonMonoisotopicGuessMz = selectedIonMonoisotopicGuessMz;
             HcdEnergy = hcdEnergy;
             ScanDescription = scanDescription;
-            CompensationVoltage = compensationVoltage; 
+            CompensationVoltage = compensationVoltage;
+            ChargeArray = chargeArray;
 
-            // Ensure the charge of the selected ion matches the polarity of the scan 
+            // Ensure the charge of the selected ion matches the polarity of the scan
             SelectedIonChargeStateGuess = Polarity switch
             {
                 Polarity.Negative when selectedIonChargeStateGuess is > 0 => -selectedIonChargeStateGuess,
@@ -82,6 +84,17 @@ namespace MassSpectrometry
                 _ => selectedIonChargeStateGuess
             };
         }
+
+        /// <summary>
+        /// Per-peak charge state, parallel to <see cref="MassSpectrum"/>.XArray.
+        /// Length must equal MassSpectrum.Size when set; null means "no charge data captured".
+        /// Encoded in mzML as a third &lt;binaryDataArray&gt; with cvParam
+        /// MS:1000516 ("charge array"), 32-bit float, zlib-compressed.
+        ///
+        /// Only set by deisotopers (e.g. YADA's annotate mode); vendor-converted mzML
+        /// rarely includes it. Readers that don't understand MS:1000516 silently ignore it.
+        /// </summary>
+        public int[] ChargeArray { get; protected set; }
 
         /// <summary>
         /// The mass spectrum associated with the scan

--- a/mzLib/MassSpectrometry/MsDataScan.cs
+++ b/mzLib/MassSpectrometry/MsDataScan.cs
@@ -89,7 +89,9 @@ namespace MassSpectrometry
         /// Per-peak charge state, parallel to <see cref="MassSpectrum"/>.XArray.
         /// Length must equal MassSpectrum.Size when set; null means "no charge data captured".
         /// Encoded in mzML as a third &lt;binaryDataArray&gt; with cvParam
-        /// MS:1000516 ("charge array"), 32-bit float, zlib-compressed.
+        /// MS:1000516 ("charge array"), 32-bit float, no compression
+        /// (charge arrays are small enough that the zlib overhead isn't worth it; could
+        /// be made configurable in a follow-up if a downstream consumer needs it).
         ///
         /// Only set by deisotopers (e.g. YADA's annotate mode); vendor-converted mzML
         /// rarely includes it. Readers that don't understand MS:1000516 silently ignore it.

--- a/mzLib/Readers/MzML/Mzml.cs
+++ b/mzLib/Readers/MzML/Mzml.cs
@@ -400,9 +400,14 @@ namespace Readers
                         bool compressed = false;
                         bool readingMzs = false;
                         bool readingIntensities = false;
+                        bool readingCharges = false;
                         bool is32bit = true;
                         double[] mzs = null;
                         double[] intensities = null;
+                        // Per-peak charge array (PSI-MS MS:1000516). Stays null when the
+                        // spectrum doesn't include the third binaryDataArray, matching the
+                        // static-reader path's behavior.
+                        int[] chargeArray = null;
 
                         while (xmlReader.Read())
                         {
@@ -578,12 +583,22 @@ namespace Readers
                                         case "MS:1000515":
                                             readingIntensities = true;
                                             break;
+
+                                        // charge array — PSI-MS MS:1000516. The static-reader
+                                        // path (GetMsDataOneBasedScanFromConnection) recognizes
+                                        // this and populates MsDataScan.ChargeArray; previously
+                                        // the dynamic path did not, so any caller using
+                                        // InitiateDynamicConnection silently lost per-peak charge
+                                        // info round-tripping through this reader.
+                                        case "MS:1000516":
+                                            readingCharges = true;
+                                            break;
                                     }
                                     break;
 
-                                // binary data array (e.g., m/z or intensity array)
+                                // binary data array (e.g., m/z or intensity or charge array)
                                 case "BINARY":
-                                    if (!readingMzs && !readingIntensities)
+                                    if (!readingMzs && !readingIntensities && !readingCharges)
                                     {
                                         break;
                                     }
@@ -608,6 +623,16 @@ namespace Readers
                                     {
                                         intensities = data;
                                         readingIntensities = false;
+                                    }
+                                    else if (readingCharges)
+                                    {
+                                        // Mirror the static-reader path: charges are stored as
+                                        // 32-bit float per PSI-MS convention; round back to int
+                                        // for the public API.
+                                        chargeArray = new int[data.Length];
+                                        for (int k = 0; k < data.Length; k++)
+                                            chargeArray[k] = (int)Math.Round(data[k]);
+                                        readingCharges = false;
                                     }
 
                                     break;
@@ -684,7 +709,8 @@ namespace Readers
                                             retentionTime, range, scanFilter, mzAnalyzerType, tic, injTime, noiseData,
                                             nativeId, selectedIonMz, selectedCharge, selectedIonIntensity, isolationMz, isolationWidth,
                                             dissociationType, oneBasedPrecursorScanNumber, selectedIonMonoisotopicGuessMz,
-                                            compensationVoltage: compensationVoltage);
+                                            compensationVoltage: compensationVoltage,
+                                            chargeArray: chargeArray);
 
                                         return scan;
                                     }

--- a/mzLib/Readers/MzML/Mzml.cs
+++ b/mzLib/Readers/MzML/Mzml.cs
@@ -284,12 +284,28 @@ namespace Readers
                     }
                 }
 
+                // Defensive URI parse: some converters (Waters / Bruker / vendor exporters)
+                // write a non-URI string in the sourceFile/@location attribute — e.g.
+                // "Company", a bare Windows path "Z:\foo\bar", or a relative path. The
+                // mzML XSD types this as xsd:anyURI but in practice anything goes. The
+                // previous `new Uri(simpler.location)` threw UriFormatException and aborted
+                // the entire file load. Now: try absolute first, fall back to wrapping the
+                // value as a file:/// URI based on the file we actually opened, finally
+                // fall back to a synthetic placeholder. The Uri is metadata only — none
+                // of the algorithm or writer paths depend on it being meaningful.
+                Uri sourceUri;
+                if (string.IsNullOrWhiteSpace(simpler.location)
+                    || !Uri.TryCreate(simpler.location, UriKind.Absolute, out sourceUri))
+                {
+                    try { sourceUri = new Uri(System.IO.Path.GetFullPath(FilePath)); }
+                    catch { sourceUri = new Uri("file:///unknown-source"); }
+                }
                 sourceFile = new SourceFile(
                     nativeIdFormat,
                     fileFormat,
                     checkSum,
                     checkSumType,
-                    new Uri(simpler.location),
+                    sourceUri,
                     simpler.id,
                     simpler.name);
             }

--- a/mzLib/Readers/MzML/Mzml.cs
+++ b/mzLib/Readers/MzML/Mzml.cs
@@ -63,6 +63,7 @@ namespace Readers
         private const string _ionInjectionTime = "MS:1000927";
         private const string _mzArray = "MS:1000514";
         private const string _intensityArray = "MS:1000515";
+        private const string _chargeArray = "MS:1000516";
 
         /// <summary>
         /// HUPO-PSI Information: 
@@ -842,12 +843,14 @@ namespace Readers
 
             double[] masses = new double[0];
             double[] intensities = new double[0];
+            int[] chargeArray = null;
 
             foreach (Generated.BinaryDataArrayType binaryData in _mzMLConnection.run.spectrumList.spectrum[oneBasedIndex - 1].binaryDataArrayList.binaryDataArray)
             {
                 bool compressed = false;
                 bool mzArray = false;
                 bool intensityArray = false;
+                bool isChargeArray = false;
                 bool is32bit = true;
                 foreach (Generated.CVParamType cv in binaryData.cvParam)
                 {
@@ -856,6 +859,7 @@ namespace Readers
                     is32bit |= cv.accession.Equals(_32bit);
                     mzArray |= cv.accession.Equals(_mzArray);
                     intensityArray |= cv.accession.Equals(_intensityArray);
+                    isChargeArray |= cv.accession.Equals(_chargeArray);
                 }
 
                 //in the futurem we may see scass w/ no data and there will be a crash here. if that happens, you can retrun an MsDataScan with null as the mzSpectrum
@@ -869,6 +873,15 @@ namespace Readers
                 if (intensityArray)
                 {
                     intensities = data;
+                }
+
+                if (isChargeArray)
+                {
+                    // Charge array stores integer charge states as float (per PSI-MS convention).
+                    // Cast back to int for the public API.
+                    chargeArray = new int[data.Length];
+                    for (int k = 0; k < data.Length; k++)
+                        chargeArray[k] = (int)Math.Round(data[k]);
                 }
             }
 
@@ -930,7 +943,8 @@ namespace Readers
                     injectionTime,
                     null,
                     nativeId,
-                    compensationVoltage: compensationVoltage);
+                    compensationVoltage: compensationVoltage,
+                    chargeArray: chargeArray);
             }
 
             double selectedIonMz = double.NaN;
@@ -1047,7 +1061,8 @@ namespace Readers
                 dissociationType,
                 precursorScanNumber,
                 monoisotopicMz,
-                compensationVoltage: compensationVoltage
+                compensationVoltage: compensationVoltage,
+                chargeArray: chargeArray
                 );
         }
 

--- a/mzLib/Readers/MzML/MzmlMethods.cs
+++ b/mzLib/Readers/MzML/MzmlMethods.cs
@@ -789,27 +789,18 @@ namespace Readers
                     unitAccession = "MS:1000040",
                     unitName = "m/z"
                 };
-                if (myMsDataFile.GetOneBasedScan(i).NoiseData == null)
+                // Compute the binary-array-list size: m/z + intensity (always),
+                // + noise/baseline/SNR (3) when NoiseData is set,
+                // + charge array (1) when ChargeArray is set.
+                int extraArrays = 0;
+                if (myMsDataFile.GetOneBasedScan(i).NoiseData != null) extraArrays += 3;
+                if (myMsDataFile.GetOneBasedScan(i).ChargeArray != null) extraArrays += 1;
+                int arrayCount = 2 + extraArrays;
+                mzML.run.spectrumList.spectrum[i - 1].binaryDataArrayList = new Generated.BinaryDataArrayListType
                 {
-                    mzML.run.spectrumList.spectrum[i - 1].binaryDataArrayList = new Generated.BinaryDataArrayListType
-                    {
-                        // ONLY WRITING M/Z AND INTENSITY DATA, NOT THE CHARGE! (but can add charge info later)
-                        // CHARGE (and other stuff) CAN BE IMPORTANT IN ML APPLICATIONS!!!!!
-                        count = 2.ToString(),
-                        binaryDataArray = new Generated.BinaryDataArrayType[2]
-                    };
-                }
-
-                if (myMsDataFile.GetOneBasedScan(i).NoiseData != null)
-                {
-                    mzML.run.spectrumList.spectrum[i - 1].binaryDataArrayList = new Generated.BinaryDataArrayListType
-                    {
-                        // ONLY WRITING M/Z AND INTENSITY DATA, NOT THE CHARGE! (but can add charge info later)
-                        // CHARGE (and other stuff) CAN BE IMPORTANT IN ML APPLICATIONS!!!!!
-                        count = 5.ToString(),
-                        binaryDataArray = new Generated.BinaryDataArrayType[5]
-                    };
-                }
+                    count = arrayCount.ToString(CultureInfo.InvariantCulture),
+                    binaryDataArray = new Generated.BinaryDataArrayType[arrayCount]
+                };
 
                 // M/Z Data
                 mzML.run.spectrumList.spectrum[i - 1].binaryDataArrayList.binaryDataArray[0] = new Generated.BinaryDataArrayType
@@ -984,6 +975,50 @@ namespace Readers
                     {
                         name = "kelleherCustomType",
                         value = "noise intensity",
+                    };
+                }
+
+                // Charge array (PSI-MS MS:1000516). One integer per peak, parallel to the m/z and
+                // intensity arrays, encoded as 32-bit float (charges fit in well under 2^23) and
+                // base64'd uncompressed. Conformant mzML readers that don't understand the
+                // accession ignore this array silently.
+                int[] chargeArray = myMsDataFile.GetOneBasedScan(i).ChargeArray;
+                if (chargeArray != null)
+                {
+                    int chargeArrayIndex = 2 + (myMsDataFile.GetOneBasedScan(i).NoiseData != null ? 3 : 0);
+                    byte[] encoded = new byte[chargeArray.Length * 4];
+                    for (int k = 0; k < chargeArray.Length; k++)
+                    {
+                        byte[] floatBytes = BitConverter.GetBytes((float)chargeArray[k]);
+                        Buffer.BlockCopy(floatBytes, 0, encoded, k * 4, 4);
+                    }
+                    mzML.run.spectrumList.spectrum[i - 1].binaryDataArrayList.binaryDataArray[chargeArrayIndex] = new Generated.BinaryDataArrayType
+                    {
+                        binary = encoded
+                    };
+                    mzML.run.spectrumList.spectrum[i - 1].binaryDataArrayList.binaryDataArray[chargeArrayIndex].arrayLength = chargeArray.Length.ToString(CultureInfo.InvariantCulture);
+                    mzML.run.spectrumList.spectrum[i - 1].binaryDataArrayList.binaryDataArray[chargeArrayIndex].encodedLength = (4 * Math.Ceiling(((double)encoded.Length / 3))).ToString(CultureInfo.InvariantCulture);
+                    mzML.run.spectrumList.spectrum[i - 1].binaryDataArrayList.binaryDataArray[chargeArrayIndex].cvParam = new Generated.CVParamType[3];
+                    mzML.run.spectrumList.spectrum[i - 1].binaryDataArrayList.binaryDataArray[chargeArrayIndex].cvParam[0] = new Generated.CVParamType
+                    {
+                        accession = "MS:1000516",
+                        name = "charge array",
+                        cvRef = "MS",
+                        value = ""
+                    };
+                    mzML.run.spectrumList.spectrum[i - 1].binaryDataArrayList.binaryDataArray[chargeArrayIndex].cvParam[1] = new Generated.CVParamType
+                    {
+                        accession = "MS:1000521",
+                        name = "32-bit float",
+                        cvRef = "MS",
+                        value = ""
+                    };
+                    mzML.run.spectrumList.spectrum[i - 1].binaryDataArrayList.binaryDataArray[chargeArrayIndex].cvParam[2] = new Generated.CVParamType
+                    {
+                        accession = "MS:1000576",
+                        name = "no compression",
+                        cvRef = "MS",
+                        value = ""
                     };
                 }
             }

--- a/mzLib/Test/FileReadingTests/SpectraFileReading/TestMzML.cs
+++ b/mzLib/Test/FileReadingTests/SpectraFileReading/TestMzML.cs
@@ -1775,15 +1775,21 @@ namespace Test.FileReadingTests.SpectraFileReading
             //   1. construct an MsDataScan with a per-peak chargeArray,
             //   2. write it as mzML,
             //   3. re-read it,
-            //   4. assert the round-tripped ChargeArray matches the original element-for-element.
+            //   4. assert ChargeArray, m/z, AND intensity all round-trip element-for-element.
             //
             // Exercises both the writer branch in MzmlMethods (third <binaryDataArray> with
             // accession="MS:1000516") and the reader branch in Mzml.cs (cvParam recognition
             // + 32-bit-float decode rounded back to int[]).
-            var spectrum = new MzSpectrum(
-                new[] { 100.0, 200.0, 300.0 },
-                new[] { 1000.0, 2000.0, 3000.0 },
-                shouldCopy: false);
+            //
+            // m/z and intensity assertions cover the most likely class of regression in this
+            // PR: a bug in the writer's per-spectrum array-list sizing (count attribute,
+            // allocation index, off-by-one when slotting the third <binaryDataArray>) could
+            // leave the new charge array intact while corrupting or mis-indexing the m/z or
+            // intensity arrays. Without these assertions a "passing" green test could ship
+            // a corrupted m/z/intensity round-trip.
+            var mzs = new[] { 100.0, 200.0, 300.0 };
+            var intensities = new[] { 1000.0, 2000.0, 3000.0 };
+            var spectrum = new MzSpectrum(mzs, intensities, shouldCopy: false);
             var charges = new[] { 2, 3, 1 };
 
             var scan = new MsDataScan(
@@ -1824,6 +1830,115 @@ namespace Test.FileReadingTests.SpectraFileReading
                 Assert.IsNotNull(readBack.ChargeArray, "ChargeArray was not populated on read-back");
                 Assert.AreEqual(charges.Length, readBack.ChargeArray.Length, "ChargeArray length mismatch");
                 NUnit.Framework.Legacy.CollectionAssert.AreEqual(charges, readBack.ChargeArray);
+
+                // m/z + intensity round-trip — guards against writer sizing/indexing bugs that
+                // would corrupt the existing arrays while leaving the new charge array alone.
+                NUnit.Framework.Legacy.CollectionAssert.AreEqual(mzs, readBack.MassSpectrum.XArray);
+                NUnit.Framework.Legacy.CollectionAssert.AreEqual(intensities, readBack.MassSpectrum.YArray);
+            }
+            finally
+            {
+                if (File.Exists(outPath)) File.Delete(outPath);
+            }
+        }
+
+        [Test]
+        public static void ChargeArrayRoundTripWithNoiseData()
+        {
+            // The writer's per-spectrum array-list sizing formula is
+            //   2 (m/z + intensity) + (3 if NoiseData) + (1 if ChargeArray)
+            // giving four distinct branches: 2, 3, 5, 6 arrays per spectrum.
+            //
+            // ChargeArrayRoundTrip exercises the 3-array branch (charges, no noise);
+            // ChargeArrayDefaultsToNullWhenAbsent exercises the baseline 2-array branch;
+            // this test exercises the most complex 6-array branch (BOTH noise AND charges).
+            // That branch is exactly where indexing/count bugs are most likely — a swap of
+            // NoiseData and ChargeArray bytes, a wrong count attribute, or a wrong array
+            // order would all surface here as an m/z, intensity, or charge mismatch on
+            // read-back, while passing the simpler tests above.
+            //
+            // Note: NoiseData itself is not currently re-populated on read-back (the reader
+            // has a "// TODO: read this" against it), so we don't assert NoiseData survives.
+            // What we DO assert is that adding NoiseData on the write side doesn't shift,
+            // duplicate, or corrupt the m/z / intensity / charge arrays it shares the
+            // binaryDataArrayList with.
+            var mzs = new[] { 110.0, 220.0, 330.0, 440.0 };
+            var intensities = new[] { 1100.0, 2200.0, 3300.0, 4400.0 };
+            var spectrum = new MzSpectrum(mzs, intensities, shouldCopy: false);
+            var charges = new[] { 1, 2, 3, 4 };
+
+            // [3, N]: row 0 = noise mass, row 1 = noise value, row 2 = baseline. Matches
+            // the GetNoiseDataMass/Noise/Baseline accessors in MsDataScan.
+            var noiseData = new double[3, 2]
+            {
+                { 50.0, 60.0 },     // mass
+                { 5.0, 6.0 },       // noise
+                { 0.5, 0.6 },       // baseline
+            };
+
+            var scan = new MsDataScan(
+                spectrum,
+                oneBasedScanNumber: 1,
+                msnOrder: 1,
+                isCentroid: true,
+                polarity: Polarity.Positive,
+                retentionTime: 1.0,
+                scanWindowRange: new MzRange(50, 1000),
+                scanFilter: "FTMS + p NSI Full ms",
+                mzAnalyzer: MZAnalyzerType.Orbitrap,
+                totalIonCurrent: 11000,
+                injectionTime: null,
+                noiseData: noiseData,
+                nativeId: "scan=1",
+                chargeArray: charges);
+
+            var sourceFile = new SourceFile(
+                nativeIdFormat: "scan number only nativeID format",
+                massSpectrometerFileFormat: "mzML format",
+                checkSum: null,
+                fileChecksumType: "SHA-1",
+                uri: new Uri("file:///test"),
+                id: "test",
+                fileName: "test.mzML");
+
+            var dataFile = new GenericMsDataFile(new[] { scan }, sourceFile);
+            string outPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "charge_noise_roundtrip.mzML");
+            MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(dataFile, outPath, false);
+
+            try
+            {
+                var reread = (Mzml)MsDataFileReader.GetDataFile(outPath);
+                reread.LoadAllStaticData();
+                var readBack = reread.GetOneBasedScan(1);
+
+                // m/z, intensity, charge all survive the 6-array writer branch.
+                NUnit.Framework.Legacy.CollectionAssert.AreEqual(mzs, readBack.MassSpectrum.XArray,
+                    "m/z array drifted when NoiseData + ChargeArray both written");
+                NUnit.Framework.Legacy.CollectionAssert.AreEqual(intensities, readBack.MassSpectrum.YArray,
+                    "intensity array drifted when NoiseData + ChargeArray both written");
+                Assert.IsNotNull(readBack.ChargeArray, "ChargeArray null after writing alongside NoiseData");
+                NUnit.Framework.Legacy.CollectionAssert.AreEqual(charges, readBack.ChargeArray);
+
+                // Sanity-check the on-disk XML: the spectrum's <binaryDataArrayList>
+                // should declare count="6" (m/z + intensity + 3 noise + charge), and the
+                // file must carry an MS:1000516 cvParam somewhere. Catches writer
+                // count-attribute and array-allocation-index bugs even when the reader is
+                // permissive enough to still parse the file.
+                //
+                // We extract the count attribute on the FIRST binaryDataArrayList in the
+                // file (the spectrum's) rather than counting <binaryDataArray> across the
+                // whole file — indexed mzML appends chromatograms (TIC + base peak) which
+                // contribute their own binaryDataArray elements at file scope.
+                string xml = File.ReadAllText(outPath);
+                var listCountMatch = System.Text.RegularExpressions.Regex.Match(
+                    xml, "<binaryDataArrayList\\s+count=\"(\\d+)\"");
+                Assert.IsTrue(listCountMatch.Success,
+                    "Output XML missing a <binaryDataArrayList count=...> element");
+                Assert.AreEqual("6", listCountMatch.Groups[1].Value,
+                    "Spectrum's binaryDataArrayList should declare count=\"6\" "
+                    + "(2 m/z+intensity + 3 noise + 1 charge)");
+                NUnit.Framework.Legacy.StringAssert.Contains("accession=\"MS:1000516\"", xml,
+                    "Output XML missing the MS:1000516 \"charge array\" cvParam");
             }
             finally
             {

--- a/mzLib/Test/FileReadingTests/SpectraFileReading/TestMzML.cs
+++ b/mzLib/Test/FileReadingTests/SpectraFileReading/TestMzML.cs
@@ -1768,6 +1768,122 @@ namespace Test.FileReadingTests.SpectraFileReading
             return new MzSpectrum(allMassesArray, allIntensitiessArray, false);
         }
 
+        [Test]
+        public static void ChargeArrayRoundTrip()
+        {
+            // Regression test for the MS:1000516 "charge array" round-trip:
+            //   1. construct an MsDataScan with a per-peak chargeArray,
+            //   2. write it as mzML,
+            //   3. re-read it,
+            //   4. assert the round-tripped ChargeArray matches the original element-for-element.
+            //
+            // Exercises both the writer branch in MzmlMethods (third <binaryDataArray> with
+            // accession="MS:1000516") and the reader branch in Mzml.cs (cvParam recognition
+            // + 32-bit-float decode rounded back to int[]).
+            var spectrum = new MzSpectrum(
+                new[] { 100.0, 200.0, 300.0 },
+                new[] { 1000.0, 2000.0, 3000.0 },
+                shouldCopy: false);
+            var charges = new[] { 2, 3, 1 };
+
+            var scan = new MsDataScan(
+                spectrum,
+                oneBasedScanNumber: 1,
+                msnOrder: 1,
+                isCentroid: true,
+                polarity: Polarity.Positive,
+                retentionTime: 1.0,
+                scanWindowRange: new MzRange(50, 1000),
+                scanFilter: "FTMS + p NSI Full ms",
+                mzAnalyzer: MZAnalyzerType.Orbitrap,
+                totalIonCurrent: 6000,
+                injectionTime: null,
+                noiseData: null,
+                nativeId: "scan=1",
+                chargeArray: charges);
+
+            var sourceFile = new SourceFile(
+                nativeIdFormat: "scan number only nativeID format",
+                massSpectrometerFileFormat: "mzML format",
+                checkSum: null,
+                fileChecksumType: "SHA-1",
+                uri: new Uri("file:///test"),
+                id: "test",
+                fileName: "test.mzML");
+
+            var dataFile = new GenericMsDataFile(new[] { scan }, sourceFile);
+            string outPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "charge_roundtrip.mzML");
+            MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(dataFile, outPath, false);
+
+            try
+            {
+                var reread = (Mzml)MsDataFileReader.GetDataFile(outPath);
+                reread.LoadAllStaticData();
+                var readBack = reread.GetOneBasedScan(1);
+
+                Assert.IsNotNull(readBack.ChargeArray, "ChargeArray was not populated on read-back");
+                Assert.AreEqual(charges.Length, readBack.ChargeArray.Length, "ChargeArray length mismatch");
+                NUnit.Framework.Legacy.CollectionAssert.AreEqual(charges, readBack.ChargeArray);
+            }
+            finally
+            {
+                if (File.Exists(outPath)) File.Delete(outPath);
+            }
+        }
+
+        [Test]
+        public static void ChargeArrayDefaultsToNullWhenAbsent()
+        {
+            // A scan written without a chargeArray should round-trip with ChargeArray == null,
+            // confirming the new code path is strictly additive and does not introduce a default
+            // empty array on read-back.
+            var spectrum = new MzSpectrum(
+                new[] { 100.0, 200.0 },
+                new[] { 500.0, 1500.0 },
+                shouldCopy: false);
+
+            var scan = new MsDataScan(
+                spectrum,
+                oneBasedScanNumber: 1,
+                msnOrder: 1,
+                isCentroid: true,
+                polarity: Polarity.Positive,
+                retentionTime: 1.0,
+                scanWindowRange: new MzRange(50, 1000),
+                scanFilter: "FTMS + p NSI Full ms",
+                mzAnalyzer: MZAnalyzerType.Orbitrap,
+                totalIonCurrent: 2000,
+                injectionTime: null,
+                noiseData: null,
+                nativeId: "scan=1");
+
+            var sourceFile = new SourceFile(
+                nativeIdFormat: "scan number only nativeID format",
+                massSpectrometerFileFormat: "mzML format",
+                checkSum: null,
+                fileChecksumType: "SHA-1",
+                uri: new Uri("file:///test"),
+                id: "test",
+                fileName: "test.mzML");
+
+            var dataFile = new GenericMsDataFile(new[] { scan }, sourceFile);
+            string outPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "no_charge_roundtrip.mzML");
+            MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(dataFile, outPath, false);
+
+            try
+            {
+                var reread = (Mzml)MsDataFileReader.GetDataFile(outPath);
+                reread.LoadAllStaticData();
+                var readBack = reread.GetOneBasedScan(1);
+
+                Assert.IsNull(readBack.ChargeArray, "ChargeArray should be null when not written");
+            }
+            finally
+            {
+                if (File.Exists(outPath)) File.Delete(outPath);
+            }
+        }
+
         private MzSpectrum CreateSpectrum(ChemicalFormula f, double lowerBound, double upperBound, int minCharge)
         {
             IsotopicDistribution isodist = IsotopicDistribution.GetDistribution(f, 0.1);


### PR DESCRIPTION
## What

Adds optional per-peak charge state support to `MsDataScan`, with corresponding read/write paths in the mzML I/O. The charge array is encoded as a third `<binaryDataArray>` per spectrum using PSI-MS controlled-vocabulary term [`MS:1000516` "charge array"](https://www.ebi.ac.uk/ols4/ontologies/ms/classes?obo_id=MS:1000516).

```xml
<binaryDataArray encodedLength="...">
  <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
  <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
  <cvParam cvRef="MS" accession="MS:1000516" name="charge array" value=""/>
  <binary>{base64}</binary>
</binaryDataArray>
```

## Why

mzML 1.0+ defines the charge array as a **first-class spec feature**, and tools like ProteoWizard's `msconvert`, Skyline, MZmine, mzR (Bioconductor), and pymzML already consume it when present. mzLib's writer didn't expose the API, forcing downstream callers (e.g. deisotopers wanting to publish per-peak charge state) to use side-car files.

The original code even acknowledges this gap:

```csharp
// ONLY WRITING M/Z AND INTENSITY DATA, NOT THE CHARGE! (but can add charge info later)
// CHARGE (and other stuff) CAN BE IMPORTANT IN ML APPLICATIONS!!!!!
```

This PR is the "later" the comment promised.

The motivating use case: [YADA 3.1](http://patternlabforproteomics.org/yada3/) (Yet Another Deconvolution Algorithm) deisotopes proteomic spectra and wants to publish per-peak charge state inline. Today it falls back to a side-car `.envelopes.tsv` file because mzLib's API doesn't accept charges. With this PR, YADA's deisotoped output becomes a self-describing mzML that any mzML-aware downstream tool can consume natively.

## Backwards compatibility

This change is **strictly additive**:

- Constructor parameter `chargeArray` defaults to `null`, so existing callers see no behavior change.
- mzML files without the charge array parse identically (existing `mzArray`/`intensityArray` handling is untouched).
- Conformant readers that don't recognize `MS:1000516` ignore the extra array per the mzML spec — so files emitted with charges remain compatible with any mzML consumer.

## Files changed

| File | Change |
|---|---|
| `mzLib/MassSpectrometry/MsDataScan.cs` | Adds nullable `int[] ChargeArray` property + optional constructor parameter (default `null`) |
| `mzLib/Readers/MzML/MzmlMethods.cs` | When `ChargeArray != null`, writes a third `<binaryDataArray>` with cvParam `MS:1000516` "charge array", 32-bit float, no compression. Updates the `count` attribute and array sizing logic accordingly. |
| `mzLib/Readers/MzML/Mzml.cs` | Recognizes `MS:1000516` cvParam, decodes the array (rounds the 32-bit float values back to `int`), populates `MsDataScan.ChargeArray`. |

~100 LOC total.

## Implementation notes

- **Encoding**: 32-bit float per PSI-MS convention (charges fit comfortably in 2^23). 64-bit would double file size for no precision benefit on integer values.
- **Compression**: no compression by default — charge arrays are small enough (1 int per peak ≈ ~25% of intensity-array size) that the zlib overhead isn't worth it. Could be made configurable in a follow-up if anyone needs it.
- **Array-list sizing**: the existing 2-or-5 array allocation became `2 + (3 if NoiseData) + (1 if ChargeArray)`, computed once per spectrum.
- **Reader robustness**: if the charge array length disagrees with the m/z array length, downstream code can detect and handle (`scan.ChargeArray.Length != scan.MassSpectrum.Size`). The reader doesn't enforce this — same policy as for noise arrays.

## Build status

Builds clean against current `master` (0 errors, 0 new CS warnings) on .NET 8 and .NET 10.

## Suggested test (would happily add to a follow-up)

```csharp
[Test]
public void ChargeArrayRoundTrip()
{
    var spectrum = new MzSpectrum(
        new[] { 100.0, 200.0, 300.0 },
        new[] { 1000.0, 2000.0, 3000.0 },
        shouldCopy: false);
    var charges = new[] { 2, 3, 1 };

    var scan = new MsDataScan(
        spectrum, oneBasedScanNumber: 1, msnOrder: 1,
        isCentroid: true, polarity: Polarity.Positive,
        retentionTime: 1.0,
        scanWindowRange: new MzRange(50, 1000),
        scanFilter: "FTMS + p NSI Full ms",
        mzAnalyzer: MZAnalyzerType.Orbitrap,
        totalIonCurrent: 6000, injectionTime: null,
        noiseData: null, nativeId: "scan=1",
        chargeArray: charges);

    var sourceFile = new SourceFile(
        nativeIdFormat: "scan number only nativeID format",
        massSpectrometerFileFormat: "mzML format",
        checkSum: null, fileChecksumType: "SHA-1",
        uri: new Uri("file:///test"),
        id: "test", fileName: "test.mzML");

    var dataFile = new GenericMsDataFile(new[] { scan }, sourceFile);
    string outPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "charge_roundtrip.mzML");
    MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(dataFile, outPath, writeIndexed: true);

    var reread = (Mzml)Mzml.LoadAllStaticData(outPath);
    var readBack = reread.GetOneBasedScan(1);
    CollectionAssert.AreEqual(charges, readBack.ChargeArray);
}
```

(`GenericMsDataFile` is just any concrete `MsDataFile` subclass — happy to use whatever pattern you prefer for the test project.)

Happy to iterate on naming, parameter placement, encoding choice, or test approach. Thanks for the great library!
