### PR TITLE
Batched Chronologer retention-time inference (PredictRetentionTimeEquivalents override)

### DIFF
--- a/mzLib/Chromatography/RetentionTimePrediction/Chronologer/ChronologerRetentionTimePredictor.cs
+++ b/mzLib/Chromatography/RetentionTimePrediction/Chronologer/ChronologerRetentionTimePredictor.cs
@@ -75,9 +75,94 @@ public class ChronologerRetentionTimePredictor : RetentionTimePredictor
         // Predict retention time - keep both prediction AND disposal inside lock
         lock (_modelLock)
         {
-            using Tensor prediction = _model.Predict(sequenceTensor);
+            using var scope = NewDisposeScope();   // dispose forward()'s intermediates deterministically
+            using Tensor prediction = _model.Predict(sequenceTensor).cpu();
             return prediction[0].ToDouble();
         }
+    }
+
+    /// <summary>
+    /// Batched override: formats/encodes the peptides in parallel (CPU) and runs the Chronologer model in
+    /// large batched forward passes instead of one locked batch-1 call per peptide. The model is in eval
+    /// mode (BatchNorm uses running statistics), so each peptide's prediction is independent of the batch —
+    /// results match <see cref="PredictCore"/> to float32 precision (libtorch selects different conv/matmul
+    /// kernels at batch size m vs 1, so the two paths are not bit-identical), just far faster for many peptides.
+    /// </summary>
+    public override IReadOnlyList<(double? PredictedValue, IRetentionPredictable Peptide, RetentionTimeFailureReason? FailureReason)>
+        PredictRetentionTimeEquivalents(IEnumerable<IRetentionPredictable> peptides, int maxThreads = 1)
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(ChronologerRetentionTimePredictor));
+
+        var list = peptides as IReadOnlyList<IRetentionPredictable> ?? peptides.ToList();
+        int n = list.Count;
+        int encodedLength = ChronologerSequenceFormatSchema.EncodedLength;
+        var results = new (double?, IRetentionPredictable, RetentionTimeFailureReason?)[n];
+        var encoded = new long[n][];                          // null when the peptide could not be encoded
+        var reasons = new RetentionTimeFailureReason?[n];
+
+        // Phase 1 — format + integer-encode each peptide in parallel (pure CPU, no model access).
+        System.Threading.Tasks.Parallel.For(0, n,
+            new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = Math.Max(1, maxThreads) }, i =>
+        {
+            var pep = list[i];
+            if (!ValidateBasicConstraints(pep, out RetentionTimeFailureReason? basicReason))
+            {
+                reasons[i] = basicReason;
+                return;
+            }
+            string? formatted = GetFormattedSequence(pep, out RetentionTimeFailureReason? fmtReason);
+            if (formatted == null)
+            {
+                reasons[i] = fmtReason ?? RetentionTimeFailureReason.PredictionError;
+                return;
+            }
+            var ids = new long[encodedLength]; // zero-padded
+            for (int k = 0; k < formatted.Length; k++)
+            {
+                if (!CodeToInt.TryGetValue(formatted[k], out int v)) { ids = null!; break; }
+                ids[k] = v;
+            }
+            if (ids == null) { reasons[i] = RetentionTimeFailureReason.PredictionError; return; }
+            encoded[i] = ids;
+        });
+
+        var valid = new List<int>(n);
+        for (int i = 0; i < n; i++) if (encoded[i] != null) valid.Add(i);
+
+        // Phase 2 — batched model inference. One forward pass per chunk (model lock held once per chunk).
+        const int chunkSize = 2048;
+        lock (_modelLock)
+        {
+            using var noGrad = no_grad();
+            for (int off = 0; off < valid.Count; off += chunkSize)
+            {
+                // Deterministically dispose every tensor created during this chunk — including the ~30
+                // intermediates allocated inside the model's forward() (residual clones, conv/norm outputs).
+                // Without a dispose scope those rely on the GC finalizer thread, which races the main thread's
+                // libtorch allocator and corrupts the native heap (0xC0000374) once enough inference has run.
+                using var scope = NewDisposeScope();
+                int m = Math.Min(chunkSize, valid.Count - off);
+                var flat = new long[(long)m * encodedLength];
+                for (int j = 0; j < m; j++)
+                    Array.Copy(encoded[valid[off + j]], 0, flat, (long)j * encodedLength, encodedLength);
+
+                using Tensor input = tensor(flat, dtype: ScalarType.Int64).reshape(m, encodedLength);
+                using Tensor prediction = _model.Predict(input);           // [m, 1]
+                double[] preds = prediction.reshape(m).to(ScalarType.Float64).cpu().data<double>().ToArray();
+                for (int j = 0; j < m; j++)
+                {
+                    int i = valid[off + j];
+                    results[i] = (preds[j], list[i], null);
+                }
+            }
+        }
+
+        for (int i = 0; i < n; i++)
+            if (encoded[i] == null)
+                results[i] = ((double?)null, list[i], reasons[i]);
+
+        return results;
     }
 
     public override string? GetFormattedSequence(IRetentionPredictable peptide, out RetentionTimeFailureReason? failureReason)

--- a/mzLib/Test/RetentionTimePrediction/RetentionTimeEquivalentBatchTests.cs
+++ b/mzLib/Test/RetentionTimePrediction/RetentionTimeEquivalentBatchTests.cs
@@ -130,7 +130,9 @@ namespace Test.RetentionTimePrediction
                     var singleResult = predictor.PredictRetentionTimeEquivalent(peptide, out var singleReason);
                     var batchResult = batchResults[peptide.BaseSequence];
 
-                    Assert.That(batchResult.PredictedValue, Is.EqualTo(singleResult),
+                    // Batched and single-peptide inference run through different libtorch conv/matmul
+                    // kernels (batch size m vs 1), so results match to float32 precision, not bit-exactly.
+                    Assert.That(batchResult.PredictedValue, Is.EqualTo(singleResult).Within(1e-4),
                         $"{predictor.PredictorName} batch result differed from single for {peptide.BaseSequence}");
                     Assert.That(batchResult.FailureReason, Is.EqualTo(singleReason),
                         $"{predictor.PredictorName} batch failure reason differed from single for {peptide.BaseSequence}");
@@ -321,7 +323,9 @@ namespace Test.RetentionTimePrediction
 
                     Assert.That(batchResult.Peptide.BaseSequence, Is.EqualTo(peptides[idx].BaseSequence),
                         $"{predictor.PredictorName} peptide mismatch at index {idx}");
-                    Assert.That(batchResult.PredictedValue, Is.EqualTo(singleValue),
+                    // Batched and single-peptide inference run through different libtorch conv/matmul
+                    // kernels (batch size m vs 1), so results match to float32 precision, not bit-exactly.
+                    Assert.That(batchResult.PredictedValue, Is.EqualTo(singleValue).Within(1e-4),
                         $"{predictor.PredictorName} value mismatch at index {idx} for {peptides[idx].BaseSequence}");
                     Assert.That(batchResult.FailureReason, Is.EqualTo(singleReason),
                         $"{predictor.PredictorName} failure reason mismatch at index {idx}");


### PR DESCRIPTION
## Summary

Adds a **true tensor-batched** `PredictRetentionTimeEquivalents` override for the Chronologer retention-time predictor. This is extracted from #1036 so it can be reviewed and merged independently of the `.msl` spectral-library format work — it's a self-contained RT-prediction performance change (2 files, +92/−3) that depends only on what's already on `master`.

## Why an override (and not an edit to the existing batch method)

`RetentionTimePredictor` already has a `PredictRetentionTimeEquivalents(...)` batch method on the base class — but it does **CPU thread-parallelism over single-peptide predictions**: it partitions the peptides across `maxThreads` workers and calls `PredictCore` once per peptide. Each peptide is therefore still its own **lock-held, batch-of-1** libtorch forward pass.

The base method can't be changed to do real batching, because batching is **model-specific** — only Chronologer has a libtorch tensor model to run an `[m, 1]` batch through; `SSRCalc`/`CZE` don't. Putting libtorch batching in the shared base would leak model internals into the abstraction. The base class even documents the intended pattern:

> *"Predictors that support true batched inference (e.g. Chronologer) should **override** `PredictRetentionTimeEquivalents` instead of this method."*

This PR does exactly that.

## What it does

- **Batched override** (`ChronologerRetentionTimePredictor`): format + integer-encode the peptides in parallel on the CPU (no model access), then run the model in **large batched forward passes** — one `[m, 1]` tensor per chunk, with the model lock taken **once per chunk instead of once per peptide**. Far fewer lock acquisitions and kernel launches → much faster when predicting many peptides (e.g. building spectral libraries over millions).
- **Numerical equivalence**: the model is in eval mode (BatchNorm uses running statistics), so each peptide's prediction is independent of the batch. Results match the single-peptide `PredictCore` to **float32 precision** — not bit-identical, because libtorch selects different conv/matmul kernels at batch size `m` vs `1`. The batch test tolerance is widened to allow that drift.
- **Deterministic native cleanup**: wraps the forward pass in `NewDisposeScope()` so `forward()`'s intermediate tensors (residual clones, conv/norm outputs) are freed promptly instead of accumulating on the native heap.

## Tests

`RetentionTimeEquivalentBatchTests` (20 tests) pass on `master` + this change; the only test edit is the float32 tolerance noted above.

## Relationship to #1036

This is the foundational, independent piece of #1036. Merging it first shrinks #1036 (these files drop out of its diff with identical content) and gives the batched-inference work its own focused review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
