### PR TITLE
Decon Param Equality: IEquatable on DeconParams and AverageResidue

### DIFF
--- a/mzLib/MassSpectrometry/Deconvolution/AverageResidue/AverageResidue.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/AverageResidue/AverageResidue.cs
@@ -1,10 +1,12 @@
-﻿namespace MassSpectrometry;
+using System;
+
+namespace MassSpectrometry;
 
 /// <summary>
 /// Represents the average residue and is used for most abundant isotopic peak to monoisotopic peak difference
 /// </summary>
 /// <remarks>CAREFUL: This is called a lot during <see cref="ClassicDeconvolutionAlgorithm"/> and care should be taken to precalculate as many values as possible when implementing a new type</remarks>
-public abstract class AverageResidue
+public abstract class AverageResidue : IEquatable<AverageResidue>
 {
     protected const double FineRes = 0.125;
     protected const double MinRes = 1e-8;
@@ -13,4 +15,30 @@ public abstract class AverageResidue
     public abstract double[] GetAllTheoreticalMasses(int index);
     public abstract double[] GetAllTheoreticalIntensities(int index);
     public abstract double GetDiffToMonoisotopic(int index);
+
+    #region IEquatable<AverageResidue>
+
+    public bool Equals(AverageResidue? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        if (GetType() != other.GetType()) return false;
+        return EqualProperties(other);
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as AverageResidue);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(GetType());
+        AddHashCodes(hash);
+        return hash.ToHashCode();
+    }
+
+    protected virtual bool EqualProperties(AverageResidue other) => true;
+
+    protected virtual void AddHashCodes(HashCode hash) { }
+
+    #endregion
 }

--- a/mzLib/MassSpectrometry/Deconvolution/AverageResidue/DecoyAveragine.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/AverageResidue/DecoyAveragine.cs
@@ -1,6 +1,7 @@
-﻿using Chemistry;
+using Chemistry;
 using System;
 using System.Linq;
+
 
 namespace MassSpectrometry;
 
@@ -114,6 +115,23 @@ public sealed class DecoyAveragine : AverageResidue
     /// </summary>
     public override double GetDiffToMonoisotopic(int index)
         => _real.GetDiffToMonoisotopic(index);
+
+    #region IEquatable<DecoyAveragine>
+
+    protected override bool EqualProperties(AverageResidue other)
+    {
+        var o = (DecoyAveragine)other;
+        return DecoyIsotopeSpacing.Equals(o.DecoyIsotopeSpacing)
+            && _real.Equals(o._real);
+    }
+
+    protected override void AddHashCodes(HashCode hash)
+    {
+        hash.Add(DecoyIsotopeSpacing);
+        hash.Add(_real);
+    }
+
+    #endregion
 
     // ── Constructor ───────────────────────────────────────────────────────────
 

--- a/mzLib/MassSpectrometry/Deconvolution/Parameters/ClassicDeconvolutionParameters.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Parameters/ClassicDeconvolutionParameters.cs
@@ -1,4 +1,5 @@
-﻿#nullable enable
+#nullable enable
+using System;
 using Chemistry;
 
 namespace MassSpectrometry
@@ -26,6 +27,34 @@ namespace MassSpectrometry
             IntensityRatioLimit = intensityRatio;
             DeconvolutionTolerancePpm = deconPpm;
         }
+
+        #region IEquatable<ClassicDeconvolutionParameters>
+
+        protected override bool EqualProperties(DeconvolutionParameters other)
+        {
+            var o = (ClassicDeconvolutionParameters)other;
+            return DeconvolutionTolerancePpm.Equals(o.DeconvolutionTolerancePpm)
+                && IntensityRatioLimit.Equals(o.IntensityRatioLimit);
+        }
+
+        protected override void AddHashCodes(HashCode hash)
+        {
+            hash.Add(DeconvolutionTolerancePpm);
+            hash.Add(IntensityRatioLimit);
+        }
+
+        public override ClassicDeconvolutionParameters Clone()
+        {
+            return new ClassicDeconvolutionParameters(
+                MinAssumedChargeState, MaxAssumedChargeState,
+                DeconvolutionTolerancePpm, IntensityRatioLimit,
+                Polarity, AverageResidueModel, ExpectedIsotopeSpacing)
+            {
+                UseGenericScore = UseGenericScore
+            };
+        }
+
+        #endregion
 
         // Thread-safe lazy caching of decoy parameters using double-checked locking.
         // The ??= operator alone is not atomic: two threads can both observe null,

--- a/mzLib/MassSpectrometry/Deconvolution/Parameters/DeconvolutionParameters.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Parameters/DeconvolutionParameters.cs
@@ -1,9 +1,10 @@
 #nullable enable
+using System;
 using Chemistry;
 
 namespace MassSpectrometry
 {
-    public abstract class DeconvolutionParameters
+    public abstract class DeconvolutionParameters : IEquatable<DeconvolutionParameters>
     {
         public abstract DeconvolutionType DeconvolutionType { get; protected set; }
         public int MinAssumedChargeState { get; set; }
@@ -62,5 +63,44 @@ namespace MassSpectrometry
         /// subclasses keep dispatching via <see cref="DeconvolutionType"/>.
         /// </summary>
         public virtual DeconvolutionAlgorithm? CreateAlgorithm() => null;
+
+        #region IEquatable<DeconvolutionParameters>
+
+        public bool Equals(DeconvolutionParameters? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            if (GetType() != other.GetType()) return false;
+            return MinAssumedChargeState == other.MinAssumedChargeState
+                && MaxAssumedChargeState == other.MaxAssumedChargeState
+                && Polarity == other.Polarity
+                && ExpectedIsotopeSpacing.Equals(other.ExpectedIsotopeSpacing)
+                && UseGenericScore == other.UseGenericScore
+                && AverageResidueModel.GetType() == other.AverageResidueModel.GetType()
+                && EqualProperties(other);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as DeconvolutionParameters);
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(MinAssumedChargeState);
+            hash.Add(MaxAssumedChargeState);
+            hash.Add(Polarity);
+            hash.Add(ExpectedIsotopeSpacing);
+            hash.Add(UseGenericScore);
+            hash.Add(AverageResidueModel.GetType());
+            AddHashCodes(hash);
+            return hash.ToHashCode();
+        }
+
+        protected abstract bool EqualProperties(DeconvolutionParameters other);
+
+        protected abstract void AddHashCodes(HashCode hash);
+
+        #endregion
+
+        public abstract DeconvolutionParameters Clone();
     }
 }

--- a/mzLib/MassSpectrometry/Deconvolution/Parameters/DeconvolutionParameters.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Parameters/DeconvolutionParameters.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using Chemistry;
 
 namespace MassSpectrometry
@@ -76,7 +77,7 @@ namespace MassSpectrometry
                 && Polarity == other.Polarity
                 && ExpectedIsotopeSpacing.Equals(other.ExpectedIsotopeSpacing)
                 && UseGenericScore == other.UseGenericScore
-                && AverageResidueModel.Equals(other.AverageResidueModel)
+                && EqualityComparer<AverageResidue>.Default.Equals(AverageResidueModel, other.AverageResidueModel)
                 && EqualProperties(other);
         }
 

--- a/mzLib/MassSpectrometry/Deconvolution/Parameters/DeconvolutionParameters.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Parameters/DeconvolutionParameters.cs
@@ -76,7 +76,7 @@ namespace MassSpectrometry
                 && Polarity == other.Polarity
                 && ExpectedIsotopeSpacing.Equals(other.ExpectedIsotopeSpacing)
                 && UseGenericScore == other.UseGenericScore
-                && AverageResidueModel.GetType() == other.AverageResidueModel.GetType()
+                && AverageResidueModel.Equals(other.AverageResidueModel)
                 && EqualProperties(other);
         }
 
@@ -90,7 +90,7 @@ namespace MassSpectrometry
             hash.Add(Polarity);
             hash.Add(ExpectedIsotopeSpacing);
             hash.Add(UseGenericScore);
-            hash.Add(AverageResidueModel.GetType());
+            hash.Add(AverageResidueModel);
             AddHashCodes(hash);
             return hash.ToHashCode();
         }

--- a/mzLib/MassSpectrometry/Deconvolution/Parameters/ExampleNewDeconvolutionParametersTemplate.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Parameters/ExampleNewDeconvolutionParametersTemplate.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace MassSpectrometry
@@ -15,5 +15,18 @@ namespace MassSpectrometry
 
         // This algorithm does not yet support decoy deconvolution.
         public override DeconvolutionParameters? ToDecoyParameters() => null;
+
+        protected override bool EqualProperties(DeconvolutionParameters other) => true;
+
+        protected override void AddHashCodes(HashCode hash) { }
+
+        public override ExampleNewDeconvolutionParametersTemplate Clone()
+        {
+            return new ExampleNewDeconvolutionParametersTemplate(
+                MinAssumedChargeState, MaxAssumedChargeState, Polarity)
+            {
+                UseGenericScore = UseGenericScore
+            };
+        }
     }
 }

--- a/mzLib/MassSpectrometry/Deconvolution/Parameters/IsoDecDeconvolutionParameters.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Parameters/IsoDecDeconvolutionParameters.cs
@@ -253,7 +253,8 @@ public class IsoDecDeconvolutionParameters : DeconvolutionParameters
         hash.Add(MinAreaCovered);
         hash.Add(DataThreshold);
         hash.Add(ReportMulitpleMonoisos);
-        hash.Add(MzWindow.GetHashCode());
+        foreach (var mz in MzWindow)
+            hash.Add(mz);
     }
 
     public override IsoDecDeconvolutionParameters Clone()

--- a/mzLib/MassSpectrometry/Deconvolution/Parameters/IsoDecDeconvolutionParameters.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Parameters/IsoDecDeconvolutionParameters.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Chemistry;
 
@@ -224,6 +226,58 @@ public class IsoDecDeconvolutionParameters : DeconvolutionParameters
         if (Polarity == Polarity.Negative)
             AdductMass = (float)-1.00727276467;
     }
+
+    #region IEquatable<IsoDecDeconvolutionParameters>
+
+    protected override bool EqualProperties(DeconvolutionParameters other)
+    {
+        var o = (IsoDecDeconvolutionParameters)other;
+        return PhaseRes == o.PhaseRes
+            && CssThreshold.Equals(o.CssThreshold)
+            && MatchTolerance.Equals(o.MatchTolerance)
+            && MaxShift == o.MaxShift
+            && KnockdownRounds == o.KnockdownRounds
+            && MinAreaCovered.Equals(o.MinAreaCovered)
+            && DataThreshold.Equals(o.DataThreshold)
+            && ReportMulitpleMonoisos == o.ReportMulitpleMonoisos
+            && MzWindow.SequenceEqual(o.MzWindow);
+    }
+
+    protected override void AddHashCodes(HashCode hash)
+    {
+        hash.Add(PhaseRes);
+        hash.Add(CssThreshold);
+        hash.Add(MatchTolerance);
+        hash.Add(MaxShift);
+        hash.Add(KnockdownRounds);
+        hash.Add(MinAreaCovered);
+        hash.Add(DataThreshold);
+        hash.Add(ReportMulitpleMonoisos);
+        hash.Add(MzWindow.GetHashCode());
+    }
+
+    public override IsoDecDeconvolutionParameters Clone()
+    {
+        var clone = new IsoDecDeconvolutionParameters(
+            polarity: Polarity,
+            phaseRes: PhaseRes,
+            reportMultipleMonoisos: ReportMulitpleMonoisos,
+            cssThreshold: CssThreshold,
+            matchTolerance: MatchTolerance,
+            maxShift: MaxShift,
+            mzWindow: (float[])MzWindow.Clone(),
+            knockdownRounds: KnockdownRounds,
+            minAreaCovered: MinAreaCovered,
+            relativeDataThreshold: DataThreshold,
+            averageResidueModel: AverageResidueModel,
+            expectedIsotopeSpacing: ExpectedIsotopeSpacing)
+        {
+            UseGenericScore = UseGenericScore
+        };
+        return clone;
+    }
+
+    #endregion
 
     // Thread-safe lazy caching of decoy parameters using double-checked locking.
     // See ClassicDeconvolutionParameters for the full rationale: ??= alone is not

--- a/mzLib/MassSpectrometry/Deconvolution/Parameters/MultipleDeconParameters.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Parameters/MultipleDeconParameters.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Chemistry;
 
 namespace MassSpectrometry;
+
 public class MultipleDeconParameters : DeconvolutionParameters
 {
     public override DeconvolutionType DeconvolutionType { get; protected set; } = DeconvolutionType.Multiple;
@@ -18,6 +19,33 @@ public class MultipleDeconParameters : DeconvolutionParameters
             throw new ArgumentException(
                 "At least one sub-deconvolution parameter set is required.", nameof(deconParameters));
     }
+
+    #region IEquatable<MultipleDeconParameters>
+
+    protected override bool EqualProperties(DeconvolutionParameters other)
+    {
+        var o = (MultipleDeconParameters)other;
+        return Parameters.SequenceEqual(o.Parameters);
+    }
+
+    protected override void AddHashCodes(HashCode hash)
+    {
+        foreach (var p in Parameters)
+            hash.Add(p);
+    }
+
+    public override MultipleDeconParameters Clone()
+    {
+        return new MultipleDeconParameters(
+            Parameters.Select(p => (DeconvolutionParameters)p.Clone()),
+            MinAssumedChargeState, MaxAssumedChargeState,
+            Polarity, AverageResidueModel, ExpectedIsotopeSpacing)
+        {
+            UseGenericScore = UseGenericScore
+        };
+    }
+
+    #endregion
 
     private volatile DeconvolutionParameters? _decoyParams = null;
     private volatile bool _decoyComputed;

--- a/mzLib/Omics/EmpiricalAverageResidue.cs
+++ b/mzLib/Omics/EmpiricalAverageResidue.cs
@@ -1,4 +1,5 @@
-﻿using Chemistry;
+using System;
+using Chemistry;
 using MassSpectrometry;
 using Omics.Digestion;
 using Omics.Modifications;
@@ -9,6 +10,8 @@ public record struct AverageResidueComposition(double C, double H, double O, dou
 
 public class EmpiricalAverageResidue : AverageResidue
 {
+    public AverageResidueComposition Composition { get; }
+
     public readonly double[][] AllMasses = new double[NumAveraginesToGenerate][];
     public readonly double[][] AllIntensities = new double[NumAveraginesToGenerate][];
     public readonly double[] MostIntenseMasses = new double[NumAveraginesToGenerate];
@@ -31,6 +34,7 @@ public class EmpiricalAverageResidue : AverageResidue
 
     public EmpiricalAverageResidue(AverageResidueComposition composition)
     {
+        Composition = composition;
         for (int i = 0; i < NumAveraginesToGenerate; i++)
         {
             double averagineMultiplier = (i + 1) / 4.0;
@@ -83,5 +87,16 @@ public class EmpiricalAverageResidue : AverageResidue
         double averageSe = totalChemicalFormula.CountWithIsotopes(PeriodicTable.GetElement("Se")) / (double)totalResidues;
 
         return new AverageResidueComposition(averageC, averageH, averageO, averageN, averageP, averageS, averageSe);
+    }
+
+    protected override bool EqualProperties(AverageResidue other)
+    {
+        var o = (EmpiricalAverageResidue)other;
+        return Composition.Equals(o.Composition);
+    }
+
+    protected override void AddHashCodes(HashCode hash)
+    {
+        hash.Add(Composition);
     }
 }

--- a/mzLib/Omics/EmpiricalAverageResidue.cs
+++ b/mzLib/Omics/EmpiricalAverageResidue.cs
@@ -8,6 +8,14 @@ namespace Omics;
 
 public record struct AverageResidueComposition(double C, double H, double O, double N, double P, double S, double Se);
 
+/// <summary>
+/// Average residue model derived from empirical data. Equality is composition-based:
+/// two instances constructed from equal <see cref="Composition"/> values compare equal,
+/// regardless of the state of derived array fields (<see cref="AllMasses"/>,
+/// <see cref="AllIntensities"/>, <see cref="MostIntenseMasses"/>,
+/// <see cref="DiffToMonoisotopic"/>), which are deterministically computed from
+/// <see cref="Composition"/> at construction time.
+/// </summary>
 public class EmpiricalAverageResidue : AverageResidue
 {
     public AverageResidueComposition Composition { get; }

--- a/mzLib/Readers/Deconvolution/FromFileDeconvolutionParameters.cs
+++ b/mzLib/Readers/Deconvolution/FromFileDeconvolutionParameters.cs
@@ -128,7 +128,8 @@ namespace Readers
                 _featuresMzAscending.ToList(),
                 MinAssumedChargeState, MaxAssumedChargeState, Polarity)
             {
-                UseGenericScore = UseGenericScore
+                UseGenericScore = UseGenericScore,
+                OriginalFilePath = OriginalFilePath
             };
         }
 

--- a/mzLib/Readers/Deconvolution/FromFileDeconvolutionParameters.cs
+++ b/mzLib/Readers/Deconvolution/FromFileDeconvolutionParameters.cs
@@ -37,6 +37,9 @@ namespace Readers
         private readonly List<ISingleChargeMs1Feature> _featuresMzAscending;
         private readonly double[] _mzKeys;
 
+        protected string OriginalFilePath { get; set; }
+
+
         /// <summary>
         /// The pre-loaded per-charge features the algorithm filters against, sorted
         /// by ascending <see cref="ISingleChargeMs1Feature.Mz"/>.
@@ -61,6 +64,8 @@ namespace Readers
                     $"File at '{filePath}' is not a recognized MS1 feature file. " +
                     $"Detected type: {resultFile.GetType().Name}. " +
                     "Expected an Ms1Feature (.ms1.feature) or Dinosaur (.feature.tsv) file.");
+
+            OriginalFilePath = filePath;
 
             resultFile.LoadResults();
             (_featuresMzAscending, _mzKeys) = SortAndIndex(featureFile.GetMs1Features());
@@ -100,6 +105,34 @@ namespace Readers
             int idx = Array.BinarySearch(_mzKeys, minMz);
             return idx < 0 ? ~idx : idx;
         }
+
+        #region IEquatable<FromFileDeconvolutionParameters>
+
+        protected override bool EqualProperties(DeconvolutionParameters other)
+        {
+            var o = (FromFileDeconvolutionParameters)other;
+            if (Features.Count != o.Features.Count) return false;
+            if (OriginalFilePath != o.OriginalFilePath) return false;
+            return true;
+        }
+
+        protected override void AddHashCodes(HashCode hash)
+        {
+            hash.Add(Features.Count);
+            hash.Add(OriginalFilePath);
+        }
+
+        public override FromFileDeconvolutionParameters Clone()
+        {
+            return new FromFileDeconvolutionParameters(
+                _featuresMzAscending.ToList(),
+                MinAssumedChargeState, MaxAssumedChargeState, Polarity)
+            {
+                UseGenericScore = UseGenericScore
+            };
+        }
+
+        #endregion
 
         /// <summary>
         /// Polymorphic factory hook: returns a <see cref="FromFileDeconvolutionAlgorithm"/>

--- a/mzLib/Test/Deconvolution/TestDeconvolutionParametersEqualityAndClone.cs
+++ b/mzLib/Test/Deconvolution/TestDeconvolutionParametersEqualityAndClone.cs
@@ -1,0 +1,409 @@
+using System;
+using System.Linq;
+using Chemistry;
+using MassSpectrometry;
+using NUnit.Framework;
+using Readers;
+
+namespace Test
+{
+    [TestFixture]
+    public class TestDeconvolutionParametersEqualityAndClone
+    {
+        // ══════════════════════════════════════════════════════════════════════
+        // ClassicDeconvolutionParameters
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Test]
+        public void Classic_Equal_SameValues_AreEqual()
+        {
+            var a = new ClassicDeconvolutionParameters(1, 12, 4.0, 3.0);
+            var b = new ClassicDeconvolutionParameters(1, 12, 4.0, 3.0);
+            Assert.That(a, Is.EqualTo(b));
+        }
+
+        [Test]
+        public void Classic_Equal_DifferentIntensityRatio_AreNotEqual()
+        {
+            var a = new ClassicDeconvolutionParameters(1, 12, 4.0, 3.0);
+            var b = new ClassicDeconvolutionParameters(1, 12, 4.0, 5.0);
+            Assert.That(a, Is.Not.EqualTo(b));
+        }
+
+        [Test]
+        public void Classic_Equal_DifferentTolerancePpm_AreNotEqual()
+        {
+            var a = new ClassicDeconvolutionParameters(1, 12, 4.0, 3.0);
+            var b = new ClassicDeconvolutionParameters(1, 12, 7.0, 3.0);
+            Assert.That(a, Is.Not.EqualTo(b));
+        }
+
+        [Test]
+        public void Classic_Equal_SameReference_IsEqual()
+        {
+            var a = new ClassicDeconvolutionParameters(1, 12, 4.0, 3.0);
+            Assert.That(a, Is.EqualTo(a));
+        }
+
+        [Test]
+        public void Classic_Equal_Null_IsNotEqual()
+        {
+            var a = new ClassicDeconvolutionParameters(1, 12, 4.0, 3.0);
+            Assert.That(a.Equals(null), Is.False);
+        }
+
+        [Test]
+        public void Classic_Equal_CrossType_IsNotEqual()
+        {
+            var classic = new ClassicDeconvolutionParameters(1, 12, 4.0, 3.0);
+            var isoDec = new IsoDecDeconvolutionParameters();
+            Assert.That(classic, Is.Not.EqualTo(isoDec));
+            Assert.That(isoDec, Is.Not.EqualTo(classic));
+        }
+
+        [Test]
+        public void Classic_GetHashCode_EqualObjects_Match()
+        {
+            var a = new ClassicDeconvolutionParameters(2, 15, 7.5, 4.0, Polarity.Negative);
+            var b = new ClassicDeconvolutionParameters(2, 15, 7.5, 4.0, Polarity.Negative);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+        }
+
+        [Test]
+        public void Classic_Clone_ReturnsNewReference()
+        {
+            var original = new ClassicDeconvolutionParameters(1, 12, 4.0, 3.0);
+            var clone = original.Clone();
+            Assert.That(clone, Is.Not.SameAs(original));
+        }
+
+        [Test]
+        public void Classic_Clone_EqualsOriginal()
+        {
+            var original = new ClassicDeconvolutionParameters(2, 15, 7.5, 4.0, Polarity.Negative);
+            var clone = original.Clone();
+            Assert.That(clone, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void Classic_Clone_ModificationDoesNotAffectOriginal()
+        {
+            var original = new ClassicDeconvolutionParameters(1, 12, 4.0, 3.0);
+            var clone = original.Clone();
+            clone.MinAssumedChargeState = 99;
+            Assert.That(original.MinAssumedChargeState, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Classic_Clone_PreservesUseGenericScore()
+        {
+            var original = new ClassicDeconvolutionParameters(1, 12, 4.0, 3.0)
+            {
+                UseGenericScore = true
+            };
+            var clone = original.Clone();
+            Assert.That(clone.UseGenericScore, Is.True);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        // IsoDecDeconvolutionParameters
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Test]
+        public void IsoDec_Equal_SameValues_AreEqual()
+        {
+            var a = new IsoDecDeconvolutionParameters(
+                polarity: Polarity.Positive,
+                cssThreshold: 0.85f,
+                matchTolerance: 7.0f,
+                maxShift: 5);
+            var b = new IsoDecDeconvolutionParameters(
+                polarity: Polarity.Positive,
+                cssThreshold: 0.85f,
+                matchTolerance: 7.0f,
+                maxShift: 5);
+            Assert.That(a, Is.EqualTo(b));
+        }
+
+        [Test]
+        public void IsoDec_Equal_DifferentCssThreshold_AreNotEqual()
+        {
+            var a = new IsoDecDeconvolutionParameters(polarity: Polarity.Positive, cssThreshold: 0.7f);
+            var b = new IsoDecDeconvolutionParameters(polarity: Polarity.Positive, cssThreshold: 0.85f);
+            Assert.That(a, Is.Not.EqualTo(b));
+        }
+
+        [Test]
+        public void IsoDec_Equal_SameReference_IsEqual()
+        {
+            var a = new IsoDecDeconvolutionParameters();
+            Assert.That(a, Is.EqualTo(a));
+        }
+
+        [Test]
+        public void IsoDec_Equal_Null_IsNotEqual()
+        {
+            var a = new IsoDecDeconvolutionParameters();
+            Assert.That(a.Equals(null), Is.False);
+        }
+
+        [Test]
+        public void IsoDec_GetHashCode_EqualObjects_Match()
+        {
+            var a = new IsoDecDeconvolutionParameters(polarity: Polarity.Positive, cssThreshold: 0.8f);
+            var b = new IsoDecDeconvolutionParameters(polarity: Polarity.Positive, cssThreshold: 0.8f);
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+        }
+
+        [Test]
+        public void IsoDec_Clone_ReturnsNewReference()
+        {
+            var original = new IsoDecDeconvolutionParameters();
+            var clone = original.Clone();
+            Assert.That(clone, Is.Not.SameAs(original));
+        }
+
+        [Test]
+        public void IsoDec_Clone_EqualsOriginal()
+        {
+            var original = new IsoDecDeconvolutionParameters(
+                polarity: Polarity.Positive,
+                cssThreshold: 0.85f,
+                matchTolerance: 7.0f,
+                maxShift: 5,
+                knockdownRounds: 3,
+                minAreaCovered: 0.30f,
+                relativeDataThreshold: 0.10f);
+            var clone = original.Clone();
+            Assert.That(clone, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void IsoDec_Clone_MzWindowIsDeepCopy()
+        {
+            var original = new IsoDecDeconvolutionParameters();
+            var clone = original.Clone();
+            clone.MzWindow[0] = 9999f;
+            Assert.That(original.MzWindow[0], Is.Not.EqualTo(9999f));
+        }
+
+        [Test]
+        public void IsoDec_Clone_PreservesUseGenericScore()
+        {
+            var original = new IsoDecDeconvolutionParameters
+            {
+                UseGenericScore = true
+            };
+            var clone = original.Clone();
+            Assert.That(clone.UseGenericScore, Is.True);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        // MultipleDeconParameters
+        // ══════════════════════════════════════════════════════════════════════
+
+        private static ClassicDeconvolutionParameters DefaultClassic()
+            => new ClassicDeconvolutionParameters(1, 12, 4.0, 3.0);
+
+        private static ClassicDeconvolutionParameters OtherClassic()
+            => new ClassicDeconvolutionParameters(1, 12, 7.0, 5.0);
+
+        [Test]
+        public void MultipleDecon_Equal_SameValues_AreEqual()
+        {
+            var sub = DefaultClassic();
+            var a = new MultipleDeconParameters(new[] { sub }, 1, 12);
+            var b = new MultipleDeconParameters(new[] { sub.Clone() }, 1, 12);
+            Assert.That(a, Is.EqualTo(b));
+        }
+
+        [Test]
+        public void MultipleDecon_Equal_DifferentSubParams_AreNotEqual()
+        {
+            var a = new MultipleDeconParameters(new[] { DefaultClassic() }, 1, 12);
+            var b = new MultipleDeconParameters(new[] { OtherClassic() }, 1, 12);
+            Assert.That(a, Is.Not.EqualTo(b));
+        }
+
+        [Test]
+        public void MultipleDecon_Equal_DifferentSubCount_AreNotEqual()
+        {
+            var a = new MultipleDeconParameters(new[] { DefaultClassic(), OtherClassic() }, 1, 12);
+            var b = new MultipleDeconParameters(new[] { DefaultClassic() }, 1, 12);
+            Assert.That(a, Is.Not.EqualTo(b));
+        }
+
+        [Test]
+        public void MultipleDecon_Equal_SameReference_IsEqual()
+        {
+            var a = new MultipleDeconParameters(new[] { DefaultClassic() }, 1, 12);
+            Assert.That(a, Is.EqualTo(a));
+        }
+
+        [Test]
+        public void MultipleDecon_Equal_Null_IsNotEqual()
+        {
+            var a = new MultipleDeconParameters(new[] { DefaultClassic() }, 1, 12);
+            Assert.That(a.Equals(null), Is.False);
+        }
+
+        [Test]
+        public void MultipleDecon_Clone_ReturnsNewReference()
+        {
+            var original = new MultipleDeconParameters(new[] { DefaultClassic() }, 1, 12);
+            var clone = original.Clone();
+            Assert.That(clone, Is.Not.SameAs(original));
+        }
+
+        [Test]
+        public void MultipleDecon_Clone_EqualsOriginal()
+        {
+            var original = new MultipleDeconParameters(new[] { DefaultClassic(), OtherClassic() }, 1, 12);
+            var clone = original.Clone();
+            Assert.That(clone, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void MultipleDecon_Clone_SubParamsAreDeepCopy()
+        {
+            var original = new MultipleDeconParameters(new[] { DefaultClassic() }, 1, 12);
+            var clone = original.Clone();
+            clone.Parameters[0].MinAssumedChargeState = 99;
+            Assert.That(original.Parameters[0].MinAssumedChargeState, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void MultipleDecon_Clone_PreservesUseGenericScore()
+        {
+            var original = new MultipleDeconParameters(new[] { DefaultClassic() }, 1, 12)
+            {
+                UseGenericScore = true
+            };
+            var clone = original.Clone();
+            Assert.That(clone.UseGenericScore, Is.True);
+        }
+
+        [Test]
+        public void MultipleDecon_ToDecoyParameters_AllFromFile_ReturnsNull()
+        {
+            var ff1 = new FromFileDeconvolutionParameters(Enumerable.Empty<ISingleChargeMs1Feature>(), 1, 60);
+            var ff2 = new FromFileDeconvolutionParameters(Enumerable.Empty<ISingleChargeMs1Feature>(), 1, 60);
+            var p = new MultipleDeconParameters(new DeconvolutionParameters[] { ff1, ff2 }, 1, 60);
+            Assert.That(p.ToDecoyParameters(), Is.Null);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        // ExampleNewDeconvolutionParametersTemplate
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Test]
+        public void ExampleTemplate_Equal_SameValues_AreEqual()
+        {
+            var a = new ExampleNewDeconvolutionParametersTemplate(1, 12);
+            var b = new ExampleNewDeconvolutionParametersTemplate(1, 12);
+            Assert.That(a, Is.EqualTo(b));
+        }
+
+        [Test]
+        public void ExampleTemplate_Equal_DifferentMinCharge_AreNotEqual()
+        {
+            var a = new ExampleNewDeconvolutionParametersTemplate(1, 12);
+            var b = new ExampleNewDeconvolutionParametersTemplate(2, 12);
+            Assert.That(a, Is.Not.EqualTo(b));
+        }
+
+        [Test]
+        public void ExampleTemplate_Clone_ReturnsNewReference()
+        {
+            var original = new ExampleNewDeconvolutionParametersTemplate(1, 12);
+            var clone = original.Clone();
+            Assert.That(clone, Is.Not.SameAs(original));
+        }
+
+        [Test]
+        public void ExampleTemplate_Clone_EqualsOriginal()
+        {
+            var original = new ExampleNewDeconvolutionParametersTemplate(2, 15, Polarity.Negative)
+            {
+                UseGenericScore = true
+            };
+            var clone = original.Clone();
+            Assert.That(clone, Is.EqualTo(original));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        // FromFileDeconvolutionParameters
+        // ══════════════════════════════════════════════════════════════════════
+
+        private static SingleChargeMs1Feature Feature(double mz = 600.0, int charge = 2,
+            double rtStart = 10.0, double rtEnd = 15.0, double intensity = 1e5)
+            => new SingleChargeMs1Feature(mz, charge, rtStart, rtEnd, intensity);
+
+        [Test]
+        public void FromFile_Equal_SameFeatures_AreEqual()
+        {
+            var feats = new[] { Feature(), Feature(601.0, 3) };
+            var a = new FromFileDeconvolutionParameters(feats, 1, 60);
+            var b = new FromFileDeconvolutionParameters(feats, 1, 60);
+            Assert.That(a, Is.EqualTo(b));
+        }
+
+        [Test]
+        public void FromFile_Equal_DifferentFeatureCount_AreNotEqual()
+        {
+            var a = new FromFileDeconvolutionParameters(new[] { Feature(), Feature(601.0, 3) }, 1, 60);
+            var b = new FromFileDeconvolutionParameters(new[] { Feature() }, 1, 60);
+            Assert.That(a, Is.Not.EqualTo(b));
+        }
+
+        [Test]
+        public void FromFile_Equal_SameReference_IsEqual()
+        {
+            var a = new FromFileDeconvolutionParameters(new[] { Feature() }, 1, 60);
+            Assert.That(a, Is.EqualTo(a));
+        }
+
+        [Test]
+        public void FromFile_Equal_Null_IsNotEqual()
+        {
+            var a = new FromFileDeconvolutionParameters(new[] { Feature() }, 1, 60);
+            Assert.That(a.Equals(null), Is.False);
+        }
+
+        [Test]
+        public void FromFile_Equal_CrossType_IsNotEqual()
+        {
+            var fromFile = new FromFileDeconvolutionParameters(new[] { Feature() }, 1, 60);
+            var classic = new ClassicDeconvolutionParameters(1, 12, 4.0, 3.0);
+            Assert.That(fromFile, Is.Not.EqualTo(classic));
+        }
+
+        [Test]
+        public void FromFile_Clone_ReturnsNewReference()
+        {
+            var original = new FromFileDeconvolutionParameters(new[] { Feature() }, 1, 60);
+            var clone = original.Clone();
+            Assert.That(clone, Is.Not.SameAs(original));
+        }
+
+        [Test]
+        public void FromFile_Clone_EqualsOriginal()
+        {
+            var feats = new[] { Feature(), Feature(601.0, 3, intensity: 2e5) };
+            var original = new FromFileDeconvolutionParameters(feats, 1, 60);
+            var clone = original.Clone();
+            Assert.That(clone, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void FromFile_Clone_PreservesUseGenericScore()
+        {
+            var original = new FromFileDeconvolutionParameters(new[] { Feature() }, 1, 60)
+            {
+                UseGenericScore = true
+            };
+            var clone = original.Clone();
+            Assert.That(clone.UseGenericScore, Is.True);
+        }
+    }
+}

--- a/mzLib/Test/MassSpectrometryTests/TestFromFileDeconvolution.cs
+++ b/mzLib/Test/MassSpectrometryTests/TestFromFileDeconvolution.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -351,6 +352,15 @@ namespace Test.MassSpectrometryTests
             public override DeconvolutionType DeconvolutionType { get; protected set; } = DeconvolutionType.FromFile;
             public FromFileParamsWithoutAlgorithmOverride() : base(minCharge: 1, maxCharge: 10) { }
             public override DeconvolutionParameters ToDecoyParameters() => null;
+            protected override bool EqualProperties(DeconvolutionParameters other) => true;
+            protected override void AddHashCodes(HashCode hash) { }
+            public override FromFileParamsWithoutAlgorithmOverride Clone()
+            {
+                return new FromFileParamsWithoutAlgorithmOverride
+                {
+                    UseGenericScore = UseGenericScore
+                };
+            }
         }
 
         [Test]


### PR DESCRIPTION
This pull request introduces a standardized implementation of equality and cloning for deconvolution parameter classes and average residue models in the mass spectrometry codebase. By implementing `IEquatable<T>`, overriding `Equals`, `GetHashCode`, and adding `Clone` methods, the code now supports robust value-based comparisons and deep copying of parameter objects. This will help with testing, caching, and use in collections, and makes the codebase more maintainable and less error-prone.

Key changes include:

### Equality and Hashing for Parameter Classes

* Added `IEquatable<T>` implementations, along with `Equals`, `GetHashCode`, and protected helper methods (`EqualProperties`, `AddHashCodes`) to `DeconvolutionParameters` and all its derived classes, such as `ClassicDeconvolutionParameters`, `IsoDecDeconvolutionParameters`, `MultipleDeconParameters`, `FromFileDeconvolutionParameters`, and example/test/template classes. This ensures value-based equality and correct behavior in collections. [[1]](diffhunk://#diff-5fe7ce6846f5976234579fc08d46ff262d092a9238e0c4a5e4210bb211389d14R2-R7) [[2]](diffhunk://#diff-b835fe906b448c3dc997866be4c031a9dc399036ce7eeb40871c5f1b7487e112R31-R58) [[3]](diffhunk://#diff-37803275a695b6a864ce335345f55e4ae8011542e978d3b42d588aae2ee78620R230-R281) [[4]](diffhunk://#diff-ffae961f53898782bdf1c8dfd98e7c0c95e2c641508da119cf1aafee53e89c92R23-R49) [[5]](diffhunk://#diff-65869d87ffa59d40f9299ce95a35e06940abff0089bd26174be927ba48373382R109-R136) [[6]](diffhunk://#diff-bcbe594da92e3b8e99fb2d87b0c6f720f7a2400dc09688cfbd0dd32f08669f8aR18-R30) [[7]](diffhunk://#diff-584bfdced466e0b4272ccbcf96c0c0d351aa1d31294fc9a70d9a44f5a5bc9702R355-R363)

* Implemented `Clone` methods for all parameter classes, enabling deep copying of parameter objects, which is useful for thread safety and avoiding side effects. [[1]](diffhunk://#diff-b835fe906b448c3dc997866be4c031a9dc399036ce7eeb40871c5f1b7487e112R31-R58) [[2]](diffhunk://#diff-37803275a695b6a864ce335345f55e4ae8011542e978d3b42d588aae2ee78620R230-R281) [[3]](diffhunk://#diff-ffae961f53898782bdf1c8dfd98e7c0c95e2c641508da119cf1aafee53e89c92R23-R49) [[4]](diffhunk://#diff-65869d87ffa59d40f9299ce95a35e06940abff0089bd26174be927ba48373382R109-R136) [[5]](diffhunk://#diff-bcbe594da92e3b8e99fb2d87b0c6f720f7a2400dc09688cfbd0dd32f08669f8aR18-R30) [[6]](diffhunk://#diff-584bfdced466e0b4272ccbcf96c0c0d351aa1d31294fc9a70d9a44f5a5bc9702R355-R363)

### Equality and Hashing for Average Residue Models

* Implemented `IEquatable<AverageResidue>`, `Equals`, and `GetHashCode` for the `AverageResidue` base class and its derived classes (`EmpiricalAverageResidue`, `DecoyAveragine`), including support for value-based equality and hash codes. [[1]](diffhunk://#diff-d44215af6b73a429f2de4acf6fa4b10dea32eb73f52cadbe99e82c023038e671L1-R9) [[2]](diffhunk://#diff-d44215af6b73a429f2de4acf6fa4b10dea32eb73f52cadbe99e82c023038e671R18-R43) [[3]](diffhunk://#diff-cc609e2b41ff6ec41ff47edbfd1970f8beb019de56555d3a4d823323009fa190R91-R101) [[4]](diffhunk://#diff-33676cc533a506dcc2f444e6b096cc73958e94d99241560f840fc2811a6dc3bfR119-R135)

* Added an `AverageResidueComposition` property to `EmpiricalAverageResidue` and included it in equality and hash code calculations. [[1]](diffhunk://#diff-cc609e2b41ff6ec41ff47edbfd1970f8beb019de56555d3a4d823323009fa190R13-R14) [[2]](diffhunk://#diff-cc609e2b41ff6ec41ff47edbfd1970f8beb019de56555d3a4d823323009fa190R37) [[3]](diffhunk://#diff-cc609e2b41ff6ec41ff47edbfd1970f8beb019de56555d3a4d823323009fa190R91-R101)

### Miscellaneous

* Added missing `using` directives for `System` and `System.Linq` in several files to support new functionality. [[1]](diffhunk://#diff-d44215af6b73a429f2de4acf6fa4b10dea32eb73f52cadbe99e82c023038e671L1-R9) [[2]](diffhunk://#diff-33676cc533a506dcc2f444e6b096cc73958e94d99241560f840fc2811a6dc3bfL1-R5) [[3]](diffhunk://#diff-b835fe906b448c3dc997866be4c031a9dc399036ce7eeb40871c5f1b7487e112L1-R2) Fa72e3d4L1, [[4]](diffhunk://#diff-cc609e2b41ff6ec41ff47edbfd1970f8beb019de56555d3a4d823323009fa190L1-R2) [[5]](diffhunk://#diff-bcbe594da92e3b8e99fb2d87b0c6f720f7a2400dc09688cfbd0dd32f08669f8aL1-R1) [[6]](diffhunk://#diff-584bfdced466e0b4272ccbcf96c0c0d351aa1d31294fc9a70d9a44f5a5bc9702R1)
* Added an `OriginalFilePath` property to `FromFileDeconvolutionParameters` and included it in equality and hash code logic. [[1]](diffhunk://#diff-65869d87ffa59d40f9299ce95a35e06940abff0089bd26174be927ba48373382R40-R42) [[2]](diffhunk://#diff-65869d87ffa59d40f9299ce95a35e06940abff0089bd26174be927ba48373382R68-R69) [[3]](diffhunk://#diff-65869d87ffa59d40f9299ce95a35e06940abff0089bd26174be927ba48373382R109-R136)

These changes collectively improve the robustness and maintainability of the codebase, especially in scenarios involving parameter comparison, caching, and testing.