### PR TITLE
Add protease subtilisin

### DIFF
--- a/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
+++ b/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
@@ -118,3 +118,4 @@ StcE-trypsin	TX|T,TX|S,SX|T,SX|S,K|,R|	full		StcE/Trypsin
 CNBr_old	M|	full	MS:1001307	CNBr	
 CNBr_N	|M	full	MS:1001307	CNBr	Test on M
 ProAlanase	P|,A|	full			
+subtilisin|p	N[P]|,S[P]|,L[P]|,K[P]|,I[P]|,D[P]|,Y[P]|,V[P]|,G[P]|,F[P]|,T[P]|,E[P]|,Q[P]|,A[P]|,R[P]|	full	MS:1001312	Subtilisin

--- a/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
+++ b/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
@@ -118,4 +118,4 @@ StcE-trypsin	TX|T,TX|S,SX|T,SX|S,K|,R|	full		StcE/Trypsin
 CNBr_old	M|	full	MS:1001307	CNBr	
 CNBr_N	|M	full	MS:1001307	CNBr	Test on M
 ProAlanase	P|,A|	full			
-subtilisin|p	N[P]|,S[P]|,L[P]|,K[P]|,I[P]|,D[P]|,Y[P]|,V[P]|,G[P]|,F[P]|,T[P]|,E[P]|,Q[P]|,A[P]|,R[P]|	full	MS:1001312	Subtilisin
+subtilisin|P	N[P]|,S[P]|,L[P]|,K[P]|,I[P]|,D[P]|,Y[P]|,V[P]|,G[P]|,F[P]|,T[P]|,E[P]|,Q[P]|,A[P]|,R[P]|	full	MS:1001312	Subtilisin

--- a/mzLib/Test/ProteomicsTests/ProteolyticDigestion/ProteinDigestionTests.cs
+++ b/mzLib/Test/ProteomicsTests/ProteolyticDigestion/ProteinDigestionTests.cs
@@ -1001,24 +1001,24 @@ namespace Test.ProteomicsTests.ProteolyticDigestion
         [Test]
         public static void TestSubtilisinP_DigestsCorrectlyAndRespectsProlineRestriction()
         {
-            // Verify subtilisin|p is loaded from the embedded resource
-            Assert.That(ProteaseDictionary.Dictionary.ContainsKey("subtilisin|p"),
-                "subtilisin|p must be present in the embedded protease dictionary");
+            // Verify subtilisin|P is loaded from the embedded resource
+            Assert.That(ProteaseDictionary.Dictionary.ContainsKey("subtilisin|P"),
+                "subtilisin|P must be present in the embedded protease dictionary");
 
-            var subtilisin = ProteaseDictionary.Dictionary["subtilisin|p"];
+            var subtilisin = ProteaseDictionary.Dictionary["subtilisin|P"];
             Assert.That(subtilisin.CleavageSpecificity, Is.EqualTo(CleavageSpecificity.Full));
 
             // Basic digestion: ANKTIDE should be cut after A, N, K, T, I, D → several fragments
             var prot = new Protein("ANKTIDE", null);
             var digestionParams = new DigestionParams(
-                protease: "subtilisin|p", maxMissedCleavages: 0, minPeptideLength: 1,
+                protease: "subtilisin|P", maxMissedCleavages: 0, minPeptideLength: 1,
                 initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
 
             var peptides = prot.Digest(digestionParams, new List<Modification>(), new List<Modification>()).ToList();
 
             // Every residue except the last is a cleavage site → 7 single-AA fragments
             Assert.That(peptides.Count, Is.EqualTo(7),
-                "subtilisin|p should cleave after every residue in ANKTIDE (no prolines present)");
+                "subtilisin|P should cleave after every residue in ANKTIDE (no prolines present)");
             CollectionAssert.AreEquivalent(
                 new[] { "A", "N", "K", "T", "I", "D", "E" },
                 peptides.Select(p => p.BaseSequence).ToList());
@@ -1028,10 +1028,20 @@ namespace Test.ProteomicsTests.ProteolyticDigestion
             var protWithPro = new Protein("AKPIDE", null);
             var peptidesWithPro = protWithPro.Digest(digestionParams, new List<Modification>(), new List<Modification>()).ToList();
 
-            Assert.That(peptidesWithPro.Any(p => p.BaseSequence == "KP"),
-                "KP should be kept intact because K[P]| is inhibited before proline");
+            Assert.That(peptidesWithPro.Any(p => p.BaseSequence == "KPI"),
+                "KPI should be kept intact because K[P]| is inhibited before proline");
             Assert.That(peptidesWithPro.All(p => p.BaseSequence != "K"),
                 "K alone must not appear as a fragment when the next residue is P");
+        }
+        [Test]
+        public static void LoadProteaseDictionary_SubtilisinP_HasProlineRestrictedMotifs()
+        {
+            Assert.That(ProteaseDictionary.Dictionary.ContainsKey("subtilisin|P"), Is.True);
+            var subtilisinP = ProteaseDictionary.Dictionary["subtilisin|P"];
+
+            Assert.That(subtilisinP.CleavageSpecificity, Is.EqualTo(CleavageSpecificity.Full));
+            Assert.That(subtilisinP.DigestionMotifs.All(m => m.PreventingCleavage == "P"), Is.True,
+                "All subtilisin|P motifs should prevent cleavage before proline");
         }
     }
 }

--- a/mzLib/Test/ProteomicsTests/ProteolyticDigestion/ProteinDigestionTests.cs
+++ b/mzLib/Test/ProteomicsTests/ProteolyticDigestion/ProteinDigestionTests.cs
@@ -992,5 +992,46 @@ namespace Test.ProteomicsTests.ProteolyticDigestion
                 ProteaseDictionary.Dictionary.Remove("MyLabProtease");
             }
         }
+
+        /// <summary>
+        /// Tests that subtilisin|p is present in the protease dictionary and correctly
+        /// cleaves a peptide sequence after the expected residues (N, S, L, K, I, D, Y,
+        /// V, G, F, T, E, Q, A, R), while respecting the proline-inhibition rule.
+        /// </summary>
+        [Test]
+        public static void TestSubtilisinP_DigestsCorrectlyAndRespectsProlineRestriction()
+        {
+            // Verify subtilisin|p is loaded from the embedded resource
+            Assert.That(ProteaseDictionary.Dictionary.ContainsKey("subtilisin|p"),
+                "subtilisin|p must be present in the embedded protease dictionary");
+
+            var subtilisin = ProteaseDictionary.Dictionary["subtilisin|p"];
+            Assert.That(subtilisin.CleavageSpecificity, Is.EqualTo(CleavageSpecificity.Full));
+
+            // Basic digestion: ANKTIDE should be cut after A, N, K, T, I, D → several fragments
+            var prot = new Protein("ANKTIDE", null);
+            var digestionParams = new DigestionParams(
+                protease: "subtilisin|p", maxMissedCleavages: 0, minPeptideLength: 1,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+
+            var peptides = prot.Digest(digestionParams, new List<Modification>(), new List<Modification>()).ToList();
+
+            // Every residue except the last is a cleavage site → 7 single-AA fragments
+            Assert.That(peptides.Count, Is.EqualTo(7),
+                "subtilisin|p should cleave after every residue in ANKTIDE (no prolines present)");
+            CollectionAssert.AreEquivalent(
+                new[] { "A", "N", "K", "T", "I", "D", "E" },
+                peptides.Select(p => p.BaseSequence).ToList());
+
+            // Proline-restriction: cleavage AFTER K is inhibited when followed by P
+            // AKPIDE → K is followed by P → K| should NOT fire; cleavage after A, I, D only
+            var protWithPro = new Protein("AKPIDE", null);
+            var peptidesWithPro = protWithPro.Digest(digestionParams, new List<Modification>(), new List<Modification>()).ToList();
+
+            Assert.That(peptidesWithPro.Any(p => p.BaseSequence == "KP"),
+                "KP should be kept intact because K[P]| is inhibited before proline");
+            Assert.That(peptidesWithPro.All(p => p.BaseSequence != "K"),
+                "K alone must not appear as a fragment when the next residue is P");
+        }
     }
 }


### PR DESCRIPTION
This pull request adds support for the protease `subtilisin|p` to the protease dictionary and introduces a corresponding unit test to ensure its correct behavior. The main focus is on enabling and verifying subtilisin|p's cleavage specificity, including proper handling of the proline-inhibition rule.

**Protease definition:**

* Added a new entry for `subtilisin|p` in the `proteases.tsv` file, specifying its cleavage after several amino acids (N, S, L, K, I, D, Y, V, G, F, T, E, Q, A, R) except when the following residue is proline.

**Testing and validation:**

* Introduced a new unit test `TestSubtilisinP_DigestsCorrectlyAndRespectsProlineRestriction` in `ProteinDigestionTests.cs` to:
  - Check that `subtilisin|p` is loaded into the protease dictionary.
  - Verify correct cleavage of a sample peptide sequence (no proline inhibition).
  - Ensure the proline-inhibition rule is respected (no cleavage when the target residue is followed by proline).