### PR TITLE
docs(readme): point build badge at GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A library for mass spectrometry projects.
 
 [![Release](https://img.shields.io/github/v/release/smith-chem-wisc/mzLib)](https://github.com/smith-chem-wisc/mzLib/releases/latest)
-[![Build status](https://ci.appveyor.com/api/projects/status/0jt31252xny5aoxt/branch/master?svg=true)](https://ci.appveyor.com/project/smith-chem-wisc/mzLib/branch/master)
+[![Build and Test](https://github.com/smith-chem-wisc/mzLib/actions/workflows/dotnet.yml/badge.svg?branch=master)](https://github.com/smith-chem-wisc/mzLib/actions/workflows/dotnet.yml)
 [![codecov](https://codecov.io/gh/smith-chem-wisc/mzLib/branch/master/graph/badge.svg)](https://codecov.io/gh/smith-chem-wisc/mzLib)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/10000/badge.svg)](https://scan.coverity.com/projects/mzlib)
 


### PR DESCRIPTION
AppVeyor was retired in the 2022 CI migration; its badge has shown a stale failing status ever since. Repoint to the live "Build and Test" workflow (dotnet.yml) so the badge reflects real master status.