### PR TITLE
Revert MCDF upgrade

### DIFF
--- a/mzLib/Readers/Readers.csproj
+++ b/mzLib/Readers/Readers.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CsvHelper" Version="32.0.3" />
-		<PackageReference Include="OpenMcdf" Version="3.1.3" />
+		<PackageReference Include="OpenMcdf" Version="2.3.1" />
 		<PackageReference Include="OpenMcdf.Extensions" Version="2.3.1" />
 		<PackageReference Include="System.Data.SQLite" Version="1.0.118" />
 		<PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />

--- a/mzLib/mzLib.nuspec
+++ b/mzLib/mzLib.nuspec
@@ -21,7 +21,7 @@
     <dependency id="Microsoft.ML.FastTree" version="2.0.0" />
     <dependency id="Microsoft.Win32.Registry" version="5.0.0" />
     <dependency id="NetSerializer" version="4.1.1" />
-    <dependency id="OpenMcdf" version="3.1.3" />
+    <dependency id="OpenMcdf" version="2.3.1" />
     <dependency id="OpenMcdf.Extensions" version="2.3.1" />
     <dependency id="SharpLearning.Optimization" version="0.28.0" />
     <dependency id="SharpZipLib" version="1.4.2" />
@@ -41,7 +41,7 @@
     <dependency id="Microsoft.ML.FastTree" version="2.0.0" />
     <dependency id="Microsoft.Win32.Registry" version="5.0.0" />
     <dependency id="NetSerializer" version="4.1.1" />
-    <dependency id="OpenMcdf" version="3.1.3" />
+    <dependency id="OpenMcdf" version="2.3.1" />
     <dependency id="OpenMcdf.Extensions" version="2.3.1" />
     <dependency id="OxyPlot.Wpf" version="2.0.0" />
     <dependency id="SharpLearning.Optimization" version="0.28.0" />


### PR DESCRIPTION
ThermoRawFileReader uses OpenMCDF version 2.3.X 

Dependabot upgraded this and we approved. 

Need to revert to restore full file reader functionality. 