### PR TITLE
test(ci): unify Koina under ExternalService; non-blocking live tests that skip on outage

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,13 +25,33 @@ jobs:
     - name: Add coverlet collector (Test)
       run: cd mzLib && dotnet add Test/Test.csproj package coverlet.collector -v 6.0.2
     - name: Test
-      run: cd mzLib && dotnet test --no-build --verbosity normal --filter "Category!=Koina" --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura ./Test/Test.csproj
+      # Exclude live external-service tests (Koina, etc.) from the required run; they run in the
+      # separate, non-blocking external-service job below. ExternalService supersedes the old Koina filter.
+      run: cd mzLib && dotnet test --no-build --verbosity normal --filter "Category!=ExternalService" --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=cobertura ./Test/Test.csproj
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
         files: mzLib/Test*/TestResults/*/coverage.cobertura.xml
+  # Runs mzLib's live external-service tests (Koina). Intentionally NOT a required status check, so a
+  # third-party outage never blocks a PR; the tests self-classify (outage -> Skipped, real break -> Fail).
+  # Do NOT add this job to branch-protection required checks.
+  external-service-tests:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: cd mzLib && dotnet restore
+    - name: Build (Test)
+      run: cd mzLib && dotnet build --no-restore ./Test/Test.csproj
+    - name: Test (external services)
+      run: cd mzLib && dotnet test --no-build --verbosity normal --filter "Category=ExternalService" ./Test/Test.csproj
   integration:
     runs-on: windows-latest
     timeout-minutes: 45
@@ -81,7 +101,11 @@ jobs:
     - name: Build MetaMorpheus
       run: cd ./MetaMorpheus/MetaMorpheus && dotnet build --no-restore
     - name: Test
-      run: cd ./MetaMorpheus/MetaMorpheus && dotnet test --no-build --verbosity normal
+      # Exclude live external-service tests from the MetaMorpheus integration run: they gate on third-party
+      # services (UniProt, etc.), are not relevant to mzLib<->MetaMorpheus compatibility, and MetaMorpheus
+      # exercises them in its own non-blocking job. This is what keeps a UniProt outage from reddening
+      # every mzLib PR (this integration job clones MetaMorpheus master and runs its suite).
+      run: cd ./MetaMorpheus/MetaMorpheus && dotnet test --no-build --verbosity normal --filter "Category!=ExternalService"
     - name: Upload artifact (installer)
       uses: actions/upload-artifact@v4
       with:

--- a/mzLib/Test/ExternalServiceTestHelper.cs
+++ b/mzLib/Test/ExternalServiceTestHelper.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Test
+{
+    /// <summary>
+    /// Support for tests that exercise a live external web service (UniProt, Koina, PRIDE, ...).
+    /// Such tests carry <c>[Category("ExternalService")]</c> so CI can run them in a dedicated,
+    /// non-blocking job (see .github/workflows/Test.yml) instead of the required unit-test run.
+    ///
+    /// The hard part is telling two failures apart:
+    ///   * the service is unavailable (down, rate-limited, 5xx, timeout) - NOT our bug, so the
+    ///     test should be <b>skipped</b> ("we tried, the service is down, don't worry"); versus
+    ///   * the service answered but the contract is broken (our URL is wrong, the response no
+    ///     longer parses, an expected value is missing) - that is a real regression and must FAIL.
+    ///
+    /// <see cref="RunAsync"/> wraps a test body and converts availability failures into
+    /// <see cref="Assert.Ignore(string)"/> (reported as Skipped) while letting genuine assertion
+    /// failures propagate. A test signals "unavailable" from inside the body either by letting a
+    /// transport exception bubble up or by calling <see cref="ThrowIfUnavailable"/> on the response.
+    /// </summary>
+    public static class ExternalServiceTestHelper
+    {
+        /// <summary>
+        /// Runs <paramref name="testBody"/>; if the external service proves unavailable, marks the
+        /// test Skipped (via Assert.Ignore) instead of Failed. Real assertion failures propagate.
+        /// </summary>
+        public static async Task RunAsync(string serviceName, Func<Task> testBody)
+        {
+            try
+            {
+                await testBody();
+            }
+            catch (ExternalServiceUnavailableException e)
+            {
+                Skip(serviceName, $"unavailable ({e.Message})");
+            }
+            catch (HttpRequestException e)
+            {
+                Skip(serviceName, $"unavailable ({e.Message})");
+            }
+            catch (TaskCanceledException)
+            {
+                Skip(serviceName, "timed out");
+            }
+            catch (SocketException e)
+            {
+                Skip(serviceName, $"unreachable ({e.Message})");
+            }
+        }
+
+        /// <summary>
+        /// Records the skip reason on both the console/CI log (via TestContext.Progress, which is
+        /// flushed immediately regardless of verbosity) and the NUnit test result, then skips the
+        /// test. This is what surfaces the "we tried, the service is down, don't worry" message.
+        /// </summary>
+        private static void Skip(string serviceName, string reason)
+        {
+            string message = $"Skipping external-service test: {serviceName} {reason}. " +
+                             "This is a third-party availability problem, not a code failure.";
+            TestContext.Progress.WriteLine(message);
+            Assert.Ignore(message);
+        }
+
+        /// <summary>
+        /// Probes an external service's health/readiness URL and skips the calling test (or, from a
+        /// [OneTimeSetUp], the whole fixture) if it is unreachable. Use this for tests whose service
+        /// call is buried deep in production code and cannot easily route through <see cref="RunAsync"/>.
+        /// </summary>
+        public static void EnsureReachable(string serviceName, string healthUrl)
+        {
+            try
+            {
+                using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
+                var response = client.GetAsync(healthUrl).GetAwaiter().GetResult();
+                ThrowIfUnavailable(response);
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new ExternalServiceUnavailableException($"health check returned HTTP {(int)response.StatusCode}");
+                }
+            }
+            catch (ExternalServiceUnavailableException e)
+            {
+                Skip(serviceName, $"unavailable ({e.Message})");
+            }
+            catch (HttpRequestException e)
+            {
+                Skip(serviceName, $"unavailable ({e.Message})");
+            }
+            catch (TaskCanceledException)
+            {
+                Skip(serviceName, "timed out");
+            }
+            catch (SocketException e)
+            {
+                Skip(serviceName, $"unreachable ({e.Message})");
+            }
+        }
+
+        /// <summary>
+        /// Classifies an HTTP response as a service-availability problem and, if so, throws
+        /// <see cref="ExternalServiceUnavailableException"/> so <see cref="RunAsync"/> skips the test.
+        /// Catches transport-level status codes (408/429/5xx) and known error bodies that some
+        /// services (e.g. UniProt's streaming endpoint) return with an HTTP 200.
+        /// </summary>
+        public static void ThrowIfUnavailable(HttpResponseMessage response, string bodyText = null)
+        {
+            int status = (int)response.StatusCode;
+            if (status == 408 || status == 429 || status >= 500)
+            {
+                throw new ExternalServiceUnavailableException($"HTTP {status} {response.ReasonPhrase}");
+            }
+
+            // Some services answer 200 but stream an error message in the body.
+            if (!string.IsNullOrWhiteSpace(bodyText) &&
+                bodyText.Contains("Error encountered when streaming data", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ExternalServiceUnavailableException("service returned an error body instead of data");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Marker exception meaning "the external service is unavailable" (as opposed to a real bug).
+    /// <see cref="ExternalServiceTestHelper.RunAsync"/> turns this into a skipped test.
+    /// </summary>
+    public class ExternalServiceUnavailableException : Exception
+    {
+        public ExternalServiceUnavailableException(string message) : base(message) { }
+    }
+}

--- a/mzLib/Test/KoinaTests/FlyabilityPrediction/PFly2024FineTunedTests.cs
+++ b/mzLib/Test/KoinaTests/FlyabilityPrediction/PFly2024FineTunedTests.cs
@@ -8,9 +8,10 @@ using PredictionClients.Koina.SupportedModels.FlyabilityModels;
 namespace Test.KoinaTests.FlyabilityPrediction
 {
     [TestFixture]
+    [Category("ExternalService")]
     [Category("Koina")]
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class PFly2024FineTunedTests
+    public class PFly2024FineTunedTests : KoinaLiveTestFixture
     {
         /// <summary>
         /// Tests that the model correctly processes valid peptide sequences without throwing exceptions.

--- a/mzLib/Test/KoinaTests/FragmentIntensityPrediction/Prosit2020IntensityHCDTests.cs
+++ b/mzLib/Test/KoinaTests/FragmentIntensityPrediction/Prosit2020IntensityHCDTests.cs
@@ -13,9 +13,10 @@ using Readers.SpectralLibrary;
 namespace Test.KoinaTests.FragmentIntensityPrediction
 {
     [TestFixture]
+    [Category("ExternalService")]
     [Category("Koina")]
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class Prosit2020IntensityHCDTests
+    public class Prosit2020IntensityHCDTests : KoinaLiveTestFixture
     {
         [Test]
         public static void TestKoinaProsit2020IntensityHCDModelWritesReadableSpectralLibrary()

--- a/mzLib/Test/KoinaTests/KoinaLiveTestFixture.cs
+++ b/mzLib/Test/KoinaTests/KoinaLiveTestFixture.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+
+namespace Test.KoinaTests
+{
+    /// <summary>
+    /// Base class for test fixtures that call the live Koina inference server
+    /// (https://koina.wilhelmlab.org). A single [OneTimeSetUp] probe checks the server's
+    /// readiness endpoint once per fixture; if Koina is unreachable the whole fixture is
+    /// Skipped (with a reason on the CI log) rather than failing - see
+    /// <see cref="ExternalServiceTestHelper"/>. Koina calls are made deep inside model
+    /// Predict(...) code, so a fixture-level probe is the least invasive way to distinguish
+    /// "Koina is down" (skip) from a genuine regression (fail).
+    ///
+    /// Derived fixtures still carry [Category("ExternalService")] and [Category("Koina")] so the
+    /// CI category filters select them.
+    /// </summary>
+    public abstract class KoinaLiveTestFixture
+    {
+        private const string KoinaReadyUrl = "https://koina.wilhelmlab.org:443/v2/health/ready";
+
+        [OneTimeSetUp]
+        public void EnsureKoinaReachable()
+        {
+            ExternalServiceTestHelper.EnsureReachable("Koina", KoinaReadyUrl);
+        }
+    }
+}

--- a/mzLib/Test/KoinaTests/RetentionTimePrediction/Prosit2019iRTTests.cs
+++ b/mzLib/Test/KoinaTests/RetentionTimePrediction/Prosit2019iRTTests.cs
@@ -9,9 +9,10 @@ using PredictionClients.Koina.SupportedModels.RetentionTimeModels;
 namespace Test.KoinaTests.RetentionTimePrediction
 {
     [TestFixture]
+    [Category("ExternalService")]
     [Category("Koina")]
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class Prosit2019iRTTests
+    public class Prosit2019iRTTests : KoinaLiveTestFixture
     {
         /// <summary>
         /// Tests that the model correctly processes valid peptide sequences without throwing exceptions.

--- a/mzLib/Test/KoinaTests/RetentionTimePrediction/Prosit2020iRTTMTTests.cs
+++ b/mzLib/Test/KoinaTests/RetentionTimePrediction/Prosit2020iRTTMTTests.cs
@@ -10,9 +10,10 @@ using PredictionClients.Koina.SupportedModels.RetentionTimeModels;
 namespace Test.KoinaTests.RetentionTimePrediction
 {
     [TestFixture]
+    [Category("ExternalService")]
     [Category("Koina")]
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class Prosit2020iRTTMTTests
+    public class Prosit2020iRTTMTTests : KoinaLiveTestFixture
     {
         [Test]
         public void TestProsit2020iRTTMTPrediction()


### PR DESCRIPTION
Companion to **smith-chem-wisc/MetaMorpheus#2682** (external-service convention). Adopts a shared pattern for tests that call a live web service, so a third-party outage can never block a PR while real breakage still fails loudly.

## The problem: two opposite failure modes
A test that hits a live service (Koina's inference server, UniProt's REST API) can go red for two very different reasons:

- **The service is down / rate-limiting / 5xx / timing out** — not our bug. The PR should not be blocked.
- **The service answered but the contract is broken** — our URL is wrong, the response no longer parses. That is a real regression and must fail.

`[Category("Koina")]` + excluding it from CI hid the tests entirely, so we also lost the "our bug" signal. This PR runs them, but in a way that distinguishes the two.

## What this PR does
- **`ExternalServiceTestHelper`** (identical to the MetaMorpheus copy): `RunAsync` wraps a test body and converts availability failures into `Assert.Ignore` (**Skipped**, with a plain-English reason echoed to the CI log) while letting genuine assertion failures fail; `EnsureReachable` is a health-probe form for calls buried in production code; `ThrowIfUnavailable` classifies a response.
- **`KoinaLiveTestFixture`** — a `[OneTimeSetUp]` probe of Koina's readiness endpoint (`/v2/health/ready`). If Koina is unreachable the whole fixture is Skipped with a reason; otherwise its tests run normally. The four live Koina fixtures (`PFly2024FineTuned`, `Prosit2020IntensityHCD`, `Prosit2019iRT`, `Prosit2020iRTTMT`) now inherit it and carry `[Category("ExternalService")]` alongside `[Category("Koina")]`.
- **`dotnet.yml`:**
  - the required build/test run now filters `Category!=ExternalService` (supersedes the old `Category!=Koina`);
  - a new **non-blocking** `external-service-tests` job runs `Category=ExternalService`;
  - **the MetaMorpheus integration run now filters `Category!=ExternalService`.**

## Example usage — adding a new external-service test
**Form 1 — wrap the call** (best when the test issues the request itself):
```csharp
[Test]
[Category("ExternalService")]      // routes it to the non-blocking job
[Category("PRIDE")]                // the specific service, for granular runs
public static Task PrideProjectIsReachable() =>
    ExternalServiceTestHelper.RunAsync("PRIDE", async () =>
    {
        using var client = new HttpClient();
        var response = await client.GetAsync("https://www.ebi.ac.uk/pride/ws/archive/v2/projects/PXD000001");
        ExternalServiceTestHelper.ThrowIfUnavailable(response);   // 5xx/429/error-body -> Skipped
        var json = await response.Content.ReadAsStringAsync();
        Assert.That(json, Does.Contain("PXD000001"));             // contract check -> a real Fail
    });
```

**Form 2 — probe once per fixture** (best when the service call is buried in production code, like Koina's `model.Predict`):
```csharp
[TestFixture]
[Category("ExternalService")]
[Category("Koina")]
public class MyKoinaTests : KoinaLiveTestFixture   // inherited OneTimeSetUp skips the fixture if Koina is down
{
    [Test] public void Predicts() { /* model.Predict(...) as usual */ }
}
```
For a non-Koina service, call the probe directly in your own setup instead of inheriting the base:
```csharp
[OneTimeSetUp]
public void EnsureUp() =>
    ExternalServiceTestHelper.EnsureReachable("PRIDE", "https://www.ebi.ac.uk/pride/ws/archive/v2/health");
```

## Why the integration change matters (mzLib CI)
mzLib's `integration` job packs the PR's mzLib, **clones `smith-chem-wisc/MetaMorpheus` at master, and runs its entire test suite**. That coupling is why a single broken live test on MetaMorpheus master reddens *every* open mzLib PR at once — the failure has nothing to do with the PR's diff (this is exactly what happened with the UniProt outage). Excluding `Category=ExternalService` from that run means MetaMorpheus's live-service tests — which gate on third parties and aren't relevant to mzLib↔MetaMorpheus compatibility — no longer gate mzLib PRs.

## What a skip looks like in the log
```
Skipping external-service test: Koina unavailable (health check returned HTTP 503). This is a third-party availability problem, not a code failure.
...
Skipped: N
```

## Verified locally
- Koina reachable: the probe passes and a live Koina fixture runs green under the `ExternalService` filter.
- The four live fixtures are excluded from the required run (`Category!=ExternalService` selects none of them).
- Test project builds clean (0 errors).

## For maintainers
Please leave the **`external-service-tests`** job **out** of branch-protection required checks so it stays informational (green normally, Skipped during an outage, red only on a genuine contract break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
