### PR TITLE
feat(mzlibutil): add canonical PSI CvParam type

### DIFF
--- a/mzLib/MzLibUtil/CvParam.cs
+++ b/mzLib/MzLibUtil/CvParam.cs
@@ -1,0 +1,91 @@
+namespace MzLibUtil
+{
+    /// <summary>
+    /// A controlled-vocabulary parameter (cvParam), the PSI standard unit shared across proteomics
+    /// data formats (mzML, mzIdentML, mzTab) and web APIs (e.g. PRIDE Archive). A cvParam is a
+    /// reference to a term in a controlled vocabulary: the vocabulary (<see cref="CvLabel"/>), the
+    /// term's stable identifier (<see cref="Accession"/>), its human-readable <see cref="Name"/>, an
+    /// optional <see cref="Value"/>, and — when the value is numeric — an optional unit term
+    /// (<see cref="UnitCvLabel"/>/<see cref="UnitAccession"/>/<see cref="UnitName"/>).
+    ///
+    /// Consumers should match on <see cref="Accession"/> (the stable machine identifier), NOT on
+    /// <see cref="Name"/> (a display label that can change). For example, a PRIDE FTP file location is
+    /// the cvParam whose <see cref="Accession"/> is "PRIDE:0000469".
+    ///
+    /// This type is intentionally serialization-agnostic: it carries no JSON/XML attributes and takes
+    /// no serializer dependency. JSON deserializers (Newtonsoft, System.Text.Json) map wire fields
+    /// such as "cvLabel"/"accession"/"name"/"value" onto these properties by case-insensitive name
+    /// matching, so no annotations are required.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CvLabel"/> corresponds to the "cvRef" attribute in the mzML/mzIdentML XML schemas and
+    /// to "cvLabel" in PRIDE's JSON — both name the controlled vocabulary the term comes from.
+    /// </remarks>
+    public record CvParam
+    {
+        /// <summary>
+        /// Parameterless constructor. Used by object initializers and by deserializers, which then set
+        /// the individual properties.
+        /// </summary>
+        public CvParam()
+        {
+        }
+
+        /// <summary>
+        /// Convenience constructor. Unit fields are optional and default to empty (no unit).
+        /// </summary>
+        /// <param name="cvLabel">The controlled vocabulary the term is from (e.g. "PRIDE", "MS").</param>
+        /// <param name="accession">The stable term accession (e.g. "PRIDE:0000469").</param>
+        /// <param name="name">The term's human-readable name (e.g. "FTP Protocol").</param>
+        /// <param name="value">The parameter value, if any.</param>
+        /// <param name="unitCvLabel">The controlled vocabulary of the unit term, if any.</param>
+        /// <param name="unitAccession">The unit term accession, if any.</param>
+        /// <param name="unitName">The unit term name, if any.</param>
+        public CvParam(string cvLabel, string accession, string name, string value,
+            string unitCvLabel = "", string unitAccession = "", string unitName = "")
+        {
+            CvLabel = cvLabel;
+            Accession = accession;
+            Name = name;
+            Value = value;
+            UnitCvLabel = unitCvLabel;
+            UnitAccession = unitAccession;
+            UnitName = unitName;
+        }
+
+        /// <summary>
+        /// The controlled vocabulary the term is from (the "cvRef" / "cvLabel"), e.g. "PRIDE" or "MS".
+        /// </summary>
+        public string CvLabel { get; init; } = string.Empty;
+
+        /// <summary>
+        /// The stable, machine-readable term identifier, e.g. "PRIDE:0000469". Match on this, not Name.
+        /// </summary>
+        public string Accession { get; init; } = string.Empty;
+
+        /// <summary>
+        /// The human-readable term name, e.g. "FTP Protocol".
+        /// </summary>
+        public string Name { get; init; } = string.Empty;
+
+        /// <summary>
+        /// The parameter value as a string. Numeric values are interpreted via the unit term, if present.
+        /// </summary>
+        public string Value { get; init; } = string.Empty;
+
+        /// <summary>
+        /// The controlled vocabulary of the unit term, if the value is numeric; otherwise empty.
+        /// </summary>
+        public string UnitCvLabel { get; init; } = string.Empty;
+
+        /// <summary>
+        /// The accession of the unit term, if the value is numeric; otherwise empty.
+        /// </summary>
+        public string UnitAccession { get; init; } = string.Empty;
+
+        /// <summary>
+        /// The name of the unit term, if the value is numeric; otherwise empty.
+        /// </summary>
+        public string UnitName { get; init; } = string.Empty;
+    }
+}

--- a/mzLib/Test/Util/CvParamTests.cs
+++ b/mzLib/Test/Util/CvParamTests.cs
@@ -1,0 +1,107 @@
+using MzLibUtil;
+using NUnit.Framework;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Test.Util;
+
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class CvParamTests
+{
+    [Test]
+    public void ParameterlessConstructor_DefaultsAllPropertiesToEmptyString()
+    {
+        var cv = new CvParam();
+        Assert.That(cv.CvLabel, Is.EqualTo(string.Empty));
+        Assert.That(cv.Accession, Is.EqualTo(string.Empty));
+        Assert.That(cv.Name, Is.EqualTo(string.Empty));
+        Assert.That(cv.Value, Is.EqualTo(string.Empty));
+        Assert.That(cv.UnitCvLabel, Is.EqualTo(string.Empty));
+        Assert.That(cv.UnitAccession, Is.EqualTo(string.Empty));
+        Assert.That(cv.UnitName, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void Constructor_SetsCoreFields_AndDefaultsUnitFieldsToEmpty()
+    {
+        var cv = new CvParam("PRIDE", "PRIDE:0000469", "FTP Protocol", "ftp://ftp.pride.ebi.ac.uk/x");
+        Assert.That(cv.CvLabel, Is.EqualTo("PRIDE"));
+        Assert.That(cv.Accession, Is.EqualTo("PRIDE:0000469"));
+        Assert.That(cv.Name, Is.EqualTo("FTP Protocol"));
+        Assert.That(cv.Value, Is.EqualTo("ftp://ftp.pride.ebi.ac.uk/x"));
+        // units are optional and absent here
+        Assert.That(cv.UnitCvLabel, Is.EqualTo(string.Empty));
+        Assert.That(cv.UnitAccession, Is.EqualTo(string.Empty));
+        Assert.That(cv.UnitName, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void Constructor_SetsFullPsiFieldSetIncludingUnits()
+    {
+        var cv = new CvParam("MS", "MS:1000040", "m/z", "1234.56",
+            unitCvLabel: "MS", unitAccession: "MS:1000040", unitName: "m/z");
+        Assert.That(cv.UnitCvLabel, Is.EqualTo("MS"));
+        Assert.That(cv.UnitAccession, Is.EqualTo("MS:1000040"));
+        Assert.That(cv.UnitName, Is.EqualTo("m/z"));
+    }
+
+    [Test]
+    public void ObjectInitializer_SetsAllProperties()
+    {
+        var cv = new CvParam
+        {
+            CvLabel = "PRIDE",
+            Accession = "PRIDE:0000408",
+            Name = "Search engine output file URI",
+            Value = "SEARCH"
+        };
+        Assert.That(cv.Accession, Is.EqualTo("PRIDE:0000408"));
+        Assert.That(cv.Value, Is.EqualTo("SEARCH"));
+    }
+
+    [Test]
+    public void Equality_SameValues_AreEqual()
+    {
+        var a = new CvParam("PRIDE", "PRIDE:0000469", "FTP Protocol", "ftp://x");
+        var b = new CvParam("PRIDE", "PRIDE:0000469", "FTP Protocol", "ftp://x");
+        Assert.That(a, Is.EqualTo(b));
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    [Test]
+    public void Equality_DifferentAccession_AreNotEqual()
+    {
+        var a = new CvParam("PRIDE", "PRIDE:0000469", "FTP Protocol", "ftp://x");
+        var b = new CvParam("PRIDE", "PRIDE:0000468", "Aspera Protocol", "fasp://x");
+        Assert.That(a, Is.Not.EqualTo(b));
+    }
+
+    [Test]
+    public void EqualityOperators_CompareByValue()
+    {
+        var a = new CvParam("PRIDE", "PRIDE:0000469", "FTP Protocol", "ftp://x");
+        var b = new CvParam("PRIDE", "PRIDE:0000469", "FTP Protocol", "ftp://x");
+        var c = new CvParam("PRIDE", "PRIDE:0000468", "Aspera Protocol", "fasp://x");
+        Assert.That(a == b, Is.True);
+        Assert.That(a != c, Is.True);
+    }
+
+    [Test]
+    public void With_ProducesModifiedCopy_LeavingOriginalUnchanged()
+    {
+        var a = new CvParam("PRIDE", "PRIDE:0000469", "FTP Protocol", "ftp://x");
+        var b = a with { Value = "ftp://y" };
+        Assert.That(b.Accession, Is.EqualTo("PRIDE:0000469"));
+        Assert.That(b.Value, Is.EqualTo("ftp://y"));
+        Assert.That(a.Value, Is.EqualTo("ftp://x"));
+    }
+
+    [Test]
+    public void ToString_IncludesAccessionAndName()
+    {
+        var cv = new CvParam("PRIDE", "PRIDE:0000469", "FTP Protocol", "ftp://x");
+        var text = cv.ToString();
+        Assert.That(text, Does.Contain("PRIDE:0000469"));
+        Assert.That(text, Does.Contain("FTP Protocol"));
+    }
+}


### PR DESCRIPTION
**The nut:** mzLib has no reusable controlled-vocabulary parameter (`cvParam`) type — the only ones today are XSD-generated classes welded to the mzML/mzIdentML schemas. This PR adds `MzLibUtil.CvParam`, a small, serialization-agnostic value type that models the PSI `cvParam` — the common currency of mzML, mzIdentML, and mzTab, and of web APIs like PRIDE Archive — so any code that needs to carry a CV term can reach for one shared type instead of re-rolling `(cvRef, accession, name, value)` by hand.

## What it is
A `record` in `MzLibUtil` with the full PSI `cvParam` field set:
- `CvLabel` — the controlled vocabulary the term is from (e.g. `PRIDE`, `MS`); the mzML/mzIdentML `cvRef`.
- `Accession` — the stable term identifier (e.g. `PRIDE:0000469`).
- `Name` — the human-readable term name.
- `Value` — the parameter value (a string; the unit gives numeric meaning).
- `UnitCvLabel` / `UnitAccession` / `UnitName` — the optional unit term, for numeric values.

Value-equality semantics (`==`, `with`) and `init`-only properties, since a CV term is a value, not mutable state.

## Why
- **Fills a real gap.** There is currently no non-generated, general-purpose `cvParam` anywhere in the library; the generated `CVParamType`s are bound to their serialization schemas and can't be reused as a plain value.
- **First consumer is on the way.** A forthcoming PRIDE Archive client will use `CvParam` to model file categories and download locations, but the type is deliberately client-agnostic so anything PSI-shaped can adopt it.

## Design notes
- **Serialization-agnostic by design.** No JSON/XML attributes and no serializer dependency added to `MzLibUtil`. Deserializers (Newtonsoft, System.Text.Json) map wire fields such as `cvLabel`/`accession`/`name`/`value` onto these properties by case-insensitive name matching, so no annotations are required and the type stays reusable across formats.
- **Key on `Accession`, not `Name`.** The XML docs steer consumers to match on the stable accession rather than the display name (which can change).
- **Non-null defaults.** All string properties default to `string.Empty` (nullable reference types are disabled in `MzLibUtil`), so a freshly constructed or partially-populated `CvParam` never carries nulls.

## Tests
`Test/Util/CvParamTests.cs` — 9 tests covering both constructors, all properties, object-initializer and `with` copies, value equality (`Equals`/`GetHashCode`/`==`/`!=`), and `ToString`. Full patch coverage of the new type.

## Scope
Additive only — one new type and its tests. No existing code changed, no new package dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01CaQVBed3CG6HuF8Nkpdzoo
