### PR TITLE
Add Precursor Most Abundant Mass psmtsv column

### DIFF
--- a/mzLib/Readers/InternalResults/IndividualResultRecords/SpectrumMatchFromTsv.cs
+++ b/mzLib/Readers/InternalResults/IndividualResultRecords/SpectrumMatchFromTsv.cs
@@ -24,6 +24,12 @@ namespace Readers
         public double? PrecursorIntensity { get; }
         public double PrecursorMz { get; protected set; }
         public double PrecursorMass { get; protected set; }
+        /// <summary>
+        /// The observed neutral mass of the most abundant (tallest) isotopologue of the precursor envelope,
+        /// the companion observation to the monoisotopic <see cref="PrecursorMass"/>. Null when the source
+        /// file did not contain the "Precursor Most Abundant Mass" column (the usual monoisotopic-mode case).
+        /// </summary>
+        public double? PrecursorMostAbundantMass { get; protected set; }
         public double RetentionTime { get; protected set; }
         public double? CollisionEnergy { get; protected set; }
         public double Score { get; protected set; }
@@ -150,6 +156,7 @@ namespace Readers
             PrecursorIntensity = GetOptionalValue<double>(SpectrumMatchFromTsvHeader.PrecursorIntensity, parsedHeader, spl, null);
             PrecursorMz = GetRequiredValue<double>(SpectrumMatchFromTsvHeader.PrecursorMz, parsedHeader, spl);
             PrecursorMass = GetRequiredValue<double>(SpectrumMatchFromTsvHeader.PrecursorMass, parsedHeader, spl);
+            PrecursorMostAbundantMass = GetOptionalValue<double>(SpectrumMatchFromTsvHeader.PrecursorMostAbundantMass, parsedHeader, spl, null);
             BaseSeq = RemoveParentheses(GetRequiredValue(SpectrumMatchFromTsvHeader.BaseSequence, parsedHeader, spl));
             FullSequence = GetRequiredValue(SpectrumMatchFromTsvHeader.FullSequence, parsedHeader, spl);
             MonoisotopicMassString = GetRequiredValue(SpectrumMatchFromTsvHeader.MonoisotopicMass, parsedHeader, spl);
@@ -275,6 +282,8 @@ namespace Readers
             PrecursorScanNum = psm.PrecursorScanNum;
             PrecursorCharge = psm.PrecursorCharge;
             PrecursorIntensity = psm.PrecursorIntensity;
+            // An observation of the precursor envelope, so it is the same for every hypothesis of this match.
+            PrecursorMostAbundantMass = psm.PrecursorMostAbundantMass;
             Score = psm.Score;
             MatchedIons = psm.MatchedIons.ToList();
             ChildScanMatchedIons = psm.ChildScanMatchedIons;

--- a/mzLib/Readers/InternalResults/IndividualResultRecords/SpectrumMatchFromTsvHeader.cs
+++ b/mzLib/Readers/InternalResults/IndividualResultRecords/SpectrumMatchFromTsvHeader.cs
@@ -15,6 +15,11 @@
         public const string PrecursorIntensity = "Precursor Intensity";
         public const string PrecursorMz = "Precursor MZ";
         public const string PrecursorMass = "Precursor Mass";
+        // Optional companion to PrecursorMass: the observed neutral mass of the most abundant (tallest)
+        // isotopologue of the precursor envelope, as opposed to its monoisotopic peak. Written only when a
+        // run used most-abundant precursor selection; the reader maps it by name and ignores it when absent.
+        // Pairs with MostAbundantMassDiffPpm, which reports the error against that same peak.
+        public const string PrecursorMostAbundantMass = "Precursor Most Abundant Mass";
         public const string OneOverK0 = "1/K0";
         public const string Score = "Score";
         public const string DeltaScore = "Delta Score";

--- a/mzLib/Readers/InternalResults/ResultFiles/SpectrumMatchTsvReader.cs
+++ b/mzLib/Readers/InternalResults/ResultFiles/SpectrumMatchTsvReader.cs
@@ -140,6 +140,7 @@ namespace Readers
             parsedHeader.Add(SpectrumMatchFromTsvHeader.PrecursorIntensity, Array.IndexOf(spl, SpectrumMatchFromTsvHeader.PrecursorIntensity));
             parsedHeader.Add(SpectrumMatchFromTsvHeader.PrecursorMz, Array.IndexOf(spl, SpectrumMatchFromTsvHeader.PrecursorMz));
             parsedHeader.Add(SpectrumMatchFromTsvHeader.PrecursorMass, Array.IndexOf(spl, SpectrumMatchFromTsvHeader.PrecursorMass));
+            parsedHeader.Add(SpectrumMatchFromTsvHeader.PrecursorMostAbundantMass, Array.IndexOf(spl, SpectrumMatchFromTsvHeader.PrecursorMostAbundantMass));
             parsedHeader.Add(SpectrumMatchFromTsvHeader.OneOverK0, Array.IndexOf(spl, SpectrumMatchFromTsvHeader.OneOverK0));
             parsedHeader.Add(SpectrumMatchFromTsvHeader.Score, Array.IndexOf(spl, SpectrumMatchFromTsvHeader.Score));
             parsedHeader.Add(SpectrumMatchFromTsvHeader.DeltaScore, Array.IndexOf(spl, SpectrumMatchFromTsvHeader.DeltaScore));

--- a/mzLib/Test/FileReadingTests/InternalFileReading/TestPsmFromTsv.cs
+++ b/mzLib/Test/FileReadingTests/InternalFileReading/TestPsmFromTsv.cs
@@ -414,6 +414,57 @@ namespace Test.FileReadingTests.InternalFileReading
         }
 
         [Test]
+        public static void PrecursorMostAbundantMass_OptionalColumn_ReadsAndSurvivesDisambiguation()
+        {
+            string baseFile = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                @"FileReadingTests\SearchResults\TDGPTMDSearchResults.psmtsv");
+
+            // A file WITHOUT the optional column: the property reads back null, so monoisotopic-mode
+            // output is unaffected and old files still read.
+            List<PsmFromTsv> withoutColumn = SpectrumMatchTsvReader.ReadPsmTsv(baseFile, out _);
+            NUnit.Framework.Assert.That(withoutColumn.First().PrecursorMostAbundantMass, Is.Null);
+
+            // Build a synthetic copy carrying "Precursor Most Abundant Mass" as the last column. Unlike the
+            // mass-error column this is an observation of the precursor envelope, not a per-hypothesis value:
+            // one number per row, never "|"-separated, even for an ambiguous match.
+            string[] lines = File.ReadAllLines(baseFile);
+            var outLines = new List<string>
+            {
+                lines[0] + "\t" + SpectrumMatchFromTsvHeader.PrecursorMostAbundantMass
+            };
+            for (int i = 1; i < lines.Length; i++)
+            {
+                outLines.Add(string.IsNullOrWhiteSpace(lines[i]) ? lines[i] : lines[i] + "\t" + "1234.5678");
+            }
+            string syntheticFile = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                "PrecursorMostAbundantMass_synthetic.psmtsv");
+            File.WriteAllLines(syntheticFile, outLines);
+
+            try
+            {
+                List<PsmFromTsv> withColumn = SpectrumMatchTsvReader.ReadPsmTsv(syntheticFile, out _);
+
+                PsmFromTsv psm = withColumn.First();
+                NUnit.Framework.Assert.That(psm.PrecursorMostAbundantMass, Is.EqualTo(1234.5678).Within(1e-6));
+
+                // The monoisotopic precursor mass is untouched by the new column.
+                NUnit.Framework.Assert.That(psm.PrecursorMass,
+                    Is.EqualTo(withoutColumn.First().PrecursorMass).Within(1e-6));
+
+                // Disambiguating an ambiguous match carries the observation through unchanged - the envelope
+                // apex is a property of the scan, so every hypothesis of the match shares it.
+                PsmFromTsv ambiguous = withColumn.First(p => p.FullSequence.Contains('|'));
+                PsmFromTsv disambiguated = new(ambiguous, ambiguous.FullSequence.Split('|')[0], 0);
+                NUnit.Framework.Assert.That(disambiguated.PrecursorMostAbundantMass,
+                    Is.EqualTo(ambiguous.PrecursorMostAbundantMass));
+            }
+            finally
+            {
+                File.Delete(syntheticFile);
+            }
+        }
+
+        [Test]
         public static void MostAbundantMassDiffPpm_OptionalColumn_ReadsAndDisambiguates()
         {
             string baseFile = Path.Combine(TestContext.CurrentContext.TestDirectory,

--- a/mzLib/Test/FileReadingTests/InternalFileReading/TestPsmFromTsv.cs
+++ b/mzLib/Test/FileReadingTests/InternalFileReading/TestPsmFromTsv.cs
@@ -428,13 +428,22 @@ namespace Test.FileReadingTests.InternalFileReading
             // mass-error column this is an observation of the precursor envelope, not a per-hypothesis value:
             // one number per row, never "|"-separated, even for an ambiguous match.
             string[] lines = File.ReadAllLines(baseFile);
+            int headerWidth = lines[0].Split('\t').Length;
             var outLines = new List<string>
             {
                 lines[0] + "\t" + SpectrumMatchFromTsvHeader.PrecursorMostAbundantMass
             };
             for (int i = 1; i < lines.Length; i++)
             {
-                outLines.Add(string.IsNullOrWhiteSpace(lines[i]) ? lines[i] : lines[i] + "\t" + "1234.5678");
+                // Only append to rows that are exactly header-width, so the value always lands at the
+                // registered column index. A ragged/short row would otherwise place it at that row's own
+                // column count and the reader would map the wrong cell (mirrors the sibling test's guard).
+                if (lines[i].Split('\t').Length != headerWidth)
+                {
+                    outLines.Add(lines[i]);
+                    continue;
+                }
+                outLines.Add(lines[i] + "\t" + "1234.5678");
             }
             string syntheticFile = Path.Combine(TestContext.CurrentContext.TestDirectory,
                 "PrecursorMostAbundantMass_synthetic.psmtsv");
@@ -452,8 +461,11 @@ namespace Test.FileReadingTests.InternalFileReading
                     Is.EqualTo(withoutColumn.First().PrecursorMass).Within(1e-6));
 
                 // Disambiguating an ambiguous match carries the observation through unchanged - the envelope
-                // apex is a property of the scan, so every hypothesis of the match shares it.
+                // apex is a property of the scan, so every hypothesis of the match shares it. Anchor the
+                // ambiguous row's value to the concrete expectation first, so a null on either side fails
+                // rather than letting the comparison degenerate to null == null.
                 PsmFromTsv ambiguous = withColumn.First(p => p.FullSequence.Contains('|'));
+                NUnit.Framework.Assert.That(ambiguous.PrecursorMostAbundantMass, Is.EqualTo(1234.5678).Within(1e-6));
                 PsmFromTsv disambiguated = new(ambiguous, ambiguous.FullSequence.Split('|')[0], 0);
                 NUnit.Framework.Assert.That(disambiguated.PrecursorMostAbundantMass,
                     Is.EqualTo(ambiguous.PrecursorMostAbundantMass));


### PR DESCRIPTION
## What

Adds an optional **`Precursor Most Abundant Mass`** column to the psmtsv reader/header, the sibling of the `Most Abundant Mass Diff (ppm)` column added in #1086.

- **#1086** added the *error* against the most-abundant peak.
- **This PR** adds the peak's *observed neutral mass* itself.

Together the two most-abundant columns mirror the existing `Precursor Mass` + `Mass Diff (ppm)` pair.

## Why

Requested by @nbollis on MetaMorpheus #2671: since MetaMorpheus now writes the most-abundant mass error, it should also write the most-abundant mass, and per the standing convention the psmtsv column must be owned by mzLib so it round-trips through the reader rather than being MM-local and write-only. This is the mzLib half; the MetaMorpheus writer change consumes it.

## How

Same recipe as #1086:
- `SpectrumMatchFromTsvHeader.PrecursorMostAbundantMass` — the registered header string.
- `SpectrumMatchFromTsv.PrecursorMostAbundantMass` (`double?`) — read via the optional-value path, so files without the column read back null and old output is unaffected.
- Registered in `SpectrumMatchTsvReader.ParseHeader` so it is mapped by name.

One deliberate difference from the error column: this is an **observation of the precursor envelope**, not a per-hypothesis value, so it is one number per row (never `|`-separated) and is copied straight through disambiguation of an ambiguous match rather than being split per segment.

## Test

`PrecursorMostAbundantMass_OptionalColumn_ReadsAndSurvivesDisambiguation`: absent column → null; present column reads the value while leaving the monoisotopic `Precursor Mass` untouched; disambiguating an ambiguous match carries the observation through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
