### PR TITLE
Expand elastase|P cleavage specificity

### DIFF
--- a/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
+++ b/mzLib/Proteomics/ProteolyticDigestion/proteases.tsv
@@ -100,7 +100,7 @@ Arg-C	R|	full	MS:1001303	Arg-C
 Asp-N	|D	full	MS:1001304	Asp-N	
 chymotrypsin|P	F[P]|,W[P]|,Y[P]|,L[P]|	full	MS:1001306	Chymotrypsin	
 CNBr	M|	full	MS:1001307	CNBr	Homoserine lactone on M
-elastase|P	A[P]|,V[P]|,S[P]|,G[P]|,L[P]|,I[P]|	full		Elastase	
+elastase|P	I[P]|,S[P]|,L[P]|,V[P]|,N[P]|,T[P]|,K[P]|,A[P]|,G[P]|,Y[P]|,Q[P]|,R[P]|,F[P]|,D[P]|	full		Elastase	
 Glu-C	E|	full			
 Glu-C (with asp)	E|,D|	full			
 Lys-C|P	K[P]|	full	MS:1001309	Lys-C	

--- a/mzLib/Test/ProteomicsTests/ProteolyticDigestion/PeptideWithSetModsDecoyTests.cs
+++ b/mzLib/Test/ProteomicsTests/ProteolyticDigestion/PeptideWithSetModsDecoyTests.cs
@@ -102,11 +102,13 @@ namespace Test.ProteomicsTests.ProteolyticDigestion
             Assert.AreEqual("MKEITPMEP", p_cnbr_reverse.BaseSequence);
             Assert.AreEqual(p_cnbr.FullSequence, p_cnbr_reverse.PeptideDescription);
 
-            //  elastase cleave after A, V, S, G, L, I,
+            //  elastase cleave after I, S, L, V, N, T, K, A, G, Y, Q, R, F, D (not before P)
+            //  Only V(3, blocked by the following P), P(4) and H(8) are not cleavage residues,
+            //  so every other position is pinned and just those three are reversed into place.
             newAminoAcidPositions = new int["KAYVPSRGHLDIN".Length];
             PeptideWithSetModifications p_elastase = new PeptideWithSetModifications(new Protein("KAYVPSRGHLDIN", "DECOY_ELASTASE"), new DigestionParams(protease: "elastase|P"), 1, 13, CleavageSpecificity.Semi, null, 0, new Dictionary<int, Modification>(), 0, null);
             PeptideWithSetModifications p_elastase_reverse = p_elastase.GetReverseDecoyFromTarget(newAminoAcidPositions);
-            Assert.AreEqual("NADHRSPGVLYIK", p_elastase_reverse.BaseSequence);
+            Assert.AreEqual("KAYHPSRGVLDIN", p_elastase_reverse.BaseSequence);
 
             //  top-down
             newAminoAcidPositions = new int["RPEPTIREK".Length];


### PR DESCRIPTION
## What

Expands the cleavage specificity of `elastase|P` in `proteases.tsv` from six P1 residues to fourteen based on substantial work I have done analyzing samples digested with elastase.

| | P1 residues |
|---|---|
| Before | `A, V, S, G, L, I` |
| After | `I, S, L, V, N, T, K, A, G, Y, Q, R, F, D` |

Added: **N, T, K, Y, Q, R, F, D**. Nothing was removed.

All motifs keep the existing `X[P]|` form, so the "do not cleave before proline" restriction is unchanged. The `full` specificity, blank PSI-MS accession and `Elastase` PSI-MS name are untouched.

## Why

The previous six-residue set corresponds to the reagent-vendor description of porcine pancreatic elastase. In practice elastase digests show a considerably wider range of P1 residues, and the enzyme behaves much closer to semi-specific than the textbook `A/V/S/G/L/I` rule implies. Restricting the definition to six residues means genuine elastase peptides are not generated during in-silico digestion and therefore cannot be identified.

Worth being explicit for reviewers: this is a deliberate move away from the strict enzymological definition toward observed cleavage behaviour. For reference, other tools sit at or below the previous set — MSFragger uses `AGILV`, Skyline `GVLIA`, and PSI-MS `MS:1001915` uses `ALIV`; Comet and Mascot ship no elastase entry at all. This change makes mzLib's elastase deliberately broader than any of them.

## Impact

`elastase|P` is opt-in, so nothing changes for users of other proteases. For users who do select it, this produces more (and shorter) candidate peptides and a correspondingly larger search space.

## Test changes

One existing expectation changed, in `PeptideWithSetModsDecoyTests.TestReverseDecoyFromTarget`.

Reverse-decoy generation pins cleavage-site residues in place and reverses everything else, so a larger motif set pins more positions. For the test protein `KAYVPSRGHLDIN`, only three positions are now unpinned — `V` (blocked by the following `P`), `P`, and `H` — so the decoy becomes `KAYHPSRGVLDIN` rather than `NADHRSPGVLYIK`.

The new expected value was derived by hand from the algorithm in `PeptideWithSetModifications.GetReverseDecoyFromTarget` and then confirmed against the implementation, rather than copied from the observed output.

This incidentally illustrates a real property of near-nonspecific proteases: reverse decoys degrade as the motif set grows, because most residues get pinned and the decoy ends up close to the target. Not addressed here, but it may be worth considering whether scrambled decoys are more appropriate for broad-specificity enzymes.

Full suite green locally: **5267 passed, 0 failed, 29 skipped**.

## Notes for a follow-up (not in this PR)

While reviewing this file a few unrelated issues surfaced that are worth separate PRs:

- `subtilisin|P` cites `MS:1001312`, which is actually **TrypChymo** (`(?<=[FYWLKR])(?!P)`). PSI-MS has no subtilisin term, so this should probably be blank.
- `trypsin` and `trypsin|P` both cite `MS:1001313`. The proline-blocking variant should likely be `MS:1001251`.
- `singleN`/`singleC` cite `MS:1001957`/`MS:1001958`, which are regex terms rather than cleavage-agent names.
- `elastase|P` has no accession, though `MS:1001915` exists.
- `TestDigestionMotif.cs:49-50` hard-codes `F[P]|,W[P]|,Y[P]|` and asserts a count of 3 for chymotrypsin. It parses a literal string rather than reading the tsv, so it silently went stale when leucine was added in #759 and the real entry became four motifs.
