### PR TITLE
feat: fetch PRIDE spectra by USI via PROXI (MzSpectrum + MsDataScan)

### DIFF
--- a/mzLib/Test/DatabaseTests/PrideProxiSpectrumTests.cs
+++ b/mzLib/Test/DatabaseTests/PrideProxiSpectrumTests.cs
@@ -1,0 +1,281 @@
+using MassSpectrometry;
+using MzLibUtil;
+using NUnit.Framework;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using UsefulProteomicsDatabases;
+
+namespace Test.DatabaseTests;
+
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class PrideProxiSpectrumTests
+{
+    // ---- test doubles -------------------------------------------------------
+
+    /// <summary>An HttpMessageHandler that returns a caller-supplied response and records request URIs.</summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+        public List<string> RequestedUris { get; } = new();
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestedUris.Add(request.RequestUri.ToString());
+            return Task.FromResult(_responder(request));
+        }
+    }
+
+    private static HttpResponseMessage JsonResponse(string body, HttpStatusCode status = HttpStatusCode.OK) =>
+        new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    /// <summary>A PROXI spectrum object in the real wire shape (lowercase keys; cvParam attributes with no cvLabel).</summary>
+    private static string SpectrumJson(string usi, double[] mzs, double[] intensities)
+    {
+        string Arr(double[] xs) => "[" + string.Join(",", xs.Select(x => x.ToString(CultureInfo.InvariantCulture))) + "]";
+        return $$"""
+        {
+          "status": "READABLE",
+          "usi": "{{usi}}",
+          "mzs": {{Arr(mzs)}},
+          "intensities": {{Arr(intensities)}},
+          "attributes": [
+            { "accession": "MS:1000041", "name": "charge state", "value": "2" },
+            { "accession": "MS:1001910", "name": "LTQ Orbitrap Elite" }
+          ]
+        }
+        """;
+    }
+
+    private static string ProxiArray(params string[] spectrumJson) => "[" + string.Join(",", spectrumJson) + "]";
+
+    // ---- ToMzSpectrum (pure) -----------------------------------------------
+
+    [Test]
+    public void ToMzSpectrum_MapsPeaks()
+    {
+        var proxi = new PrideProxiSpectrum
+        {
+            Usi = "mzspec:PXD000001:file:scan:1:PEPTIDE/2",
+            Mzs = new[] { 100.0, 200.0, 300.0 },
+            Intensities = new[] { 10.0, 20.0, 30.0 },
+        };
+
+        MzSpectrum spectrum = proxi.ToMzSpectrum();
+
+        Assert.That(spectrum.XArray, Is.EqualTo(new[] { 100.0, 200.0, 300.0 }));
+        Assert.That(spectrum.YArray, Is.EqualTo(new[] { 10.0, 20.0, 30.0 }));
+        Assert.That(spectrum.Size, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void ToMzSpectrum_SortsPeaksByAscendingMz_KeepingIntensityPairing()
+    {
+        // MzSpectrum assumes ascending m/z; ToMzSpectrum must sort defensively and carry intensities along.
+        var proxi = new PrideProxiSpectrum
+        {
+            Mzs = new[] { 300.0, 100.0, 200.0 },
+            Intensities = new[] { 30.0, 10.0, 20.0 },
+        };
+
+        MzSpectrum spectrum = proxi.ToMzSpectrum();
+
+        Assert.That(spectrum.XArray, Is.EqualTo(new[] { 100.0, 200.0, 300.0 }));
+        Assert.That(spectrum.YArray, Is.EqualTo(new[] { 10.0, 20.0, 30.0 })); // intensity 10 still paired with m/z 100
+    }
+
+    [Test]
+    public void ToMzSpectrum_DoesNotReorderTheSourceDtoArrays()
+    {
+        // the sort works on a copy, so a caller re-reading the DTO sees its original (server) order preserved
+        var proxi = new PrideProxiSpectrum
+        {
+            Mzs = new[] { 300.0, 100.0, 200.0 },
+            Intensities = new[] { 30.0, 10.0, 20.0 },
+        };
+
+        proxi.ToMzSpectrum();
+
+        Assert.That(proxi.Mzs, Is.EqualTo(new[] { 300.0, 100.0, 200.0 }));
+        Assert.That(proxi.Intensities, Is.EqualTo(new[] { 30.0, 10.0, 20.0 }));
+    }
+
+    [Test]
+    public void ToMzSpectrum_EmptyPeaks_ReturnsEmptySpectrum()
+    {
+        var proxi = new PrideProxiSpectrum(); // default empty arrays
+
+        MzSpectrum spectrum = proxi.ToMzSpectrum();
+
+        Assert.That(spectrum.Size, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ToMzSpectrum_NullPeakArrays_TreatedAsEmpty()
+    {
+        // a deserializer could leave an array null; ToMzSpectrum coalesces to empty rather than throwing NRE
+        var proxi = new PrideProxiSpectrum { Mzs = null, Intensities = null };
+
+        MzSpectrum spectrum = proxi.ToMzSpectrum();
+
+        Assert.That(spectrum.Size, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ToMzSpectrum_LengthMismatch_ThrowsMzLibException()
+    {
+        var proxi = new PrideProxiSpectrum
+        {
+            Usi = "mzspec:PXD000001:file:scan:1:PEPTIDE/2",
+            Mzs = new[] { 100.0, 200.0 },
+            Intensities = new[] { 10.0 }, // one short
+        };
+
+        var ex = Assert.Throws<MzLibException>(() => proxi.ToMzSpectrum());
+        Assert.That(ex.Message, Does.Contain("PEPTIDE")); // message names the offending USI
+    }
+
+    [Test]
+    public void ToMzSpectrum_NullSpectrum_ThrowsArgumentNullException()
+    {
+        PrideProxiSpectrum proxi = null;
+        Assert.That(() => proxi.ToMzSpectrum(), Throws.ArgumentNullException);
+    }
+
+    // ---- GetProxiSpectrumAsync (offline) -----------------------------------
+
+    [Test]
+    public async Task GetProxiSpectrumAsync_DeserializesSpectrum_AndAttributes()
+    {
+        string usi = "mzspec:PXD000561:file:scan:17555:VLHPLEGAVVIIFK/2";
+        var handler = new StubHandler(_ =>
+            JsonResponse(ProxiArray(SpectrumJson(usi, new[] { 110.07, 111.06 }, new[] { 39316.4, 319.7 }))));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        PrideProxiSpectrum spectrum = await client.GetProxiSpectrumAsync(usi);
+
+        Assert.That(spectrum.Status, Is.EqualTo("READABLE"));
+        Assert.That(spectrum.Usi, Is.EqualTo(usi));
+        Assert.That(spectrum.Mzs, Is.EqualTo(new[] { 110.07, 111.06 }));
+        Assert.That(spectrum.Intensities, Is.EqualTo(new[] { 39316.4, 319.7 }));
+        Assert.That(spectrum.Attributes.Count, Is.EqualTo(2));
+        // attributes map onto CvParam by accession; the charge-state cvParam carries a value, the instrument one does not
+        var charge = spectrum.Attributes.FirstOrDefault(a => a.Accession == "MS:1000041");
+        Assert.That(charge, Is.Not.Null);
+        Assert.That(charge.Value, Is.EqualTo("2"));
+        Assert.That(spectrum.Attributes.Any(a => a.Accession == "MS:1001910" && a.Name == "LTQ Orbitrap Elite"));
+    }
+
+    [Test]
+    public async Task GetProxiSpectrumAsync_BuildsAbsoluteProxiUrl_WithEscapedUsi_AndResultTypeFull()
+    {
+        string usi = "mzspec:PXD000561:file:scan:17555:VLHPLEGAVVIIFK/2";
+        var handler = new StubHandler(_ => JsonResponse(ProxiArray(SpectrumJson(usi, new[] { 100.0 }, new[] { 1.0 }))));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        await client.GetProxiSpectrumAsync(usi);
+
+        string requested = handler.RequestedUris.Single();
+        // absolute PROXI path root (NOT the v3 archive BaseAddress), USI percent-encoded, resultType=full present
+        Assert.That(requested, Does.StartWith(PrideArchiveClient.DefaultProxiBaseAddress + "spectra?usi="));
+        Assert.That(requested, Does.Contain(Uri.EscapeDataString(usi)));
+        Assert.That(requested, Does.Contain("resultType=full"));
+    }
+
+    [Test]
+    public void GetProxiSpectrumAsync_BlankUsi_ThrowsArgumentException()
+    {
+        using var client = new PrideArchiveClient(new HttpClient(new StubHandler(_ => JsonResponse("[]"))));
+        Assert.That(async () => await client.GetProxiSpectrumAsync("   "), Throws.ArgumentException);
+    }
+
+    [TestCase(HttpStatusCode.NotFound)]   // PROXI: unknown / unreadable USI
+    [TestCase(HttpStatusCode.BadRequest)] // PROXI: malformed USI
+    public void GetProxiSpectrumAsync_NonSuccessStatus_ThrowsHttpRequestException(HttpStatusCode status)
+    {
+        var handler = new StubHandler(_ => JsonResponse("", status));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+        Assert.That(async () => await client.GetProxiSpectrumAsync("mzspec:PXD:file:scan:1:PEP/2"),
+            Throws.InstanceOf<HttpRequestException>());
+    }
+
+    [TestCase("[]")]     // empty array on a 200 (contract oddity)
+    [TestCase("null")]   // JSON null body
+    [TestCase("[null]")] // array whose single element is null
+    public void GetProxiSpectrumAsync_NoSpectrumInBody_ThrowsHttpRequestException(string body)
+    {
+        var handler = new StubHandler(_ => JsonResponse(body));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+        Assert.That(async () => await client.GetProxiSpectrumAsync("mzspec:PXD:file:scan:1:PEP/2"),
+            Throws.InstanceOf<HttpRequestException>());
+    }
+
+    // ---- GetSpectrumAsync (offline) ----------------------------------------
+
+    [Test]
+    public async Task GetSpectrumAsync_ReturnsMzSpectrum_WithSortedPeaks()
+    {
+        string usi = "mzspec:PXD000561:file:scan:17555:VLHPLEGAVVIIFK/2";
+        // deliberately unsorted on the wire to prove the end-to-end call sorts
+        var handler = new StubHandler(_ =>
+            JsonResponse(ProxiArray(SpectrumJson(usi, new[] { 300.0, 100.0, 200.0 }, new[] { 30.0, 10.0, 20.0 }))));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        MzSpectrum spectrum = await client.GetSpectrumAsync(usi);
+
+        Assert.That(spectrum.XArray, Is.EqualTo(new[] { 100.0, 200.0, 300.0 }));
+        Assert.That(spectrum.YArray, Is.EqualTo(new[] { 10.0, 20.0, 30.0 }));
+    }
+}
+
+/// <summary>
+/// Live canary for the PROXI spectrum path against the real PRIDE PROXI API. Carries
+/// [Category("ExternalService")] so CI runs it in the non-blocking external-service job, and
+/// [Category("Pride")] to select it alone. Routed through <see cref="ExternalServiceTestHelper.RunAsync"/>
+/// so a PRIDE/EBI outage SKIPS, while a genuine contract break (wrong path, unparseable response, missing
+/// peaks) FAILS. Fetches a known-stable spectrum and checks it carries peaks and metadata.
+/// </summary>
+[TestFixture]
+[Category("ExternalService")]
+[Category("Pride")]
+[ExcludeFromCodeCoverage]
+public class PrideProxiSpectrumLiveTests
+{
+    // A long-public spectrum from PXD000561 ("A draft map of the human proteome"), the canonical PROXI example.
+    private const string KnownUsi = "mzspec:PXD000561:Adult_Frontalcortex_bRP_Elite_85_f09:scan:17555:VLHPLEGAVVIIFK/2";
+
+    [Test]
+    public Task GetProxiSpectrumAsync_LiveKnownUsi_ReturnsPeaksAndAttributes() =>
+        ExternalServiceTestHelper.RunAsync("PRIDE", async () =>
+        {
+            using var client = new PrideArchiveClient();
+            var spectrum = await client.GetProxiSpectrumAsync(KnownUsi);
+
+            Assert.That(spectrum.Usi, Is.EqualTo(KnownUsi));
+            Assert.That(spectrum.Mzs.Length, Is.GreaterThan(1));
+            Assert.That(spectrum.Mzs.Length, Is.EqualTo(spectrum.Intensities.Length));
+            Assert.That(spectrum.Attributes, Is.Not.Empty);
+        });
+
+    [Test]
+    public Task GetSpectrumAsync_LiveKnownUsi_ReturnsPopulatedMzSpectrum() =>
+        ExternalServiceTestHelper.RunAsync("PRIDE", async () =>
+        {
+            using var client = new PrideArchiveClient();
+            var spectrum = await client.GetSpectrumAsync(KnownUsi);
+
+            Assert.That(spectrum.Size, Is.GreaterThan(1));
+            // peaks come back m/z-ascending
+            Assert.That(spectrum.XArray.First(), Is.LessThan(spectrum.XArray.Last()));
+        });
+}

--- a/mzLib/Test/DatabaseTests/PrideProxiSpectrumTests.cs
+++ b/mzLib/Test/DatabaseTests/PrideProxiSpectrumTests.cs
@@ -1,4 +1,4 @@
-using MassSpectrometry;
+﻿using MassSpectrometry;
 using MzLibUtil;
 using NUnit.Framework;
 using System;
@@ -59,97 +59,279 @@ public class PrideProxiSpectrumTests
 
     private static string ProxiArray(params string[] spectrumJson) => "[" + string.Join(",", spectrumJson) + "]";
 
-    // ---- ToMzSpectrum (pure) -----------------------------------------------
+    private static CvParam Cv(string accession, string name, string value = "",
+        string unitAccession = "", string unitName = "") =>
+        new() { Accession = accession, Name = name, Value = value, UnitAccession = unitAccession, UnitName = unitName };
+
+    /// <summary>
+    /// The attribute set PRIDE really returns for a fragment spectrum, verified live against
+    /// mzspec:PXD000561:Adult_Frontalcortex_bRP_Elite_85_f09:scan:17555:VLHPLEGAVVIIFK/2.
+    /// </summary>
+    private static List<CvParam> RealisticAttributes() => new()
+    {
+        Cv("MS:1001910", "LTQ Orbitrap Elite"),
+        Cv("MS:1000463", "instrument", "LTQ Orbitrap Velos"),
+        Cv("MS:1000463", "instrument", "LTQ Orbitrap Elite"), // repeats: one term per project instrument
+        Cv("MS:1000512", "filter string", "FTMS + p NSI d Full ms2 767.97@hcd32.00 [110.00-1550.00]"),
+        Cv("MS:1000828", "isolation window lower offset", "1"),
+        Cv("MS:1000041", "charge state", "2"),
+        Cv("MS:1000511", "ms level", "2"),
+        Cv("MS:1000525", "spectrum representation", "centroid spectrum"),
+        Cv("MS:1003057", "scan number", "17555"),
+        Cv("MS:1000827", "isolation window target m/z", "767.973937988281"),
+        Cv("MS:1000016", "scan start time", "4662.3241"),
+        Cv("MS:1000829", "isolation window upper offset", "1"),
+        Cv("MS:1000927", "ion injection time", "147.372"),
+        Cv("MS:1000465", "scan polarity", "positive scan"),
+        Cv("MS:1000744", "selected ion m/z", "767.973937988281"),
+    };
+
+    // ---- PrideProxiSpectrum is an MzSpectrum -------------------------------
 
     [Test]
-    public void ToMzSpectrum_MapsPeaks()
+    public void Constructor_MapsPeaksOntoTheSpectrumItself()
     {
-        var proxi = new PrideProxiSpectrum
-        {
-            Usi = "mzspec:PXD000001:file:scan:1:PEPTIDE/2",
-            Mzs = new[] { 100.0, 200.0, 300.0 },
-            Intensities = new[] { 10.0, 20.0, 30.0 },
-        };
+        var proxi = new PrideProxiSpectrum(
+            new[] { 100.0, 200.0, 300.0 }, new[] { 10.0, 20.0, 30.0 },
+            usi: "mzspec:PXD000001:file:scan:1:PEPTIDE/2");
 
-        MzSpectrum spectrum = proxi.ToMzSpectrum();
-
-        Assert.That(spectrum.XArray, Is.EqualTo(new[] { 100.0, 200.0, 300.0 }));
-        Assert.That(spectrum.YArray, Is.EqualTo(new[] { 10.0, 20.0, 30.0 }));
-        Assert.That(spectrum.Size, Is.EqualTo(3));
+        Assert.That(proxi, Is.InstanceOf<MzSpectrum>()); // no conversion step needed
+        Assert.That(proxi.XArray, Is.EqualTo(new[] { 100.0, 200.0, 300.0 }));
+        Assert.That(proxi.YArray, Is.EqualTo(new[] { 10.0, 20.0, 30.0 }));
+        Assert.That(proxi.Size, Is.EqualTo(3));
+        Assert.That(proxi.Usi, Is.EqualTo("mzspec:PXD000001:file:scan:1:PEPTIDE/2"));
     }
 
     [Test]
-    public void ToMzSpectrum_SortsPeaksByAscendingMz_KeepingIntensityPairing()
+    public void Constructor_SortsPeaksByAscendingMz_KeepingIntensityPairing()
     {
-        // MzSpectrum assumes ascending m/z; ToMzSpectrum must sort defensively and carry intensities along.
-        var proxi = new PrideProxiSpectrum
-        {
-            Mzs = new[] { 300.0, 100.0, 200.0 },
-            Intensities = new[] { 30.0, 10.0, 20.0 },
-        };
+        // MzSpectrum assumes ascending m/z and never sorts, so the DTO must sort defensively on construction.
+        var proxi = new PrideProxiSpectrum(new[] { 300.0, 100.0, 200.0 }, new[] { 30.0, 10.0, 20.0 });
 
-        MzSpectrum spectrum = proxi.ToMzSpectrum();
-
-        Assert.That(spectrum.XArray, Is.EqualTo(new[] { 100.0, 200.0, 300.0 }));
-        Assert.That(spectrum.YArray, Is.EqualTo(new[] { 10.0, 20.0, 30.0 })); // intensity 10 still paired with m/z 100
+        Assert.That(proxi.XArray, Is.EqualTo(new[] { 100.0, 200.0, 300.0 }));
+        Assert.That(proxi.YArray, Is.EqualTo(new[] { 10.0, 20.0, 30.0 })); // intensity 10 still paired with m/z 100
     }
 
     [Test]
-    public void ToMzSpectrum_DoesNotReorderTheSourceDtoArrays()
+    public void Constructor_DoesNotReorderTheCallersArrays()
     {
-        // the sort works on a copy, so a caller re-reading the DTO sees its original (server) order preserved
-        var proxi = new PrideProxiSpectrum
-        {
-            Mzs = new[] { 300.0, 100.0, 200.0 },
-            Intensities = new[] { 30.0, 10.0, 20.0 },
-        };
+        // the base ctor copies, so the sort cannot reach back and reorder arrays the caller still holds
+        double[] mzs = { 300.0, 100.0, 200.0 };
+        double[] intensities = { 30.0, 10.0, 20.0 };
 
-        proxi.ToMzSpectrum();
+        _ = new PrideProxiSpectrum(mzs, intensities);
 
-        Assert.That(proxi.Mzs, Is.EqualTo(new[] { 300.0, 100.0, 200.0 }));
-        Assert.That(proxi.Intensities, Is.EqualTo(new[] { 30.0, 10.0, 20.0 }));
+        Assert.That(mzs, Is.EqualTo(new[] { 300.0, 100.0, 200.0 }));
+        Assert.That(intensities, Is.EqualTo(new[] { 30.0, 10.0, 20.0 }));
     }
 
     [Test]
-    public void ToMzSpectrum_EmptyPeaks_ReturnsEmptySpectrum()
+    public void Constructor_NoArguments_IsAnEmptySpectrumWithNoMetadata()
     {
-        var proxi = new PrideProxiSpectrum(); // default empty arrays
+        var proxi = new PrideProxiSpectrum();
 
-        MzSpectrum spectrum = proxi.ToMzSpectrum();
-
-        Assert.That(spectrum.Size, Is.EqualTo(0));
+        Assert.That(proxi.Size, Is.EqualTo(0));
+        Assert.That(proxi.Usi, Is.Empty);
+        Assert.That(proxi.Status, Is.Empty);
+        Assert.That(proxi.Attributes, Is.Empty); // never null, so callers can enumerate unguarded
     }
 
     [Test]
-    public void ToMzSpectrum_NullPeakArrays_TreatedAsEmpty()
+    public void Constructor_NullPeakArrays_TreatedAsEmpty()
     {
-        // a deserializer could leave an array null; ToMzSpectrum coalesces to empty rather than throwing NRE
-        var proxi = new PrideProxiSpectrum { Mzs = null, Intensities = null };
+        // a server could omit the peak arrays entirely; coalesce to empty rather than throwing NRE in the base ctor
+        var proxi = new PrideProxiSpectrum(null, null, usi: "mzspec:PXD000001:file:scan:1:PEPTIDE/2");
 
-        MzSpectrum spectrum = proxi.ToMzSpectrum();
-
-        Assert.That(spectrum.Size, Is.EqualTo(0));
+        Assert.That(proxi.Size, Is.EqualTo(0));
     }
 
     [Test]
-    public void ToMzSpectrum_LengthMismatch_ThrowsMzLibException()
+    public void Constructor_LengthMismatch_ThrowsMzLibException()
     {
-        var proxi = new PrideProxiSpectrum
-        {
-            Usi = "mzspec:PXD000001:file:scan:1:PEPTIDE/2",
-            Mzs = new[] { 100.0, 200.0 },
-            Intensities = new[] { 10.0 }, // one short
-        };
+        var ex = Assert.Throws<MzLibException>(() => new PrideProxiSpectrum(
+            new[] { 100.0, 200.0 }, new[] { 10.0 }, // one intensity short
+            usi: "mzspec:PXD000001:file:scan:1:PEPTIDE/2"));
 
-        var ex = Assert.Throws<MzLibException>(() => proxi.ToMzSpectrum());
         Assert.That(ex.Message, Does.Contain("PEPTIDE")); // message names the offending USI
     }
 
+    // ---- ToMsDataScan (pure) -----------------------------------------------
+
     [Test]
-    public void ToMzSpectrum_NullSpectrum_ThrowsArgumentNullException()
+    public void ToMsDataScan_ReadsEveryCvTermPrideActuallySends()
+    {
+        var proxi = new PrideProxiSpectrum(
+            new[] { 110.07, 111.06, 1500.0 }, new[] { 39316.4, 319.7, 12.0 },
+            usi: "mzspec:PXD000561:file:scan:17555:VLHPLEGAVVIIFK/2",
+            status: "READABLE",
+            attributes: RealisticAttributes());
+
+        MsDataScan scan = proxi.ToMsDataScan();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(scan.MassSpectrum, Is.SameAs(proxi)); // the DTO is carried through, not re-wrapped
+            Assert.That(scan.OneBasedScanNumber, Is.EqualTo(17555));  // MS:1003057
+            Assert.That(scan.MsnOrder, Is.EqualTo(2));                // MS:1000511
+            Assert.That(scan.IsCentroid, Is.True);                    // MS:1000525 "centroid spectrum"
+            Assert.That(scan.Polarity, Is.EqualTo(Polarity.Positive));// MS:1000465 "positive scan"
+            Assert.That(scan.RetentionTime, Is.EqualTo(4662.3241 / 60.0).Within(1e-9)); // MS:1000016, seconds -> minutes
+            Assert.That(scan.SelectedIonMZ, Is.EqualTo(767.973937988281).Within(1e-9)); // MS:1000744
+            Assert.That(scan.SelectedIonChargeStateGuess, Is.EqualTo(2));               // MS:1000041
+            Assert.That(scan.IsolationMz, Is.EqualTo(767.973937988281).Within(1e-9));   // MS:1000827
+            Assert.That(scan.IsolationWidth, Is.EqualTo(2.0).Within(1e-9));             // MS:1000828 + MS:1000829
+            Assert.That(scan.InjectionTime, Is.EqualTo(147.372).Within(1e-9));          // MS:1000927
+            Assert.That(scan.ScanFilter, Does.Contain("hcd32.00"));                     // MS:1000512, verbatim
+            Assert.That(scan.NativeId, Is.EqualTo("scan=17555"));
+            Assert.That(scan.TotalIonCurrent, Is.EqualTo(39316.4 + 319.7 + 12.0).Within(1e-9));
+            // the scan window is synthesized from the peaks, since PROXI states none
+            Assert.That(scan.ScanWindowRange.Minimum, Is.EqualTo(110.07).Within(1e-9));
+            Assert.That(scan.ScanWindowRange.Maximum, Is.EqualTo(1500.0).Within(1e-9));
+        });
+    }
+
+    [Test]
+    public void ToMsDataScan_LeavesUnstatedFieldsUnknown_RatherThanGuessing()
+    {
+        // PROXI names the instrument but not the analyzer, and carries no dissociation term at all
+        var proxi = new PrideProxiSpectrum(new[] { 100.0 }, new[] { 1.0 }, attributes: RealisticAttributes());
+
+        MsDataScan scan = proxi.ToMsDataScan();
+
+        Assert.That(scan.MzAnalyzer, Is.EqualTo(MZAnalyzerType.Unknown));
+        Assert.That(scan.DissociationType, Is.EqualTo(DissociationType.Unknown));
+        Assert.That(scan.OneBasedPrecursorScanNumber, Is.Null);
+        Assert.That(scan.NoiseData, Is.Null);
+    }
+
+    [Test]
+    public void ToMsDataScan_NoAttributes_FallsBackToDefaults()
+    {
+        var proxi = new PrideProxiSpectrum(new[] { 100.0, 200.0 }, new[] { 1.0, 2.0 });
+
+        MsDataScan scan = proxi.ToMsDataScan();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(scan.OneBasedScanNumber, Is.EqualTo(1));
+            Assert.That(scan.MsnOrder, Is.EqualTo(2)); // a USI addresses a fragment spectrum
+            Assert.That(scan.IsCentroid, Is.False);
+            Assert.That(scan.Polarity, Is.EqualTo(Polarity.Unknown));
+            Assert.That(scan.RetentionTime, Is.EqualTo(0));
+            Assert.That(scan.SelectedIonMZ, Is.Null);
+            Assert.That(scan.SelectedIonChargeStateGuess, Is.Null);
+            Assert.That(scan.IsolationMz, Is.Null);
+            Assert.That(scan.IsolationWidth, Is.Null);
+            Assert.That(scan.InjectionTime, Is.Null);
+            Assert.That(scan.ScanFilter, Is.Null);
+        });
+    }
+
+    [Test]
+    public void ToMsDataScan_EmptyPeaks_HasNoScanWindow()
+    {
+        MsDataScan scan = new PrideProxiSpectrum().ToMsDataScan();
+
+        Assert.That(scan.ScanWindowRange, Is.Null); // nothing to bound it with
+        Assert.That(scan.TotalIonCurrent, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ToMsDataScan_ReadsPolarityAndCentroidFromBareTerms()
+    {
+        // a PROXI server other than PRIDE may send the PSI terms directly instead of as a value
+        var proxi = new PrideProxiSpectrum(new[] { 100.0 }, new[] { 1.0 }, attributes: new List<CvParam>
+        {
+            Cv("MS:1000129", "negative scan"),
+            Cv("MS:1000127", "centroid spectrum"),
+        });
+
+        MsDataScan scan = proxi.ToMsDataScan();
+
+        Assert.That(scan.Polarity, Is.EqualTo(Polarity.Negative));
+        Assert.That(scan.IsCentroid, Is.True);
+    }
+
+    [Test]
+    public void ToMsDataScan_UnrecognizedPolarityValue_IsUnknown()
+    {
+        var proxi = new PrideProxiSpectrum(new[] { 100.0 }, new[] { 1.0 },
+            attributes: new List<CvParam> { Cv("MS:1000465", "scan polarity", "sideways scan") });
+
+        Assert.That(proxi.ToMsDataScan().Polarity, Is.EqualTo(Polarity.Unknown));
+    }
+
+    [TestCase("UO:0000031", "minute", 12.5)]  // stated in minutes -> taken as-is
+    [TestCase("UO:0000010", "second", 750.0 / 60.0)] // stated in seconds -> converted
+    [TestCase("", "", 750.0 / 60.0)]          // no unit -> seconds, which is what PRIDE serves
+    public void ToMsDataScan_NormalizesRetentionTimeToMinutes(string unitAccession, string unitName, double expected)
+    {
+        double value = unitName == "minute" ? 12.5 : 750.0;
+        var proxi = new PrideProxiSpectrum(new[] { 100.0 }, new[] { 1.0 }, attributes: new List<CvParam>
+        {
+            Cv("MS:1000016", "scan start time", value.ToString(CultureInfo.InvariantCulture), unitAccession, unitName),
+        });
+
+        Assert.That(proxi.ToMsDataScan().RetentionTime, Is.EqualTo(expected).Within(1e-9));
+    }
+
+    [Test]
+    public void ToMsDataScan_IsolationMzFallsBackToPrecursorMz_WhenNoWindowStated()
+    {
+        var proxi = new PrideProxiSpectrum(new[] { 100.0 }, new[] { 1.0 },
+            attributes: new List<CvParam> { Cv("MS:1000744", "selected ion m/z", "500.25") });
+
+        MsDataScan scan = proxi.ToMsDataScan();
+
+        Assert.That(scan.IsolationMz, Is.EqualTo(500.25).Within(1e-9));
+        Assert.That(scan.IsolationWidth, Is.Null); // no offsets stated, so no width is invented
+    }
+
+    [Test]
+    public void ToMsDataScan_OneIsolationOffsetOnly_UsesIt()
+    {
+        var proxi = new PrideProxiSpectrum(new[] { 100.0 }, new[] { 1.0 }, attributes: new List<CvParam>
+        {
+            Cv("MS:1000827", "isolation window target m/z", "500.0"),
+            Cv("MS:1000829", "isolation window upper offset", "1.5"),
+        });
+
+        Assert.That(proxi.ToMsDataScan().IsolationWidth, Is.EqualTo(1.5).Within(1e-9));
+    }
+
+    [Test]
+    public void ToMsDataScan_NonNumericCvValue_IsIgnoredRatherThanThrowing()
+    {
+        var proxi = new PrideProxiSpectrum(new[] { 100.0 }, new[] { 1.0 }, attributes: new List<CvParam>
+        {
+            Cv("MS:1000041", "charge state", "not a number"),
+            Cv("MS:1000511", "ms level", ""),
+        });
+
+        MsDataScan scan = proxi.ToMsDataScan();
+
+        Assert.That(scan.SelectedIonChargeStateGuess, Is.Null);
+        Assert.That(scan.MsnOrder, Is.EqualTo(2)); // falls back to the default
+    }
+
+    [Test]
+    public void ToMsDataScan_ReadsTheFirstOccurrenceOfARepeatedTerm()
+    {
+        // PRIDE sends one "instrument" term per project instrument; a repeated term must not throw
+        var proxi = new PrideProxiSpectrum(new[] { 100.0 }, new[] { 1.0 }, attributes: new List<CvParam>
+        {
+            Cv("MS:1003057", "scan number", "111"),
+            Cv("MS:1003057", "scan number", "222"),
+        });
+
+        Assert.That(proxi.ToMsDataScan().OneBasedScanNumber, Is.EqualTo(111));
+    }
+
+    [Test]
+    public void ToMsDataScan_NullSpectrum_ThrowsArgumentNullException()
     {
         PrideProxiSpectrum proxi = null;
-        Assert.That(() => proxi.ToMzSpectrum(), Throws.ArgumentNullException);
+        Assert.That(() => proxi.ToMsDataScan(), Throws.ArgumentNullException);
     }
 
     // ---- GetProxiSpectrumAsync (offline) -----------------------------------
@@ -166,8 +348,8 @@ public class PrideProxiSpectrumTests
 
         Assert.That(spectrum.Status, Is.EqualTo("READABLE"));
         Assert.That(spectrum.Usi, Is.EqualTo(usi));
-        Assert.That(spectrum.Mzs, Is.EqualTo(new[] { 110.07, 111.06 }));
-        Assert.That(spectrum.Intensities, Is.EqualTo(new[] { 39316.4, 319.7 }));
+        Assert.That(spectrum.XArray, Is.EqualTo(new[] { 110.07, 111.06 }));
+        Assert.That(spectrum.YArray, Is.EqualTo(new[] { 39316.4, 319.7 }));
         Assert.That(spectrum.Attributes.Count, Is.EqualTo(2));
         // attributes map onto CvParam by accession; the charge-state cvParam carries a value, the instrument one does not
         var charge = spectrum.Attributes.FirstOrDefault(a => a.Accession == "MS:1000041");
@@ -220,6 +402,20 @@ public class PrideProxiSpectrumTests
             Throws.InstanceOf<HttpRequestException>());
     }
 
+    [Test]
+    public void GetProxiSpectrumAsync_RaggedPeakArraysOnTheWire_ThrowsMzLibException()
+    {
+        // the parallel-arrays guard runs inside the constructor Newtonsoft deserializes through; it surfaces
+        // unwrapped rather than as a JsonSerializationException, so the documented contract still holds
+        var handler = new StubHandler(_ => JsonResponse(
+            """[{"usi":"mzspec:PXD000001:file:scan:1:PEPTIDE/2","mzs":[100.0,200.0],"intensities":[1.0]}]"""));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        var ex = Assert.ThrowsAsync<MzLibException>(
+            async () => await client.GetProxiSpectrumAsync("mzspec:PXD000001:file:scan:1:PEPTIDE/2"));
+        Assert.That(ex.Message, Does.Contain("PEPTIDE"));
+    }
+
     // ---- GetSpectrumAsync (offline) ----------------------------------------
 
     [Test]
@@ -262,9 +458,18 @@ public class PrideProxiSpectrumLiveTests
             var spectrum = await client.GetProxiSpectrumAsync(KnownUsi);
 
             Assert.That(spectrum.Usi, Is.EqualTo(KnownUsi));
-            Assert.That(spectrum.Mzs.Length, Is.GreaterThan(1));
-            Assert.That(spectrum.Mzs.Length, Is.EqualTo(spectrum.Intensities.Length));
+            Assert.That(spectrum.Size, Is.GreaterThan(1));
+            Assert.That(spectrum.XArray.Length, Is.EqualTo(spectrum.YArray.Length));
             Assert.That(spectrum.Attributes, Is.Not.Empty);
+
+            // the CV attributes read into a real MsDataScan
+            MsDataScan scan = spectrum.ToMsDataScan();
+            Assert.That(scan.MsnOrder, Is.EqualTo(2));
+            Assert.That(scan.OneBasedScanNumber, Is.EqualTo(17555)); // the scan number in the USI
+            Assert.That(scan.SelectedIonChargeStateGuess, Is.EqualTo(2)); // the charge in the USI
+            Assert.That(scan.SelectedIonMZ, Is.Not.Null);
+            Assert.That(scan.Polarity, Is.EqualTo(Polarity.Positive));
+            Assert.That(scan.RetentionTime, Is.GreaterThan(0));
         });
 
     [Test]

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using MassSpectrometry;
 using Newtonsoft.Json;
 
 namespace UsefulProteomicsDatabases
@@ -23,6 +24,14 @@ namespace UsefulProteomicsDatabases
     {
         /// <summary>The base address of the PRIDE Archive REST API (v3).</summary>
         public const string DefaultBaseAddress = "https://www.ebi.ac.uk/pride/ws/archive/v3/";
+
+        /// <summary>
+        /// The base address of PRIDE's PROXI spectrum API. PROXI (the PSI standard for retrieving a spectrum by
+        /// USI) lives under a DIFFERENT path root than the v3 archive API (<see cref="DefaultBaseAddress"/>), so
+        /// PROXI requests are issued as absolute URIs and do not resolve against the client's archive
+        /// <see cref="HttpClient.BaseAddress"/>.
+        /// </summary>
+        public const string DefaultProxiBaseAddress = "https://www.ebi.ac.uk/pride/proxi/archive/v0.1/";
 
         // Explicit JSON nulls must not clobber the non-null string defaults on the DTOs.
         private static readonly JsonSerializerSettings JsonSettings = new() { NullValueHandling = NullValueHandling.Ignore };
@@ -232,6 +241,71 @@ namespace UsefulProteomicsDatabases
                 downloadedPaths.Add(await DownloadFileAsync(file, destinationDirectory, overwrite, cancellationToken).ConfigureAwait(false));
             }
             return downloadedPaths;
+        }
+
+        /// <summary>
+        /// Fetches a single spectrum by its USI (Universal Spectrum Identifier) from PRIDE's PROXI API, returning
+        /// the raw PROXI object: the peak arrays plus the controlled-vocabulary
+        /// <see cref="PrideProxiSpectrum.Attributes"/> (charge, precursor m/z, ms level, scan number,
+        /// instrument, ...). Use <see cref="GetSpectrumAsync"/> instead if you only need the peaks as an
+        /// <see cref="MzSpectrum"/> and can discard the attributes.
+        /// </summary>
+        /// <param name="usi">
+        /// The Universal Spectrum Identifier, e.g.
+        /// "mzspec:PXD000561:Adult_Frontalcortex_bRP_Elite_85_f09:scan:17555:VLHPLEGAVVIIFK/2".
+        /// </param>
+        /// <param name="cancellationToken">Cancels the fetch.</param>
+        /// <returns>The spectrum identified by <paramref name="usi"/>. Never null.</returns>
+        /// <exception cref="ArgumentException">The USI is null, empty, or whitespace.</exception>
+        /// <exception cref="HttpRequestException">
+        /// The API returned a non-success status — PROXI answers an unknown or unreadable USI with 404 and a
+        /// malformed USI with 400 — or returned an empty result for the USI.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The operation was cancelled via <paramref name="cancellationToken"/>.</exception>
+        public async Task<PrideProxiSpectrum> GetProxiSpectrumAsync(string usi, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(usi))
+                throw new ArgumentException("A USI (Universal Spectrum Identifier) is required.", nameof(usi));
+
+            // PROXI is a different path root than the v3 archive BaseAddress, so an archive-relative URI (the
+            // GetProjectFilesAsync pattern) would resolve to the wrong path. An absolute PROXI URI overrides the
+            // client's BaseAddress. resultType=full asks PROXI for the peak arrays, not just the metadata.
+            string requestUri = $"{DefaultProxiBaseAddress}spectra?usi={Uri.EscapeDataString(usi)}&resultType=full";
+            using HttpResponseMessage response = await _httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+                throw new HttpRequestException(
+                    $"PRIDE PROXI request failed with status {(int)response.StatusCode} {response.ReasonPhrase} for '{requestUri}'.");
+
+            string content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            // PROXI wraps its result in a JSON array (one entry per matched spectrum). A USI identifies exactly
+            // one spectrum, so take the first. An empty array on a 200 is a contract oddity — unknown USIs 404
+            // rather than returning [] — so treat "no spectrum" as an error instead of returning null.
+            List<PrideProxiSpectrum> spectra =
+                JsonConvert.DeserializeObject<List<PrideProxiSpectrum>>(content, JsonSettings) ?? new List<PrideProxiSpectrum>();
+            if (spectra.Count == 0 || spectra[0] == null)
+                throw new HttpRequestException($"PRIDE PROXI returned no spectrum for USI '{usi}'.");
+
+            return spectra[0];
+        }
+
+        /// <summary>
+        /// Fetches a spectrum by its USI and returns its peaks as an mzLib <see cref="MzSpectrum"/>. This is the
+        /// convenience over <see cref="GetProxiSpectrumAsync"/> + <see cref="PrideArchiveExtensions.ToMzSpectrum"/>:
+        /// the PROXI metadata attributes are discarded — call <see cref="GetProxiSpectrumAsync"/> to keep them.
+        /// </summary>
+        /// <param name="usi">The Universal Spectrum Identifier.</param>
+        /// <param name="cancellationToken">Cancels the fetch.</param>
+        /// <returns>The spectrum's peaks as an <see cref="MzSpectrum"/> (m/z ascending). Never null.</returns>
+        /// <exception cref="ArgumentException">The USI is null, empty, or whitespace.</exception>
+        /// <exception cref="HttpRequestException">The API returned a non-success status or an empty result for the USI.</exception>
+        /// <exception cref="MzLibUtil.MzLibException">The returned spectrum's peak arrays are not parallel.</exception>
+        /// <exception cref="OperationCanceledException">The operation was cancelled via <paramref name="cancellationToken"/>.</exception>
+        public async Task<MzSpectrum> GetSpectrumAsync(string usi, CancellationToken cancellationToken = default)
+        {
+            PrideProxiSpectrum spectrum = await GetProxiSpectrumAsync(usi, cancellationToken).ConfigureAwait(false);
+            return spectrum.ToMzSpectrum();
         }
 
         /// <summary>Reads the PRIDE "total_records" response header, if present and numeric.</summary>

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
@@ -291,9 +291,12 @@ namespace UsefulProteomicsDatabases
         }
 
         /// <summary>
-        /// Fetches a spectrum by its USI and returns its peaks as an mzLib <see cref="MzSpectrum"/>. This is the
-        /// convenience over <see cref="GetProxiSpectrumAsync"/> + <see cref="PrideArchiveExtensions.ToMzSpectrum"/>:
-        /// the PROXI metadata attributes are discarded — call <see cref="GetProxiSpectrumAsync"/> to keep them.
+        /// Fetches a spectrum by its USI and returns it as an mzLib <see cref="MzSpectrum"/> — the simple case,
+        /// for callers that only want the peaks. The returned object is the <see cref="PrideProxiSpectrum"/>
+        /// itself (which derives from <see cref="MzSpectrum"/>), narrowed to the base type; call
+        /// <see cref="GetProxiSpectrumAsync"/> instead to keep its PROXI metadata attributes in view, or
+        /// <see cref="PrideArchiveExtensions.ToMsDataScan"/> to read those attributes into a full
+        /// <see cref="MsDataScan"/>.
         /// </summary>
         /// <param name="usi">The Universal Spectrum Identifier.</param>
         /// <param name="cancellationToken">Cancels the fetch.</param>
@@ -302,11 +305,8 @@ namespace UsefulProteomicsDatabases
         /// <exception cref="HttpRequestException">The API returned a non-success status or an empty result for the USI.</exception>
         /// <exception cref="MzLibUtil.MzLibException">The returned spectrum's peak arrays are not parallel.</exception>
         /// <exception cref="OperationCanceledException">The operation was cancelled via <paramref name="cancellationToken"/>.</exception>
-        public async Task<MzSpectrum> GetSpectrumAsync(string usi, CancellationToken cancellationToken = default)
-        {
-            PrideProxiSpectrum spectrum = await GetProxiSpectrumAsync(usi, cancellationToken).ConfigureAwait(false);
-            return spectrum.ToMzSpectrum();
-        }
+        public async Task<MzSpectrum> GetSpectrumAsync(string usi, CancellationToken cancellationToken = default) =>
+            await GetProxiSpectrumAsync(usi, cancellationToken).ConfigureAwait(false);
 
         /// <summary>Reads the PRIDE "total_records" response header, if present and numeric.</summary>
         private static bool TryGetTotalRecords(HttpResponseMessage response, out long total)

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveExtensions.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using MassSpectrometry;
 using MzLibUtil;
@@ -9,8 +10,9 @@ namespace UsefulProteomicsDatabases
     /// <summary>
     /// Pure, offline helpers over PRIDE data: resolving a <see cref="PrideArchiveFile"/> to an HTTPS download
     /// URL, filtering / summarizing a manifest (a <see cref="IEnumerable{T}"/> of <see cref="PrideArchiveFile"/>),
-    /// and converting a <see cref="PrideProxiSpectrum"/> to an mzLib <see cref="MzSpectrum"/>. No network access —
-    /// the fetch/download themselves live on <see cref="PrideArchiveClient"/>.
+    /// and reading a <see cref="PrideProxiSpectrum"/>'s controlled-vocabulary metadata into an mzLib
+    /// <see cref="MsDataScan"/>. No network access — the fetch/download themselves live on
+    /// <see cref="PrideArchiveClient"/>.
     /// </summary>
     public static class PrideArchiveExtensions
     {
@@ -140,41 +142,222 @@ namespace UsefulProteomicsDatabases
             return files.Where(f => f != null).Sum(f => f.FileSizeBytes);
         }
 
+        // ---- PROXI spectrum metadata -------------------------------------------------------------------
+        //
+        // The PSI-MS accessions PROXI uses to describe a spectrum. Matched on accession, never on name (see
+        // CvParam's own doc). Verified against a live PRIDE PROXI response for
+        // mzspec:PXD000561:Adult_Frontalcortex_bRP_Elite_85_f09:scan:17555:VLHPLEGAVVIIFK/2.
+
+        /// <summary>"MS:1000511" — ms level (1 for a survey scan, 2 for a fragment spectrum, ...).</summary>
+        private const string MsLevelAccession = "MS:1000511";
+
+        /// <summary>"MS:1003057" — the scan's number within its originating run.</summary>
+        private const string ScanNumberAccession = "MS:1003057";
+
+        /// <summary>"MS:1000041" — the precursor's charge state.</summary>
+        private const string ChargeStateAccession = "MS:1000041";
+
+        /// <summary>"MS:1000744" — the selected (precursor) ion's m/z.</summary>
+        private const string SelectedIonMzAccession = "MS:1000744";
+
+        /// <summary>"MS:1000042" — the selected ion's peak intensity.</summary>
+        private const string SelectedIonIntensityAccession = "MS:1000042";
+
+        /// <summary>"MS:1000827" — the isolation window's target m/z.</summary>
+        private const string IsolationWindowTargetMzAccession = "MS:1000827";
+
+        /// <summary>"MS:1000828" — the isolation window's lower offset from its target.</summary>
+        private const string IsolationWindowLowerOffsetAccession = "MS:1000828";
+
+        /// <summary>"MS:1000829" — the isolation window's upper offset from its target.</summary>
+        private const string IsolationWindowUpperOffsetAccession = "MS:1000829";
+
+        /// <summary>"MS:1000016" — the scan's start (retention) time.</summary>
+        private const string ScanStartTimeAccession = "MS:1000016";
+
+        /// <summary>"MS:1000927" — the ion injection time, in milliseconds.</summary>
+        private const string IonInjectionTimeAccession = "MS:1000927";
+
+        /// <summary>"MS:1000512" — the vendor filter string describing the scan.</summary>
+        private const string FilterStringAccession = "MS:1000512";
+
+        /// <summary>"MS:1000465" — scan polarity, whose value names the polarity ("positive scan"/"negative scan").</summary>
+        private const string ScanPolarityAccession = "MS:1000465";
+
+        /// <summary>"MS:1000130" — positive scan, when polarity is given as a bare term rather than a value.</summary>
+        private const string PositiveScanAccession = "MS:1000130";
+
+        /// <summary>"MS:1000129" — negative scan, when polarity is given as a bare term rather than a value.</summary>
+        private const string NegativeScanAccession = "MS:1000129";
+
+        /// <summary>"MS:1000525" — spectrum representation, whose value is "centroid spectrum" or "profile spectrum".</summary>
+        private const string SpectrumRepresentationAccession = "MS:1000525";
+
+        /// <summary>"MS:1000127" — centroid spectrum, when representation is given as a bare term.</summary>
+        private const string CentroidSpectrumAccession = "MS:1000127";
+
+        /// <summary>"UO:0000031" — the unit term for minutes.</summary>
+        private const string MinuteUnitAccession = "UO:0000031";
+
         /// <summary>
-        /// Converts a <see cref="PrideProxiSpectrum"/>'s parallel <c>mzs</c>/<c>intensities</c> arrays into an
-        /// mzLib <see cref="MzSpectrum"/>. Pure and offline — the fetch lives on
-        /// <see cref="PrideArchiveClient.GetProxiSpectrumAsync"/>. The PROXI metadata
-        /// (<see cref="PrideProxiSpectrum.Attributes"/>) is not carried onto the spectrum; read it from the DTO
-        /// if you need charge, precursor m/z, scan number, etc.
+        /// Reads a <see cref="PrideProxiSpectrum"/>'s controlled-vocabulary <see cref="PrideProxiSpectrum.Attributes"/>
+        /// into a fully-populated mzLib <see cref="MsDataScan"/> — scan number, ms level, polarity, retention time,
+        /// centroid-ness, precursor m/z and charge, isolation window, injection time and filter string — carrying
+        /// the spectrum itself through as the scan's <see cref="MsDataScan.MassSpectrum"/> (a
+        /// <see cref="PrideProxiSpectrum"/> already is an <see cref="MzSpectrum"/>). Pure and offline; the fetch
+        /// lives on <see cref="PrideArchiveClient.GetProxiSpectrumAsync"/>.
         /// </summary>
         /// <remarks>
-        /// <see cref="MzSpectrum"/> assumes an ascending m/z array and neither sorts nor validates its inputs, so
-        /// this method does both defensively: it rejects a mzs/intensities length mismatch, and it sorts a fresh
-        /// copy of the peaks by ascending m/z (PROXI normally already returns them sorted). Sorting a copy leaves
-        /// the DTO's own arrays untouched; because those copies are then owned solely by the spectrum, it is
-        /// constructed with <c>shouldCopy: false</c> to avoid a redundant second copy.
+        /// PROXI describes far less than a vendor file does, so several <see cref="MsDataScan"/> fields are filled
+        /// with the honest "not stated" value rather than a guess:
+        /// <list type="bullet">
+        /// <item><description><see cref="MZAnalyzerType.Unknown"/> — PROXI names the <i>instrument</i>
+        /// ("MS:1000463"), not the mass analyzer, so there is no analyzer term to map. (An mzML-sourced analyzer
+        /// accession would map through <c>Readers.Mzml.AnalyzerDictionary</c>, which is not reachable from this
+        /// project: Readers references UsefulProteomicsDatabases, not the reverse.)</description></item>
+        /// <item><description><see cref="DissociationType.Unknown"/> — PROXI carries no dissociation term; the
+        /// method is recorded only inside the vendor filter string, which is too vendor-specific to parse
+        /// reliably. The filter string is preserved verbatim as <see cref="MsDataScan.ScanFilter"/>.</description></item>
+        /// <item><description>No noise data, and no precursor scan number — PROXI reports neither.</description></item>
+        /// </list>
+        /// Retention time is normalized to <b>minutes</b>, mzLib's convention everywhere. "MS:1000016" is
+        /// interpreted per its unit term when one is present, and as seconds when it is absent — which is what
+        /// PRIDE serves (a live scan reports 4662.32, i.e. 77.7 min, not 4662 min).
+        /// Ms level defaults to 2 and the scan number to 1 when the respective term is absent; a USI addresses a
+        /// fragment spectrum, so 2 is the meaningful default (the same one <c>Mgf</c> hardcodes).
         /// </remarks>
-        /// <param name="spectrum">The PROXI spectrum whose peaks are converted.</param>
-        /// <returns>An <see cref="MzSpectrum"/> of the spectrum's peaks, m/z ascending. Empty if the spectrum has no peaks.</returns>
+        /// <param name="spectrum">The PROXI spectrum to convert.</param>
+        /// <returns>An <see cref="MsDataScan"/> wrapping <paramref name="spectrum"/> and its CV metadata.</returns>
         /// <exception cref="ArgumentNullException">The spectrum is null.</exception>
-        /// <exception cref="MzLibException">The spectrum's mzs and intensities arrays have different lengths.</exception>
-        public static MzSpectrum ToMzSpectrum(this PrideProxiSpectrum spectrum)
+        public static MsDataScan ToMsDataScan(this PrideProxiSpectrum spectrum)
         {
             if (spectrum == null)
                 throw new ArgumentNullException(nameof(spectrum));
 
-            double[] mzs = spectrum.Mzs ?? Array.Empty<double>();
-            double[] intensities = spectrum.Intensities ?? Array.Empty<double>();
-            if (mzs.Length != intensities.Length)
-                throw new MzLibException(
-                    $"PROXI spectrum '{spectrum.Usi}' has {mzs.Length} m/z values but {intensities.Length} intensities; the peak arrays must be parallel.");
+            int scanNumber = GetInt(spectrum, ScanNumberAccession) ?? 1;
+            double? selectedIonMz = GetDouble(spectrum, SelectedIonMzAccession);
 
-            // Copy before sorting so a caller re-reading the DTO's arrays does not see them reordered, then hand
-            // MzSpectrum arrays it alone owns (shouldCopy: false, since Array.Sort already produced fresh arrays).
-            double[] sortedMzs = (double[])mzs.Clone();
-            double[] sortedIntensities = (double[])intensities.Clone();
-            Array.Sort(sortedMzs, sortedIntensities); // sorts intensities as the companion of the m/z key array
-            return new MzSpectrum(sortedMzs, sortedIntensities, shouldCopy: false);
+            // PROXI states the isolation window as a target m/z plus offsets; MsDataScan wants a centre and a
+            // total width. Fall back to the precursor m/z as the centre, as the readers do when only one is known.
+            double? lowerOffset = GetDouble(spectrum, IsolationWindowLowerOffsetAccession);
+            double? upperOffset = GetDouble(spectrum, IsolationWindowUpperOffsetAccession);
+            double? isolationWidth = lowerOffset.HasValue || upperOffset.HasValue
+                ? (lowerOffset ?? 0) + (upperOffset ?? 0)
+                : null;
+
+            // PROXI states no acquisition scan window, so bound it by the peaks actually returned — the same
+            // synthesis Mgf performs for a format that omits it.
+            MzRange scanWindowRange = spectrum.Size > 0
+                ? new MzRange(spectrum.XArray[0], spectrum.XArray[spectrum.Size - 1])
+                : null;
+
+            return new MsDataScan(
+                massSpectrum: spectrum,
+                oneBasedScanNumber: scanNumber,
+                msnOrder: GetInt(spectrum, MsLevelAccession) ?? 2,
+                isCentroid: IsCentroid(spectrum),
+                polarity: GetPolarity(spectrum),
+                retentionTime: GetRetentionTimeInMinutes(spectrum),
+                scanWindowRange: scanWindowRange,
+                scanFilter: GetValue(spectrum, FilterStringAccession),
+                mzAnalyzer: MZAnalyzerType.Unknown,
+                totalIonCurrent: spectrum.SumOfAllY,
+                injectionTime: GetDouble(spectrum, IonInjectionTimeAccession),
+                noiseData: null,
+                nativeId: $"scan={scanNumber}",
+                selectedIonMz: selectedIonMz,
+                selectedIonChargeStateGuess: GetInt(spectrum, ChargeStateAccession),
+                selectedIonIntensity: GetDouble(spectrum, SelectedIonIntensityAccession),
+                isolationMZ: GetDouble(spectrum, IsolationWindowTargetMzAccession) ?? selectedIonMz,
+                isolationWidth: isolationWidth,
+                dissociationType: DissociationType.Unknown,
+                oneBasedPrecursorScanNumber: null,
+                selectedIonMonoisotopicGuessMz: selectedIonMz);
+        }
+
+        /// <summary>
+        /// The value of the first attribute with <paramref name="accession"/>, or null if absent or blank. First,
+        /// not single: PRIDE legitimately repeats a term (one "instrument" per instrument in the project).
+        /// </summary>
+        private static string GetValue(PrideProxiSpectrum spectrum, string accession)
+        {
+            foreach (CvParam attribute in spectrum.Attributes)
+            {
+                if (attribute != null && string.Equals(attribute.Accession, accession, StringComparison.Ordinal))
+                    return string.IsNullOrEmpty(attribute.Value) ? null : attribute.Value;
+            }
+            return null;
+        }
+
+        /// <summary>True if an attribute with <paramref name="accession"/> is present, whatever its value.</summary>
+        private static bool HasAccession(PrideProxiSpectrum spectrum, string accession) =>
+            spectrum.Attributes.Any(a => a != null && string.Equals(a.Accession, accession, StringComparison.Ordinal));
+
+        /// <summary>The first attribute with <paramref name="accession"/> parsed as a double, or null.</summary>
+        private static double? GetDouble(PrideProxiSpectrum spectrum, string accession) =>
+            double.TryParse(GetValue(spectrum, accession), NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
+                ? value
+                : null;
+
+        /// <summary>The first attribute with <paramref name="accession"/> parsed as an int, or null.</summary>
+        private static int? GetInt(PrideProxiSpectrum spectrum, string accession) =>
+            int.TryParse(GetValue(spectrum, accession), NumberStyles.Integer, CultureInfo.InvariantCulture, out int value)
+                ? value
+                : null;
+
+        /// <summary>
+        /// The scan's polarity. PRIDE states it as "MS:1000465" carrying the value "positive scan"/"negative
+        /// scan"; other PROXI servers may instead send the bare PSI terms "MS:1000130"/"MS:1000129". Both forms
+        /// are read; an unstated polarity is <see cref="Polarity.Unknown"/>.
+        /// </summary>
+        private static Polarity GetPolarity(PrideProxiSpectrum spectrum)
+        {
+            if (HasAccession(spectrum, PositiveScanAccession))
+                return Polarity.Positive;
+            if (HasAccession(spectrum, NegativeScanAccession))
+                return Polarity.Negative;
+
+            string polarity = GetValue(spectrum, ScanPolarityAccession);
+            if (polarity == null)
+                return Polarity.Unknown;
+            if (polarity.Contains("positive", StringComparison.OrdinalIgnoreCase))
+                return Polarity.Positive;
+            if (polarity.Contains("negative", StringComparison.OrdinalIgnoreCase))
+                return Polarity.Negative;
+            return Polarity.Unknown;
+        }
+
+        /// <summary>
+        /// Whether the peaks are centroided. PRIDE states this as "MS:1000525" carrying "centroid spectrum";
+        /// other servers may send the bare term "MS:1000127". Absent either, false (profile) is assumed, matching
+        /// the PSI default.
+        /// </summary>
+        private static bool IsCentroid(PrideProxiSpectrum spectrum)
+        {
+            if (HasAccession(spectrum, CentroidSpectrumAccession))
+                return true;
+
+            string representation = GetValue(spectrum, SpectrumRepresentationAccession);
+            return representation != null && representation.Contains("centroid", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// The scan's retention time in minutes, mzLib's convention. "MS:1000016" is converted per its unit term
+        /// when one is present; with no unit term the value is read as seconds, which is what PRIDE serves.
+        /// Zero when the term is absent.
+        /// </summary>
+        private static double GetRetentionTimeInMinutes(PrideProxiSpectrum spectrum)
+        {
+            double? scanStartTime = GetDouble(spectrum, ScanStartTimeAccession);
+            if (!scanStartTime.HasValue)
+                return 0;
+
+            CvParam term = spectrum.Attributes.FirstOrDefault(
+                a => a != null && string.Equals(a.Accession, ScanStartTimeAccession, StringComparison.Ordinal));
+            bool isMinutes = string.Equals(term?.UnitAccession, MinuteUnitAccession, StringComparison.Ordinal)
+                || string.Equals(term?.UnitName, "minute", StringComparison.OrdinalIgnoreCase);
+
+            return isMinutes ? scanStartTime.Value : scanStartTime.Value / 60.0;
         }
     }
 }

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveExtensions.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveExtensions.cs
@@ -1,15 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MassSpectrometry;
 using MzLibUtil;
 
 namespace UsefulProteomicsDatabases
 {
     /// <summary>
-    /// Pure, offline helpers over the PRIDE Archive manifest: resolving a <see cref="PrideArchiveFile"/> to an
-    /// HTTPS download URL, and filtering / summarizing a manifest (a <see cref="IEnumerable{T}"/> of
-    /// <see cref="PrideArchiveFile"/>). No network access — the download itself lives on
-    /// <see cref="PrideArchiveClient"/>.
+    /// Pure, offline helpers over PRIDE data: resolving a <see cref="PrideArchiveFile"/> to an HTTPS download
+    /// URL, filtering / summarizing a manifest (a <see cref="IEnumerable{T}"/> of <see cref="PrideArchiveFile"/>),
+    /// and converting a <see cref="PrideProxiSpectrum"/> to an mzLib <see cref="MzSpectrum"/>. No network access —
+    /// the fetch/download themselves live on <see cref="PrideArchiveClient"/>.
     /// </summary>
     public static class PrideArchiveExtensions
     {
@@ -137,6 +138,43 @@ namespace UsefulProteomicsDatabases
                 throw new ArgumentNullException(nameof(files));
 
             return files.Where(f => f != null).Sum(f => f.FileSizeBytes);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="PrideProxiSpectrum"/>'s parallel <c>mzs</c>/<c>intensities</c> arrays into an
+        /// mzLib <see cref="MzSpectrum"/>. Pure and offline — the fetch lives on
+        /// <see cref="PrideArchiveClient.GetProxiSpectrumAsync"/>. The PROXI metadata
+        /// (<see cref="PrideProxiSpectrum.Attributes"/>) is not carried onto the spectrum; read it from the DTO
+        /// if you need charge, precursor m/z, scan number, etc.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="MzSpectrum"/> assumes an ascending m/z array and neither sorts nor validates its inputs, so
+        /// this method does both defensively: it rejects a mzs/intensities length mismatch, and it sorts a fresh
+        /// copy of the peaks by ascending m/z (PROXI normally already returns them sorted). Sorting a copy leaves
+        /// the DTO's own arrays untouched; because those copies are then owned solely by the spectrum, it is
+        /// constructed with <c>shouldCopy: false</c> to avoid a redundant second copy.
+        /// </remarks>
+        /// <param name="spectrum">The PROXI spectrum whose peaks are converted.</param>
+        /// <returns>An <see cref="MzSpectrum"/> of the spectrum's peaks, m/z ascending. Empty if the spectrum has no peaks.</returns>
+        /// <exception cref="ArgumentNullException">The spectrum is null.</exception>
+        /// <exception cref="MzLibException">The spectrum's mzs and intensities arrays have different lengths.</exception>
+        public static MzSpectrum ToMzSpectrum(this PrideProxiSpectrum spectrum)
+        {
+            if (spectrum == null)
+                throw new ArgumentNullException(nameof(spectrum));
+
+            double[] mzs = spectrum.Mzs ?? Array.Empty<double>();
+            double[] intensities = spectrum.Intensities ?? Array.Empty<double>();
+            if (mzs.Length != intensities.Length)
+                throw new MzLibException(
+                    $"PROXI spectrum '{spectrum.Usi}' has {mzs.Length} m/z values but {intensities.Length} intensities; the peak arrays must be parallel.");
+
+            // Copy before sorting so a caller re-reading the DTO's arrays does not see them reordered, then hand
+            // MzSpectrum arrays it alone owns (shouldCopy: false, since Array.Sort already produced fresh arrays).
+            double[] sortedMzs = (double[])mzs.Clone();
+            double[] sortedIntensities = (double[])intensities.Clone();
+            Array.Sort(sortedMzs, sortedIntensities); // sorts intensities as the companion of the m/z key array
+            return new MzSpectrum(sortedMzs, sortedIntensities, shouldCopy: false);
         }
     }
 }

--- a/mzLib/UsefulProteomicsDatabases/PrideProxiSpectrum.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideProxiSpectrum.cs
@@ -1,42 +1,90 @@
 using System;
 using System.Collections.Generic;
+using MassSpectrometry;
 using MzLibUtil;
+using Newtonsoft.Json;
 
 namespace UsefulProteomicsDatabases
 {
     /// <summary>
     /// One spectrum returned by a PROXI query, keyed by a USI (Universal Spectrum Identifier). PROXI is the
     /// PSI standard REST API for retrieving a spectrum by USI; PRIDE serves it at
-    /// <c>/pride/proxi/archive/v0.1/spectra?usi={usi}&amp;resultType=full</c>. A plain data object populated by
-    /// JSON deserialization: the parallel <see cref="Mzs"/>/<see cref="Intensities"/> peak arrays convert to an
-    /// mzLib <see cref="MassSpectrometry.MzSpectrum"/> via <see cref="PrideArchiveExtensions.ToMzSpectrum"/>, and
-    /// the controlled-vocabulary <see cref="Attributes"/> (charge, precursor m/z, ms level, scan number,
-    /// instrument, ...) are modeled with <see cref="CvParam"/>.
+    /// <c>/pride/proxi/archive/v0.1/spectra?usi={usi}&amp;resultType=full</c>.
+    ///
+    /// This <b>is</b> an mzLib <see cref="MzSpectrum"/> — the wire's parallel <c>mzs</c>/<c>intensities</c>
+    /// arrays become the spectrum's <see cref="MzSpectrum.XArray"/>/<see cref="MzSpectrum.YArray"/>, so a
+    /// fetched PROXI spectrum can be handed directly to anything in mzLib that takes an
+    /// <see cref="MzSpectrum"/>, with no conversion step. On top of that it carries what an
+    /// <see cref="MzSpectrum"/> cannot: the <see cref="Usi"/> it was resolved from, its PROXI
+    /// <see cref="Status"/>, and the controlled-vocabulary <see cref="Attributes"/> (charge, precursor m/z,
+    /// ms level, scan number, instrument, ...) modeled as <see cref="CvParam"/>. Those attributes are read
+    /// into a full <see cref="MsDataScan"/> by <see cref="PrideArchiveExtensions.ToMsDataScan"/>.
     /// </summary>
     /// <remarks>
     /// PROXI is repository-agnostic — the same shape is served by PeptideAtlas, MassIVE, and ProteomeCentral —
     /// so this DTO is not PRIDE-specific beyond where <see cref="PrideArchiveClient"/> points. The wire cvParams
     /// carry <c>accession</c>/<c>name</c>/(optional) <c>value</c> but no <c>cvLabel</c>; the accession prefix
     /// ("MS:", "PRIDE:", "UO:", ...) identifies the source ontology, so match on <see cref="CvParam.Accession"/>.
+    ///
+    /// Because <see cref="MzSpectrum"/> has no parameterless constructor and keeps its peak arrays private to
+    /// set, the peaks must arrive through the constructor rather than being assigned by the deserializer after
+    /// the fact — hence the <see cref="JsonConstructorAttribute"/>. Newtonsoft matches the JSON keys to the
+    /// constructor's parameter names case-insensitively, and supplies null for any key the server omits.
     /// </remarks>
-    public class PrideProxiSpectrum
+    public class PrideProxiSpectrum : MzSpectrum
     {
+        /// <summary>
+        /// Builds a PROXI spectrum from its wire fields. Also the constructor Newtonsoft deserializes through.
+        /// </summary>
+        /// <param name="mzs">The m/z values of the spectrum's peaks. Null is treated as no peaks.</param>
+        /// <param name="intensities">The intensities of the spectrum's peaks, parallel to <paramref name="mzs"/>.</param>
+        /// <param name="usi">The Universal Spectrum Identifier this spectrum was resolved from.</param>
+        /// <param name="status">The spectrum's read status as reported by PROXI (e.g. "READABLE").</param>
+        /// <param name="attributes">The spectrum's controlled-vocabulary metadata terms.</param>
+        /// <exception cref="MzLibException">The mzs and intensities arrays have different lengths.</exception>
+        [JsonConstructor]
+        public PrideProxiSpectrum(double[] mzs = null, double[] intensities = null, string usi = null,
+            string status = null, List<CvParam> attributes = null)
+            // shouldCopy: true because the sort below reorders the arrays in place; copying leaves a caller's
+            // (or the deserializer's) arrays as they were, rather than reordering them behind its back.
+            : base(ValidatedMzs(mzs, intensities, usi), intensities ?? Array.Empty<double>(), shouldCopy: true)
+        {
+            Usi = usi ?? string.Empty;
+            Status = status ?? string.Empty;
+            Attributes = attributes ?? new List<CvParam>();
+
+            // MzSpectrum assumes ascending m/z and neither sorts nor validates, so sort defensively (PROXI
+            // normally already returns them sorted). Sorting in place is safe here: the base constructor was
+            // handed copies. Intensities ride along as the companion of the m/z key array.
+            Array.Sort(XArray, YArray);
+        }
+
+        /// <summary>
+        /// Coalesces the peak arrays and rejects a non-parallel pair, before the base constructor sees them.
+        /// Static because it runs as part of the <c>base(...)</c> call, ahead of any instance state.
+        /// </summary>
+        private static double[] ValidatedMzs(double[] mzs, double[] intensities, string usi)
+        {
+            mzs ??= Array.Empty<double>();
+            intensities ??= Array.Empty<double>();
+            if (mzs.Length != intensities.Length)
+                throw new MzLibException(
+                    $"PROXI spectrum '{usi}' has {mzs.Length} m/z values but {intensities.Length} intensities; the peak arrays must be parallel.");
+            return mzs;
+        }
+
         /// <summary>The spectrum's read status as reported by PROXI (e.g. "READABLE").</summary>
-        public string Status { get; set; } = string.Empty;
+        public string Status { get; }
 
         /// <summary>The Universal Spectrum Identifier this spectrum was resolved from.</summary>
-        public string Usi { get; set; } = string.Empty;
-
-        /// <summary>The m/z values of the spectrum's peaks. Parallel to <see cref="Intensities"/>.</summary>
-        public double[] Mzs { get; set; } = Array.Empty<double>();
-
-        /// <summary>The intensity values of the spectrum's peaks. Parallel to <see cref="Mzs"/>.</summary>
-        public double[] Intensities { get; set; } = Array.Empty<double>();
+        public string Usi { get; }
 
         /// <summary>
         /// Spectrum and dataset metadata as controlled-vocabulary terms — e.g. charge state (MS:1000041),
         /// selected ion m/z (MS:1000744), ms level (MS:1000511), scan number (MS:1003057), instrument model.
+        /// A term may legitimately appear more than once (PRIDE sends one "instrument" term per instrument in
+        /// the originating project), so match the first occurrence rather than expecting a single one.
         /// </summary>
-        public List<CvParam> Attributes { get; set; } = new();
+        public List<CvParam> Attributes { get; }
     }
 }

--- a/mzLib/UsefulProteomicsDatabases/PrideProxiSpectrum.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideProxiSpectrum.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using MzLibUtil;
+
+namespace UsefulProteomicsDatabases
+{
+    /// <summary>
+    /// One spectrum returned by a PROXI query, keyed by a USI (Universal Spectrum Identifier). PROXI is the
+    /// PSI standard REST API for retrieving a spectrum by USI; PRIDE serves it at
+    /// <c>/pride/proxi/archive/v0.1/spectra?usi={usi}&amp;resultType=full</c>. A plain data object populated by
+    /// JSON deserialization: the parallel <see cref="Mzs"/>/<see cref="Intensities"/> peak arrays convert to an
+    /// mzLib <see cref="MassSpectrometry.MzSpectrum"/> via <see cref="PrideArchiveExtensions.ToMzSpectrum"/>, and
+    /// the controlled-vocabulary <see cref="Attributes"/> (charge, precursor m/z, ms level, scan number,
+    /// instrument, ...) are modeled with <see cref="CvParam"/>.
+    /// </summary>
+    /// <remarks>
+    /// PROXI is repository-agnostic — the same shape is served by PeptideAtlas, MassIVE, and ProteomeCentral —
+    /// so this DTO is not PRIDE-specific beyond where <see cref="PrideArchiveClient"/> points. The wire cvParams
+    /// carry <c>accession</c>/<c>name</c>/(optional) <c>value</c> but no <c>cvLabel</c>; the accession prefix
+    /// ("MS:", "PRIDE:", "UO:", ...) identifies the source ontology, so match on <see cref="CvParam.Accession"/>.
+    /// </remarks>
+    public class PrideProxiSpectrum
+    {
+        /// <summary>The spectrum's read status as reported by PROXI (e.g. "READABLE").</summary>
+        public string Status { get; set; } = string.Empty;
+
+        /// <summary>The Universal Spectrum Identifier this spectrum was resolved from.</summary>
+        public string Usi { get; set; } = string.Empty;
+
+        /// <summary>The m/z values of the spectrum's peaks. Parallel to <see cref="Intensities"/>.</summary>
+        public double[] Mzs { get; set; } = Array.Empty<double>();
+
+        /// <summary>The intensity values of the spectrum's peaks. Parallel to <see cref="Mzs"/>.</summary>
+        public double[] Intensities { get; set; } = Array.Empty<double>();
+
+        /// <summary>
+        /// Spectrum and dataset metadata as controlled-vocabulary terms — e.g. charge state (MS:1000041),
+        /// selected ion m/z (MS:1000744), ms level (MS:1000511), scan number (MS:1003057), instrument model.
+        /// </summary>
+        public List<CvParam> Attributes { get; set; } = new();
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/UsefulProteomicsDatabases.csproj
+++ b/mzLib/UsefulProteomicsDatabases/UsefulProteomicsDatabases.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Chemistry\Chemistry.csproj" />
+    <ProjectReference Include="..\MassSpectrometry\MassSpectrometry.csproj" />
     <ProjectReference Include="..\MzLibUtil\MzLibUtil.csproj" />
     <ProjectReference Include="..\Proteomics\Proteomics.csproj" />
     <ProjectReference Include="..\Transcriptomics\Transcriptomics.csproj" />


### PR DESCRIPTION
## The nut

Given a **USI** (Universal Spectrum Identifier), fetch a spectrum from PRIDE and get back something that **is** an mzLib `MzSpectrum` — and, when you want the metadata too, a full `MsDataScan`. The next capability on the PRIDE client after the merged manifest MVP (#1088) and file download (#1093).

## What's here

`PrideProxiSpectrum` **derives from `MzSpectrum`**. A spectrum fetched from PRIDE can be handed straight to anything in mzLib that takes an `MzSpectrum`, with no conversion step. On top of the peaks it carries what an `MzSpectrum` cannot: the `Usi` it was resolved from, its PROXI `Status`, and the controlled-vocabulary `Attributes` (`MzLibUtil.CvParam`, exactly as `PrideArchiveFile` uses them).

New API on `PrideArchiveClient`:
- **`GetProxiSpectrumAsync(usi)` → `PrideProxiSpectrum`** — the spectrum plus its CV attributes.
- **`GetSpectrumAsync(usi)` → `MzSpectrum`** — the simple case; returns that same object narrowed to the base type.

And the piece that turns the CV terms into something mzLib can use:
- **`PrideArchiveExtensions.ToMsDataScan()`** — a pure, offline transform reading the PROXI attributes into a fully-populated `MsDataScan`: scan number, ms level, polarity, retention time, centroid-ness, precursor m/z and charge, isolation window, injection time, filter string. The spectrum itself is carried through as the scan's `MassSpectrum` rather than re-wrapped.

```csharp
using var client = new PrideArchiveClient();
MsDataScan scan = (await client.GetProxiSpectrumAsync(usi)).ToMsDataScan();
```

## Design notes

**Why `[JsonConstructor]`.** `MzSpectrum` has no parameterless constructor and keeps `XArray`/`YArray` private to set, so the peaks must reach the base constructor rather than being assigned by the deserializer afterwards. The DTO is immutable as a result. It sorts ascending on construction (`MzSpectrum` assumes sorted m/z and does not sort itself — the `LibrarySpectrum` pattern) and still rejects a `mzs`/`intensities` length mismatch. That guard now runs *inside* a constructor Newtonsoft invokes, so the contract was verified rather than assumed: the `MzLibException` **surfaces unwrapped**, not as a `JsonSerializationException`. There is a test pinning it.

**The CV mapping was built against a live response, not the spec** — which changed the design:

| Field | PSI form expected | What PRIDE actually sends |
|---|---|---|
| Polarity | `MS:1000130` / `MS:1000129` | `MS:1000465` carrying the value `"positive scan"` |
| Mass analyzer | `MS:1000484` etc. | *nothing* — only `MS:1000463 instrument` |
| Dissociation | `MS:1000422` etc. | *nothing* — only inside the vendor filter string |

Both spellings of polarity and centroid-ness are read, since PROXI is repository-agnostic and another server (PeptideAtlas, MassIVE) may send the bare terms.

**`ToMsDataScan` lives beside the DTO in `UsefulProteomicsDatabases`, not in `Readers`.** `Readers` references `UsefulProteomicsDatabases`, not the reverse, so `Readers.Mzml`'s CV dictionaries are not reachable from here — and per the table above, all three of them miss on PRIDE's payload anyway, so there is essentially nothing to reuse and nothing duplicated.

**Fields PROXI does not state are left `Unknown`/`null` rather than guessed** — `MZAnalyzerType.Unknown`, `DissociationType.Unknown`, no noise data, no precursor scan number. The filter string does encode the dissociation method (`hcd32.00`), but parsing vendor filter strings is too fragile to bury in a converter; it is preserved verbatim as `ScanFilter` so a caller can do that deliberately.

**Retention time is normalized to minutes**, mzLib's convention everywhere — per its unit term when one is present, and as seconds when absent, which is what PRIDE serves. A live scan reports `4662.32`; read as minutes that would be 77 hours rather than 77 minutes.

**Defaults where a term is absent:** ms level 2 and scan number 1. A USI addresses a fragment spectrum, so 2 is the meaningful default (the same one `Mgf` hardcodes). PRIDE sends `MS:1000511` in practice.

**Other notes.** PROXI lives under a different path root than the v3 archive API (`/pride/proxi/archive/v0.1/` vs `/pride/ws/archive/v3/`), so the request is issued as an absolute URI rather than resolving against the client's archive `BaseAddress`. Adds a `MassSpectrometry` project reference to `UsefulProteomicsDatabases` (no cycle — `MassSpectrometry` depends only on `Chemistry` + `MzLibUtil`). A repeated attribute is read first-wins, since PRIDE legitimately sends one `instrument` term per instrument in the originating project.

## Verified against the live API

Probed the real endpoint before writing the DTO and again before writing the CV mapping: `resultType=full` returns a **1-element JSON array** of `{status, usi, mzs[], intensities[], attributes[cvParam]}`; an unknown/unreadable USI returns **404** and a malformed USI **400**, both surfacing as `HttpRequestException` through the existing non-success path.

## Tests

- **22 offline** fixture-based tests: deserialization, URL construction, the error contract, the constructor's sort/length-mismatch/null/empty edges, and `ToMsDataScan` across the full realistic attribute set, the unstated-field defaults, both polarity/centroid spellings, retention-time units, a repeated term, and non-numeric CV values.
- **2 live canaries** carrying `[Category("ExternalService")]` + `[Category("Pride")]`, routed through `ExternalServiceTestHelper` so a PRIDE/EBI outage **skips** while a genuine contract break **fails** — same convention as #1090/#1088/#1093. The canary now also asserts `ToMsDataScan` against the real payload (scan 17555, charge 2, positive polarity, RT > 0), so a PRIDE contract change fails loudly instead of silently degrading to defaults.

All 81 offline PRIDE tests and both live canaries green; full solution builds clean.

## Review history

Revised after review: `PrideProxiSpectrum` was originally a plain DTO with a `ToMzSpectrum()` extension. Per @Alexander-Sol's feedback it is now an `MzSpectrum` subclass, and `ToMzSpectrum` is removed as unnecessary. `ToMsDataScan` is new in the same revision. **The DTO's shape changed (it is now immutable, constructed rather than object-initialized), so this needs a fresh look from earlier approvers.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
