### PR TITLE
Read PRIDE project metadata by accession (PrideProject + Try/GetProjectAsync)

### DIFF
--- a/mzLib/Test/DatabaseTests/PrideProjectTests.cs
+++ b/mzLib/Test/DatabaseTests/PrideProjectTests.cs
@@ -182,7 +182,7 @@ public class PrideProjectTests
     }
 
     [Test]
-    public async Task GetProjectAsync_CvParamGroups_DeserializeAndKeyOnAccession()
+    public async Task GetProjectAsync_CvParamGroups_Deserialize()
     {
         using var client = ClientReturning(ProjectJson);
 
@@ -210,10 +210,10 @@ public class PrideProjectTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(project.QuantificationMethods, Is.Empty);
-            Assert.That(project.OrganismParts, Is.Empty);
-            Assert.That(project.Diseases, Is.Empty);
-            Assert.That(project.AdditionalAttributes, Is.Empty);
+            Assert.That(project.QuantificationMethods, Is.Not.Null.And.Empty);
+            Assert.That(project.OrganismParts, Is.Not.Null.And.Empty);
+            Assert.That(project.Diseases, Is.Not.Null.And.Empty);
+            Assert.That(project.AdditionalAttributes, Is.Not.Null.And.Empty);
         });
     }
 
@@ -304,11 +304,11 @@ public class PrideProjectTests
             Assert.That(project.Accession, Is.EqualTo("PXD000001"));
             Assert.That(project.Title, Is.Empty);
             Assert.That(project.Doi, Is.Empty);
-            Assert.That(project.Instruments, Is.Empty);
-            Assert.That(project.Submitters, Is.Empty);
-            Assert.That(project.References, Is.Empty);
-            Assert.That(project.SampleAttributes, Is.Empty);
-            Assert.That(project.ProjectTags, Is.Empty);
+            Assert.That(project.Instruments, Is.Not.Null.And.Empty);
+            Assert.That(project.Submitters, Is.Not.Null.And.Empty);
+            Assert.That(project.References, Is.Not.Null.And.Empty);
+            Assert.That(project.SampleAttributes, Is.Not.Null.And.Empty);
+            Assert.That(project.ProjectTags, Is.Not.Null.And.Empty);
         });
     }
 
@@ -367,6 +367,33 @@ public class PrideProjectTests
             Is.EqualTo("https://www.ebi.ac.uk/pride/ws/archive/v3/projects/PXD%23frag"));
     }
 
+    /// <summary>
+    /// The traversal case, which is the reason the escape matters: an accession containing path
+    /// separators must stay a single path segment rather than climbing out of projects/. It is asserted
+    /// through AbsolutePath, captured in the responder, because the recorded RequestedUris uses
+    /// Uri.ToString(), which renders %2F back as "/" and would show a traversal that did not occur.
+    /// </summary>
+    [Test]
+    public async Task GetProjectAsync_AccessionWithPathSeparators_CannotEscapeTheProjectsSegment()
+    {
+        string absolutePath = null;
+        var handler = new StubHandler(request =>
+        {
+            absolutePath = request.RequestUri.AbsolutePath;
+            return JsonResponse(ProjectJson);
+        });
+        using var client = ClientReturning(null, handler: handler);
+
+        await client.GetProjectAsync("PXD/../../evil");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(absolutePath, Is.EqualTo("/pride/ws/archive/v3/projects/PXD%2F..%2F..%2Fevil"));
+            Assert.That(absolutePath, Does.StartWith("/pride/ws/archive/v3/projects/"));
+            Assert.That(absolutePath, Does.Not.Contain("/.."));
+        });
+    }
+
     // ---- error contract -----------------------------------------------------
     // Kept offline deliberately: the live fixture routes through ExternalServiceTestHelper, which
     // converts HttpRequestException into Assert.Ignore — so a LIVE negative test would be silently
@@ -384,8 +411,11 @@ public class PrideProjectTests
         var handler = new StubHandler(_ => JsonResponse(ProjectJson));
         using var client = ClientReturning(null, handler: handler);
 
-        Assert.That(async () => await client.GetProjectAsync(accession), Throws.InstanceOf<ArgumentException>());
-        Assert.That(handler.RequestedUris, Is.Empty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(async () => await client.GetProjectAsync(accession), Throws.InstanceOf<ArgumentException>());
+            Assert.That(handler.RequestedUris, Is.Empty);
+        });
     }
 
     [Test]
@@ -395,8 +425,11 @@ public class PrideProjectTests
         var handler = new StubHandler(_ => JsonResponse(ProjectJson));
         using var client = ClientReturning(null, handler: handler);
 
-        Assert.That(async () => await client.TryGetProjectAsync(accession), Throws.InstanceOf<ArgumentException>());
-        Assert.That(handler.RequestedUris, Is.Empty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(async () => await client.TryGetProjectAsync(accession), Throws.InstanceOf<ArgumentException>());
+            Assert.That(handler.RequestedUris, Is.Empty);
+        });
     }
 
     /// <summary>An unknown accession 404s on this endpoint — unlike the manifest, which answers 200 [].</summary>
@@ -462,15 +495,6 @@ public class PrideProjectTests
         using var client = ClientReturning("upstream failure", status);
 
         Assert.That(async () => await client.TryGetProjectAsync("PXD012345"),
-            Throws.InstanceOf<HttpRequestException>());
-    }
-
-    [Test]
-    public void GetProjectAsync_NonSuccessStatus_ThrowsHttpRequestException()
-    {
-        using var client = ClientReturning("server error", HttpStatusCode.InternalServerError);
-
-        Assert.That(async () => await client.GetProjectAsync("PXD012345"),
             Throws.InstanceOf<HttpRequestException>());
     }
 
@@ -588,6 +612,11 @@ public class PrideProjectLiveTests
                 // "Expected: True, But was: False", which cannot be triaged from a CI log.
                 Assert.That(project.Instruments, Is.All.Matches<CvParam>(i => !string.IsNullOrEmpty(i.Accession)));
                 Assert.That(project.Submitters, Is.Not.Empty);
+                // The nested key/value shape is the likeliest place for the wire format to drift, and
+                // the offline fixture cannot notice drift because it is a frozen copy of that format.
+                Assert.That(project.SampleAttributes, Is.Not.Empty);
+                Assert.That(project.SampleAttributes,
+                    Is.All.Matches<PrideSampleAttribute>(a => !string.IsNullOrEmpty(a.Key.Accession) && a.Value.Count > 0));
             });
         });
 

--- a/mzLib/Test/DatabaseTests/PrideProjectTests.cs
+++ b/mzLib/Test/DatabaseTests/PrideProjectTests.cs
@@ -1,0 +1,517 @@
+using NUnit.Framework;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using UsefulProteomicsDatabases;
+
+namespace Test.DatabaseTests;
+
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class PrideProjectTests
+{
+    // ---- test doubles -------------------------------------------------------
+
+    /// <summary>An HttpMessageHandler that returns a caller-supplied response and records request URIs.</summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+        public List<string> RequestedUris { get; } = new();
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestedUris.Add(request.RequestUri.ToString());
+            return Task.FromResult(_responder(request));
+        }
+    }
+
+    private static HttpResponseMessage JsonResponse(string body, HttpStatusCode status = HttpStatusCode.OK)
+        => new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    /// <summary>
+    /// A PRIDE project metadata object in the real v3 wire shape, captured live from
+    /// <c>projects/PXD012345</c> on 2026-07-21 and trimmed to one entry per collection. Note the
+    /// bare calendar dates, the "@type" discriminators, and that sampleAttributes nests a CvParam
+    /// key against a list of CvParam values.
+    /// </summary>
+    private const string ProjectJson =
+        """
+        {
+          "accession": "PXD012345",
+          "title": "Metaproteomics benchmark dataset",
+          "projectDescription": "A benchmark of four organisms.",
+          "sampleProcessingProtocol": "Cells were lysed and digested with trypsin.",
+          "dataProcessingProtocol": "Searched with MaxQuant against a combined database.",
+          "doi": "10.6019/PXD012345",
+          "submissionType": "COMPLETE",
+          "license": "CC BY 4.0",
+          "submissionDate": "2019-01-15",
+          "publicationDate": "2025-07-13",
+          "projectTags": ["Technical", "Metaproteomics"],
+          "keywords": ["benchmark"],
+          "countries": ["Italy"],
+          "submitters": [
+            {
+              "title": "Professor",
+              "firstName": "Anna Laura",
+              "lastName": "Capriotti",
+              "identifier": "11200124",
+              "affiliation": "Sapienza University of Rome",
+              "email": "annalaura.capriotti@uniroma1.it",
+              "country": "Italy",
+              "orcid": "",
+              "name": "Anna Laura Capriotti",
+              "id": "11200124"
+            }
+          ],
+          "labPIs": [
+            { "title": "Dr", "firstName": "Aldo", "lastName": "Lagana", "affiliation": "Sapienza", "email": "", "country": "Italy", "orcid": "0000-0002-1234-5678", "name": "Aldo Lagana", "id": "99" }
+          ],
+          "references": [
+            { "referenceLine": "Macedo-Silva C et al. Cell Death Discov. 2025 11(1):306", "pubmedID": 40610411, "doi": "10.1038/s41420-025-02597-4" }
+          ],
+          "instruments": [ { "@type": "CvParam", "cvLabel": "MS", "accession": "MS:1000449", "name": "LTQ Orbitrap" } ],
+          "softwares": [ { "@type": "CvParam", "cvLabel": "MS", "accession": "MS:1001583", "name": "MaxQuant" } ],
+          "experimentTypes": [ { "@type": "CvParam", "cvLabel": "MS", "accession": "MS:1000550", "name": "Shotgun proteomics" } ],
+          "quantificationMethods": [],
+          "organisms": [ { "@type": "CvParam", "cvLabel": "NEWT", "accession": "NEWT:4530", "name": "Oryza sativa (rice)" } ],
+          "organismParts": [],
+          "diseases": [],
+          "identifiedPTMStrings": [ { "@type": "CvParam", "cvLabel": "PRIDE", "accession": "PRIDE:0000398", "name": "No PTMs are included in the dataset" } ],
+          "additionalAttributes": [],
+          "sampleAttributes": [
+            {
+              "@type": "Tuple",
+              "key": { "cvLabel": "EFO", "accession": "OBI:0100026", "name": "organism" },
+              "value": [
+                { "cvLabel": "NEWT", "accession": "NEWT:5476", "name": "Candida albicans (Yeast)" },
+                { "cvLabel": "NEWT", "accession": "NEWT:562", "name": "Escherichia coli" }
+              ]
+            }
+          ],
+          "totalFileDownloads": 19,
+          "botCount": 3,
+          "hubCount": 1,
+          "organicCount": 15
+        }
+        """;
+
+    private static PrideArchiveClient ClientReturning(string body, HttpStatusCode status = HttpStatusCode.OK,
+        StubHandler handler = null)
+    {
+        handler ??= new StubHandler(_ => JsonResponse(body, status));
+        return new PrideArchiveClient(new HttpClient(handler));
+    }
+
+    // ---- deserialization ----------------------------------------------------
+
+    [Test]
+    public async Task GetProjectAsync_RealWireShape_DeserializesScalarFields()
+    {
+        using var client = ClientReturning(ProjectJson);
+
+        PrideProject project = await client.GetProjectAsync("PXD012345");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project.Accession, Is.EqualTo("PXD012345"));
+            Assert.That(project.Title, Is.EqualTo("Metaproteomics benchmark dataset"));
+            Assert.That(project.ProjectDescription, Is.EqualTo("A benchmark of four organisms."));
+            Assert.That(project.SampleProcessingProtocol, Does.StartWith("Cells were lysed"));
+            Assert.That(project.DataProcessingProtocol, Does.StartWith("Searched with MaxQuant"));
+            Assert.That(project.Doi, Is.EqualTo("10.6019/PXD012345"));
+            Assert.That(project.SubmissionType, Is.EqualTo("COMPLETE"));
+            Assert.That(project.License, Is.EqualTo("CC BY 4.0"));
+            Assert.That(project.TotalFileDownloads, Is.EqualTo(19));
+            Assert.That(project.BotCount, Is.EqualTo(3));
+            Assert.That(project.HubCount, Is.EqualTo(1));
+            Assert.That(project.OrganicCount, Is.EqualTo(15));
+        });
+    }
+
+    /// <summary>
+    /// The dates arrive as bare calendar dates with no time and no UTC offset, which is why they are
+    /// modeled as DateTime rather than the DateTimeOffset used on PrideArchiveFile. Asserting the
+    /// whole value (rather than just the date part) pins that no machine-local offset crept in.
+    /// </summary>
+    [Test]
+    public async Task GetProjectAsync_BareCalendarDates_ParseWithoutTimeZoneDrift()
+    {
+        using var client = ClientReturning(ProjectJson);
+
+        PrideProject project = await client.GetProjectAsync("PXD012345");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project.SubmissionDate, Is.EqualTo(new DateTime(2019, 1, 15)));
+            Assert.That(project.PublicationDate, Is.EqualTo(new DateTime(2025, 7, 13)));
+        });
+    }
+
+    [Test]
+    public async Task GetProjectAsync_StringArrays_Deserialize()
+    {
+        using var client = ClientReturning(ProjectJson);
+
+        PrideProject project = await client.GetProjectAsync("PXD012345");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project.ProjectTags, Is.EqualTo(new[] { "Technical", "Metaproteomics" }));
+            Assert.That(project.Keywords, Is.EqualTo(new[] { "benchmark" }));
+            Assert.That(project.Countries, Is.EqualTo(new[] { "Italy" }));
+        });
+    }
+
+    [Test]
+    public async Task GetProjectAsync_CvParamGroups_DeserializeAndKeyOnAccession()
+    {
+        using var client = ClientReturning(ProjectJson);
+
+        PrideProject project = await client.GetProjectAsync("PXD012345");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project.Instruments.Single().Accession, Is.EqualTo("MS:1000449"));
+            Assert.That(project.Instruments.Single().Name, Is.EqualTo("LTQ Orbitrap"));
+            Assert.That(project.Instruments.Single().CvLabel, Is.EqualTo("MS"));
+            Assert.That(project.Softwares.Single().Accession, Is.EqualTo("MS:1001583"));
+            Assert.That(project.ExperimentTypes.Single().Accession, Is.EqualTo("MS:1000550"));
+            Assert.That(project.Organisms.Single().Accession, Is.EqualTo("NEWT:4530"));
+            Assert.That(project.IdentifiedPTMStrings.Single().Accession, Is.EqualTo("PRIDE:0000398"));
+        });
+    }
+
+    /// <summary>Empty CV collections must arrive as empty lists, never null — the class promises "never null".</summary>
+    [Test]
+    public async Task GetProjectAsync_EmptyCvCollections_AreEmptyNotNull()
+    {
+        using var client = ClientReturning(ProjectJson);
+
+        PrideProject project = await client.GetProjectAsync("PXD012345");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project.QuantificationMethods, Is.Empty);
+            Assert.That(project.OrganismParts, Is.Empty);
+            Assert.That(project.Diseases, Is.Empty);
+            Assert.That(project.AdditionalAttributes, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task GetProjectAsync_Submitters_DeserializeEveryContactField()
+    {
+        using var client = ClientReturning(ProjectJson);
+
+        PrideContact submitter = (await client.GetProjectAsync("PXD012345")).Submitters.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(submitter.Title, Is.EqualTo("Professor"));
+            Assert.That(submitter.FirstName, Is.EqualTo("Anna Laura"));
+            Assert.That(submitter.LastName, Is.EqualTo("Capriotti"));
+            Assert.That(submitter.Name, Is.EqualTo("Anna Laura Capriotti"));
+            Assert.That(submitter.Affiliation, Is.EqualTo("Sapienza University of Rome"));
+            Assert.That(submitter.Email, Is.EqualTo("annalaura.capriotti@uniroma1.it"));
+            Assert.That(submitter.Country, Is.EqualTo("Italy"));
+            Assert.That(submitter.Orcid, Is.Empty);
+            Assert.That(submitter.Id, Is.EqualTo("11200124"));
+        });
+    }
+
+    [Test]
+    public async Task GetProjectAsync_LabPIs_Deserialize()
+    {
+        using var client = ClientReturning(ProjectJson);
+
+        PrideContact pi = (await client.GetProjectAsync("PXD012345")).LabPIs.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(pi.Name, Is.EqualTo("Aldo Lagana"));
+            Assert.That(pi.Orcid, Is.EqualTo("0000-0002-1234-5678"));
+            Assert.That(pi.Email, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task GetProjectAsync_References_DeserializeIncludingNumericPubmedId()
+    {
+        using var client = ClientReturning(ProjectJson);
+
+        PrideReference reference = (await client.GetProjectAsync("PXD012345")).References.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(reference.PubmedId, Is.EqualTo(40610411));
+            Assert.That(reference.Doi, Is.EqualTo("10.1038/s41420-025-02597-4"));
+            Assert.That(reference.ReferenceLine, Does.Contain("Cell Death Discov"));
+        });
+    }
+
+    /// <summary>
+    /// sampleAttributes is the only nested shape PRIDE sends: a single CvParam key against a LIST of
+    /// CvParam values. The "@type": "Tuple" discriminator must be ignored, not bound.
+    /// </summary>
+    [Test]
+    public async Task GetProjectAsync_SampleAttributes_DeserializeKeyAndValueList()
+    {
+        using var client = ClientReturning(ProjectJson);
+
+        PrideSampleAttribute attribute = (await client.GetProjectAsync("PXD012345")).SampleAttributes.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(attribute.Key.Accession, Is.EqualTo("OBI:0100026"));
+            Assert.That(attribute.Key.Name, Is.EqualTo("organism"));
+            Assert.That(attribute.Value, Has.Count.EqualTo(2));
+            Assert.That(attribute.Value.Select(v => v.Accession), Is.EqualTo(new[] { "NEWT:5476", "NEWT:562" }));
+        });
+    }
+
+    /// <summary>
+    /// PRIDE omits fields for sparsely-annotated projects. Absent members must fall back to the DTO's
+    /// non-null defaults rather than becoming null.
+    /// </summary>
+    [Test]
+    public async Task GetProjectAsync_MinimalPayload_LeavesDefaultsIntact()
+    {
+        using var client = ClientReturning("""{ "accession": "PXD000001" }""");
+
+        PrideProject project = await client.GetProjectAsync("PXD000001");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project.Accession, Is.EqualTo("PXD000001"));
+            Assert.That(project.Title, Is.Empty);
+            Assert.That(project.Doi, Is.Empty);
+            Assert.That(project.Instruments, Is.Empty);
+            Assert.That(project.Submitters, Is.Empty);
+            Assert.That(project.References, Is.Empty);
+            Assert.That(project.SampleAttributes, Is.Empty);
+            Assert.That(project.ProjectTags, Is.Empty);
+        });
+    }
+
+    /// <summary>An explicit JSON null must not clobber a non-null DTO default (NullValueHandling.Ignore).</summary>
+    [Test]
+    public async Task GetProjectAsync_ExplicitJsonNulls_DoNotClobberDefaults()
+    {
+        using var client = ClientReturning("""
+            { "accession": "PXD000001", "title": null, "instruments": null, "submitters": null, "projectTags": null }
+            """);
+
+        PrideProject project = await client.GetProjectAsync("PXD000001");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project.Title, Is.Empty);
+            Assert.That(project.Instruments, Is.Not.Null.And.Empty);
+            Assert.That(project.Submitters, Is.Not.Null.And.Empty);
+            Assert.That(project.ProjectTags, Is.Not.Null.And.Empty);
+        });
+    }
+
+    // ---- request construction -----------------------------------------------
+
+    /// <summary>
+    /// This endpoint shares the v3 base address, so the request must resolve as a RELATIVE URI —
+    /// unlike PROXI, which sits under a different path root and needs an absolute one.
+    /// </summary>
+    [Test]
+    public async Task GetProjectAsync_BuildsRelativeV3Uri()
+    {
+        var handler = new StubHandler(_ => JsonResponse(ProjectJson));
+        using var client = ClientReturning(null, handler: handler);
+
+        await client.GetProjectAsync("PXD012345");
+
+        Assert.That(handler.RequestedUris.Single(),
+            Is.EqualTo("https://www.ebi.ac.uk/pride/ws/archive/v3/projects/PXD012345"));
+    }
+
+    /// <summary>
+    /// The accession is caller-supplied, so it is escaped before being interpolated into the path.
+    /// A "#" is the assertable case: unescaped it would truncate the request into a fragment and
+    /// silently fetch the wrong project. (Uri.ToString() renders %20 and %2F back in decoded form,
+    /// so those cannot be asserted through the recorded URI even though they are escaped too.)
+    /// </summary>
+    [Test]
+    public async Task GetProjectAsync_EscapesAccessionIntoPath()
+    {
+        var handler = new StubHandler(_ => JsonResponse(ProjectJson));
+        using var client = ClientReturning(null, handler: handler);
+
+        await client.GetProjectAsync("PXD#frag");
+
+        Assert.That(handler.RequestedUris.Single(),
+            Is.EqualTo("https://www.ebi.ac.uk/pride/ws/archive/v3/projects/PXD%23frag"));
+    }
+
+    // ---- error contract -----------------------------------------------------
+    // Kept offline deliberately: the live fixture routes through ExternalServiceTestHelper, which
+    // converts HttpRequestException into Assert.Ignore — so a LIVE negative test would be silently
+    // skipped rather than passed, and would prove nothing.
+
+    [Test]
+    public void GetProjectAsync_BlankAccession_ThrowsArgumentException(
+        [Values(null, "", "   ")] string accession)
+    {
+        using var client = ClientReturning(ProjectJson);
+
+        Assert.That(async () => await client.GetProjectAsync(accession), Throws.ArgumentException);
+    }
+
+    [Test]
+    public void TryGetProjectAsync_BlankAccession_ThrowsArgumentException()
+    {
+        using var client = ClientReturning(ProjectJson);
+
+        Assert.That(async () => await client.TryGetProjectAsync("  "), Throws.ArgumentException);
+    }
+
+    /// <summary>An unknown accession 404s on this endpoint — unlike the manifest, which answers 200 [].</summary>
+    [Test]
+    public async Task TryGetProjectAsync_UnknownAccession_ReturnsFalseAndNull()
+    {
+        using var client = ClientReturning("", HttpStatusCode.NotFound);
+
+        (bool found, PrideProject project) = await client.TryGetProjectAsync("PXD999999999");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(found, Is.False);
+            Assert.That(project, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task TryGetProjectAsync_KnownAccession_ReturnsTrueAndProject()
+    {
+        using var client = ClientReturning(ProjectJson);
+
+        (bool found, PrideProject project) = await client.TryGetProjectAsync("PXD012345");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(found, Is.True);
+            Assert.That(project, Is.Not.Null);
+            Assert.That(project.Accession, Is.EqualTo("PXD012345"));
+        });
+    }
+
+    [Test]
+    public void GetProjectAsync_UnknownAccession_ThrowsHttpRequestException()
+    {
+        using var client = ClientReturning("", HttpStatusCode.NotFound);
+
+        Assert.That(async () => await client.GetProjectAsync("PXD999999999"),
+            Throws.InstanceOf<HttpRequestException>().With.Message.Contains("PXD999999999"));
+    }
+
+    /// <summary>
+    /// The whole point of the Try contract: only a 404 is an absence. A service outage must still
+    /// throw, so that it can never be misreported to the caller as "no such project".
+    /// </summary>
+    [Test]
+    public void TryGetProjectAsync_ServiceUnavailable_ThrowsRatherThanReportingNotFound(
+        [Values(HttpStatusCode.InternalServerError, HttpStatusCode.ServiceUnavailable,
+                HttpStatusCode.RequestTimeout, HttpStatusCode.TooManyRequests)] HttpStatusCode status)
+    {
+        using var client = ClientReturning("upstream failure", status);
+
+        Assert.That(async () => await client.TryGetProjectAsync("PXD012345"),
+            Throws.InstanceOf<HttpRequestException>());
+    }
+
+    [Test]
+    public void GetProjectAsync_NonSuccessStatus_ThrowsHttpRequestException()
+    {
+        using var client = ClientReturning("server error", HttpStatusCode.InternalServerError);
+
+        Assert.That(async () => await client.GetProjectAsync("PXD012345"),
+            Throws.InstanceOf<HttpRequestException>());
+    }
+
+    /// <summary>A 200 carrying no project is a broken contract, not an absence — so it throws rather than reporting not-found.</summary>
+    [Test]
+    public void TryGetProjectAsync_EmptyBodyOn200_ThrowsHttpRequestException()
+    {
+        using var client = ClientReturning("null");
+
+        Assert.That(async () => await client.TryGetProjectAsync("PXD012345"),
+            Throws.InstanceOf<HttpRequestException>());
+    }
+
+    [Test]
+    public void GetProjectAsync_Cancelled_ThrowsOperationCanceledException()
+    {
+        using var client = ClientReturning(ProjectJson);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.That(async () => await client.GetProjectAsync("PXD012345", cts.Token),
+            Throws.InstanceOf<OperationCanceledException>());
+    }
+}
+
+/// <summary>
+/// Live canary against the real PRIDE Archive API. Carries [Category("ExternalService")] so CI runs
+/// it in the dedicated, non-blocking external-service job (see .github/workflows/dotnet.yml) rather
+/// than the required unit-test run; [Category("Pride")] allows selecting it on its own. The call is
+/// routed through <see cref="ExternalServiceTestHelper.RunAsync"/> so a PRIDE outage (timeout / 5xx /
+/// unreachable) SKIPS the test, while a genuine contract break (wrong URL, unparseable response,
+/// missing value) still FAILS. Run on demand — or in the external-service job — to detect API drift.
+/// </summary>
+/// <remarks>
+/// Only positive assertions belong here. A live "unknown accession" test would raise the very
+/// HttpRequestException that RunAsync treats as an outage, so it would be silently skipped rather
+/// than passed; that coverage lives offline in <see cref="PrideProjectTests"/>.
+/// </remarks>
+[TestFixture]
+[Category("ExternalService")]
+[Category("Pride")]
+[ExcludeFromCodeCoverage]
+public class PrideProjectLiveTests
+{
+    [Test]
+    public Task GetProjectAsync_LivePxd012345_ReturnsPopulatedMetadata() =>
+        ExternalServiceTestHelper.RunAsync("PRIDE", async () =>
+        {
+            using var client = new PrideArchiveClient();
+            PrideProject project = await client.GetProjectAsync("PXD012345");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(project.Accession, Is.EqualTo("PXD012345"));
+                Assert.That(project.Title, Is.Not.Empty);
+                Assert.That(project.SubmissionDate, Is.Not.EqualTo(default(DateTime)));
+                Assert.That(project.Instruments, Is.Not.Empty);
+                Assert.That(project.Instruments.All(i => !string.IsNullOrEmpty(i.Accession)));
+                Assert.That(project.Submitters, Is.Not.Empty);
+            });
+        });
+
+    [Test]
+    public Task TryGetProjectAsync_LiveUnknownAccession_ReportsNotFound() =>
+        ExternalServiceTestHelper.RunAsync("PRIDE", async () =>
+        {
+            using var client = new PrideArchiveClient();
+            (bool found, PrideProject project) = await client.TryGetProjectAsync("PXD999999999");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(found, Is.False);
+                Assert.That(project, Is.Null);
+            });
+        });
+}

--- a/mzLib/Test/DatabaseTests/PrideProjectTests.cs
+++ b/mzLib/Test/DatabaseTests/PrideProjectTests.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using MzLibUtil;
 using UsefulProteomicsDatabases;
 
 namespace Test.DatabaseTests;
@@ -139,9 +140,14 @@ public class PrideProjectTests
 
     /// <summary>
     /// The dates arrive as bare calendar dates with no time and no UTC offset, which is why they are
-    /// modeled as DateTime rather than the DateTimeOffset used on PrideArchiveFile. Asserting the
-    /// whole value (rather than just the date part) pins that no machine-local offset crept in.
+    /// modeled as DateTime rather than the DateTimeOffset used on PrideArchiveFile.
     /// </summary>
+    /// <remarks>
+    /// DateTime equality ignores Kind, so comparing values alone would still pass if the deserializer
+    /// attached a machine-local offset — the exact drift this test exists to catch. Kind is therefore
+    /// asserted explicitly: Unspecified means no zone was invented, and the time component must be
+    /// midnight because the wire carries no time at all.
+    /// </remarks>
     [Test]
     public async Task GetProjectAsync_BareCalendarDates_ParseWithoutTimeZoneDrift()
     {
@@ -153,6 +159,10 @@ public class PrideProjectTests
         {
             Assert.That(project.SubmissionDate, Is.EqualTo(new DateTime(2019, 1, 15)));
             Assert.That(project.PublicationDate, Is.EqualTo(new DateTime(2025, 7, 13)));
+            Assert.That(project.SubmissionDate.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+            Assert.That(project.PublicationDate.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+            Assert.That(project.SubmissionDate.TimeOfDay, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(project.PublicationDate.TimeOfDay, Is.EqualTo(TimeSpan.Zero));
         });
     }
 
@@ -362,21 +372,31 @@ public class PrideProjectTests
     // converts HttpRequestException into Assert.Ignore — so a LIVE negative test would be silently
     // skipped rather than passed, and would prove nothing.
 
+    /// <summary>
+    /// InstanceOf, not Throws.ArgumentException: the latter is an exact-type constraint, which would pin
+    /// the null case away from the BCL's ArgumentNullException idiom should the guard ever adopt it.
+    /// Asserting no request was recorded proves the guard runs BEFORE the network call, not after.
+    /// </summary>
     [Test]
-    public void GetProjectAsync_BlankAccession_ThrowsArgumentException(
+    public void GetProjectAsync_BlankAccession_ThrowsArgumentExceptionWithoutCallingTheApi(
         [Values(null, "", "   ")] string accession)
     {
-        using var client = ClientReturning(ProjectJson);
+        var handler = new StubHandler(_ => JsonResponse(ProjectJson));
+        using var client = ClientReturning(null, handler: handler);
 
-        Assert.That(async () => await client.GetProjectAsync(accession), Throws.ArgumentException);
+        Assert.That(async () => await client.GetProjectAsync(accession), Throws.InstanceOf<ArgumentException>());
+        Assert.That(handler.RequestedUris, Is.Empty);
     }
 
     [Test]
-    public void TryGetProjectAsync_BlankAccession_ThrowsArgumentException()
+    public void TryGetProjectAsync_BlankAccession_ThrowsArgumentExceptionWithoutCallingTheApi(
+        [Values(null, "", "   ")] string accession)
     {
-        using var client = ClientReturning(ProjectJson);
+        var handler = new StubHandler(_ => JsonResponse(ProjectJson));
+        using var client = ClientReturning(null, handler: handler);
 
-        Assert.That(async () => await client.TryGetProjectAsync("  "), Throws.ArgumentException);
+        Assert.That(async () => await client.TryGetProjectAsync(accession), Throws.InstanceOf<ArgumentException>());
+        Assert.That(handler.RequestedUris, Is.Empty);
     }
 
     /// <summary>An unknown accession 404s on this endpoint — unlike the manifest, which answers 200 [].</summary>
@@ -409,13 +429,25 @@ public class PrideProjectTests
         });
     }
 
+    /// <summary>
+    /// "No such project" must NOT be an HttpRequestException. That type means "the service is
+    /// unavailable" and ExternalServiceTestHelper converts it to a skipped test, so a withdrawn
+    /// accession would silently pass instead of failing. It is an MzLibException, and this test pins
+    /// that it is not an HttpRequestException so the distinction cannot regress.
+    /// </summary>
     [Test]
-    public void GetProjectAsync_UnknownAccession_ThrowsHttpRequestException()
+    public void GetProjectAsync_UnknownAccession_ThrowsMzLibExceptionNotHttpRequestException()
     {
         using var client = ClientReturning("", HttpStatusCode.NotFound);
 
-        Assert.That(async () => await client.GetProjectAsync("PXD999999999"),
-            Throws.InstanceOf<HttpRequestException>().With.Message.Contains("PXD999999999"));
+        MzLibException exception = Assert.ThrowsAsync<MzLibException>(
+            async () => await client.GetProjectAsync("PXD999999999"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Does.Contain("PXD999999999"));
+            Assert.That(exception, Is.Not.InstanceOf<HttpRequestException>());
+        });
     }
 
     /// <summary>
@@ -442,14 +474,66 @@ public class PrideProjectTests
             Throws.InstanceOf<HttpRequestException>());
     }
 
-    /// <summary>A 200 carrying no project is a broken contract, not an absence — so it throws rather than reporting not-found.</summary>
+    /// <summary>
+    /// A 200 carrying no project is a broken contract, not an absence — so it throws, and as an
+    /// MzLibException rather than an HttpRequestException so a live run fails instead of skipping.
+    /// Both the literal "null" payload and a genuinely empty body deserialize to null and must behave
+    /// identically; the empty body is the case a real proxy or truncated response produces.
+    /// </summary>
     [Test]
-    public void TryGetProjectAsync_EmptyBodyOn200_ThrowsHttpRequestException()
+    public void TryGetProjectAsync_NoProjectOn200_ThrowsMzLibException(
+        [Values("null", "", "   ")] string body)
     {
-        using var client = ClientReturning("null");
+        using var client = ClientReturning(body);
 
         Assert.That(async () => await client.TryGetProjectAsync("PXD012345"),
-            Throws.InstanceOf<HttpRequestException>());
+            Throws.InstanceOf<MzLibException>());
+    }
+
+    /// <summary>
+    /// An empty JSON object deserializes to a fully-defaulted PrideProject, which would otherwise be
+    /// returned as a successful result carrying nothing. A real project always has its accession.
+    /// </summary>
+    [Test]
+    public void TryGetProjectAsync_EmptyJsonObject_ThrowsMzLibException()
+    {
+        using var client = ClientReturning("{}");
+
+        Assert.That(async () => await client.TryGetProjectAsync("PXD012345"),
+            Throws.InstanceOf<MzLibException>().With.Message.Contains("no accession"));
+    }
+
+    /// <summary>
+    /// NullValueHandling.Ignore suppresses null values, not null ELEMENTS, so a null inside a CV array
+    /// would otherwise survive into a collection documented as never-null and NRE at first dereference.
+    /// </summary>
+    [Test]
+    public async Task TryGetProjectAsync_NullElementsInArrays_AreDropped()
+    {
+        using var client = ClientReturning("""
+            {
+              "accession": "PXD012345",
+              "instruments": [ null, { "accession": "MS:1000449", "name": "LTQ Orbitrap" }, null ],
+              "projectTags": [ null, "Technical" ],
+              "submitters": [ null ],
+              "sampleAttributes": [
+                null,
+                { "key": { "accession": "OBI:0100026" }, "value": [ null, { "accession": "NEWT:562" } ] }
+              ]
+            }
+            """);
+
+        (_, PrideProject project) = await client.TryGetProjectAsync("PXD012345");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(project.Instruments, Has.Count.EqualTo(1));
+            Assert.That(project.Instruments.Single().Accession, Is.EqualTo("MS:1000449"));
+            Assert.That(project.ProjectTags, Is.EqualTo(new[] { "Technical" }));
+            Assert.That(project.Submitters, Is.Empty);
+            Assert.That(project.SampleAttributes, Has.Count.EqualTo(1));
+            Assert.That(project.SampleAttributes.Single().Value.Single().Accession, Is.EqualTo("NEWT:562"));
+        });
     }
 
     [Test]
@@ -473,9 +557,13 @@ public class PrideProjectTests
 /// missing value) still FAILS. Run on demand — or in the external-service job — to detect API drift.
 /// </summary>
 /// <remarks>
-/// Only positive assertions belong here. A live "unknown accession" test would raise the very
-/// HttpRequestException that RunAsync treats as an outage, so it would be silently skipped rather
-/// than passed; that coverage lives offline in <see cref="PrideProjectTests"/>.
+/// What the live unknown-accession canary below can and cannot catch, stated precisely because the
+/// distinction is easy to get wrong: if PRIDE ever answered a nonexistent accession with 200 and a
+/// project, TryGetProjectAsync would report Found = true and the test FAILS, which is the drift worth
+/// catching. If PRIDE instead answered 5xx, that is indistinguishable from an outage and RunAsync
+/// skips — so the test cannot prove 404 is still 404. The exhaustive error-contract coverage
+/// therefore lives offline in <see cref="PrideProjectTests"/>, where the status code is dictated by a
+/// stub rather than by EBI's mood.
 /// </remarks>
 [TestFixture]
 [Category("ExternalService")]
@@ -496,7 +584,9 @@ public class PrideProjectLiveTests
                 Assert.That(project.Title, Is.Not.Empty);
                 Assert.That(project.SubmissionDate, Is.Not.EqualTo(default(DateTime)));
                 Assert.That(project.Instruments, Is.Not.Empty);
-                Assert.That(project.Instruments.All(i => !string.IsNullOrEmpty(i.Accession)));
+                // Constraint form, not Assert.That(bool): a collapsed LINQ predicate reports only
+                // "Expected: True, But was: False", which cannot be triaged from a CI log.
+                Assert.That(project.Instruments, Is.All.Matches<CvParam>(i => !string.IsNullOrEmpty(i.Accession)));
                 Assert.That(project.Submitters, Is.Not.Empty);
             });
         });

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -130,6 +131,83 @@ namespace UsefulProteomicsDatabases
             }
 
             return files;
+        }
+
+        /// <summary>
+        /// Returns the metadata describing a PRIDE Archive project — title, protocols, instruments,
+        /// species, publications and submitters — letting a caller judge and cite a dataset before
+        /// downloading any of it. Use <see cref="TryGetProjectAsync"/> instead when the accession comes
+        /// from user input and may simply not exist.
+        /// </summary>
+        /// <param name="accession">The PRIDE project accession, e.g. "PXD012345".</param>
+        /// <param name="cancellationToken">Cancels the fetch.</param>
+        /// <returns>The project's metadata. Never null.</returns>
+        /// <exception cref="ArgumentException">The accession is null, empty, or whitespace.</exception>
+        /// <exception cref="HttpRequestException">
+        /// No project has that accession — unlike <see cref="GetProjectFilesAsync"/>, which answers an
+        /// unknown accession with an empty manifest, this endpoint answers with 404 — or the API returned
+        /// some other non-success status, or an empty body.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The operation was cancelled via <paramref name="cancellationToken"/>.</exception>
+        public async Task<PrideProject> GetProjectAsync(string accession, CancellationToken cancellationToken = default)
+        {
+            (bool found, PrideProject project) = await TryGetProjectAsync(accession, cancellationToken).ConfigureAwait(false);
+
+            if (!found)
+                throw new HttpRequestException($"PRIDE Archive has no project with accession '{accession}'.");
+
+            return project;
+        }
+
+        /// <summary>
+        /// Attempts to fetch a PRIDE Archive project's metadata, reporting a non-existent accession as a
+        /// value rather than an exception — the cheap way to validate an accession a user typed.
+        /// </summary>
+        /// <remarks>
+        /// <c>Found</c> is false for one reason only: PRIDE answered, and no project has that accession
+        /// (HTTP 404). Every other failure — the service being unreachable, timing out, rate-limiting, or
+        /// returning 5xx — still throws, because collapsing an outage into "no such project" would send a
+        /// caller hunting for a typo in a perfectly good accession. This is also what lets a live test
+        /// distinguish "PRIDE is down, skip" from "the contract broke, fail".
+        /// </remarks>
+        /// <param name="accession">The PRIDE project accession, e.g. "PXD012345".</param>
+        /// <param name="cancellationToken">Cancels the fetch.</param>
+        /// <returns>
+        /// <c>Found</c> and the project when the accession exists; <c>false</c> and null when PRIDE reports
+        /// no such project. The project is never null when <c>Found</c> is true.
+        /// </returns>
+        /// <exception cref="ArgumentException">The accession is null, empty, or whitespace.</exception>
+        /// <exception cref="HttpRequestException">The API was unreachable, returned a non-success status other than 404, or returned an empty body.</exception>
+        /// <exception cref="OperationCanceledException">The operation was cancelled via <paramref name="cancellationToken"/>.</exception>
+        public async Task<(bool Found, PrideProject Project)> TryGetProjectAsync(string accession,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(accession))
+                throw new ArgumentException("A PRIDE project accession is required.", nameof(accession));
+
+            // This endpoint shares the v3 BaseAddress, so a relative URI resolves correctly (unlike PROXI,
+            // which sits under a different path root and needs an absolute URI).
+            string requestUri = $"projects/{Uri.EscapeDataString(accession)}";
+            using HttpResponseMessage response = await _httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
+
+            // 404 is the ONE expected "no" and is reported as a value. It is checked before the general
+            // status guard so that every other failure still throws.
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return (false, null);
+
+            if (!response.IsSuccessStatusCode)
+                throw new HttpRequestException(
+                    $"PRIDE Archive request failed with status {(int)response.StatusCode} {response.ReasonPhrase} for '{requestUri}'.");
+
+            string content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            // Unlike the manifest and PROXI endpoints, this one returns a bare object rather than an array,
+            // so there is nothing to unwrap. A 200 carrying no project is a broken contract, not an absence.
+            PrideProject project = JsonConvert.DeserializeObject<PrideProject>(content, JsonSettings);
+            if (project == null)
+                throw new HttpRequestException($"PRIDE Archive returned an empty body for accession '{accession}'.");
+
+            return (true, project);
         }
 
         /// <summary>

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
@@ -7,19 +7,29 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using MassSpectrometry;
+using MzLibUtil;
 using Newtonsoft.Json;
 
 namespace UsefulProteomicsDatabases
 {
     /// <summary>
     /// A client for the PRIDE Archive REST API (https://www.ebi.ac.uk/pride/ws/archive/v3/) that makes
-    /// EBI PRIDE proteomics dataset data available to mzLib. The initial capability, given a project
-    /// accession (e.g. "PXD012345"), is to return the complete manifest of that project's files.
+    /// EBI PRIDE proteomics dataset data available to mzLib. Given a project accession (e.g. "PXD012345")
+    /// it returns the project's metadata, the complete manifest of its files, and the files' bytes; it
+    /// also fetches individual spectra by USI through the PROXI standard.
     /// </summary>
     /// <remarks>
+    /// Two failure kinds are deliberately given different exception types, because callers — and
+    /// <c>ExternalServiceTestHelper</c>, which skips a live test on <see cref="HttpRequestException"/> —
+    /// must be able to tell them apart. The service being unreachable, timing out or answering 5xx is an
+    /// <see cref="HttpRequestException"/>. PRIDE answering successfully but with something the contract
+    /// forbids — no such project, an empty body, a payload missing its accession — is an
+    /// <see cref="MzLibException"/>, so it fails loudly instead of being mistaken for an outage.
+    /// <para>
     /// Holds one reusable <see cref="HttpClient"/> and is <see cref="IDisposable"/>. Use one instance
     /// per unit of work and dispose it. A constructor overload accepts an <see cref="HttpClient"/> to
     /// support testing and custom configuration.
+    /// </para>
     /// </remarks>
     public sealed class PrideArchiveClient : IDisposable
     {
@@ -143,18 +153,21 @@ namespace UsefulProteomicsDatabases
         /// <param name="cancellationToken">Cancels the fetch.</param>
         /// <returns>The project's metadata. Never null.</returns>
         /// <exception cref="ArgumentException">The accession is null, empty, or whitespace.</exception>
-        /// <exception cref="HttpRequestException">
+        /// <exception cref="MzLibException">
         /// No project has that accession — unlike <see cref="GetProjectFilesAsync"/>, which answers an
-        /// unknown accession with an empty manifest, this endpoint answers with 404 — or the API returned
-        /// some other non-success status, or an empty body.
+        /// unknown accession with an empty manifest, this endpoint answers with 404. This is deliberately
+        /// NOT an <see cref="HttpRequestException"/>: that type means "the service is unavailable" and is
+        /// converted to a skipped test by <c>ExternalServiceTestHelper</c>, which would let a withdrawn
+        /// accession pass unnoticed instead of failing.
         /// </exception>
+        /// <exception cref="HttpRequestException">The API was unreachable or returned a non-success status other than 404.</exception>
         /// <exception cref="OperationCanceledException">The operation was cancelled via <paramref name="cancellationToken"/>.</exception>
         public async Task<PrideProject> GetProjectAsync(string accession, CancellationToken cancellationToken = default)
         {
             (bool found, PrideProject project) = await TryGetProjectAsync(accession, cancellationToken).ConfigureAwait(false);
 
             if (!found)
-                throw new HttpRequestException($"PRIDE Archive has no project with accession '{accession}'.");
+                throw new MzLibException($"PRIDE Archive has no project with accession '{accession}'.");
 
             return project;
         }
@@ -177,7 +190,8 @@ namespace UsefulProteomicsDatabases
         /// no such project. The project is never null when <c>Found</c> is true.
         /// </returns>
         /// <exception cref="ArgumentException">The accession is null, empty, or whitespace.</exception>
-        /// <exception cref="HttpRequestException">The API was unreachable, returned a non-success status other than 404, or returned an empty body.</exception>
+        /// <exception cref="HttpRequestException">The API was unreachable or returned a non-success status other than 404.</exception>
+        /// <exception cref="MzLibException">PRIDE answered successfully but the payload was empty or carried no accession — a broken contract rather than an absence.</exception>
         /// <exception cref="OperationCanceledException">The operation was cancelled via <paramref name="cancellationToken"/>.</exception>
         public async Task<(bool Found, PrideProject Project)> TryGetProjectAsync(string accession,
             CancellationToken cancellationToken = default)
@@ -202,10 +216,24 @@ namespace UsefulProteomicsDatabases
             string content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
             // Unlike the manifest and PROXI endpoints, this one returns a bare object rather than an array,
-            // so there is nothing to unwrap. A 200 carrying no project is a broken contract, not an absence.
+            // so there is nothing to unwrap. A 200 carrying no project is a broken contract, not an absence,
+            // so it throws MzLibException rather than HttpRequestException — the latter would be read as an
+            // outage and silently skip a live test.
             PrideProject project = JsonConvert.DeserializeObject<PrideProject>(content, JsonSettings);
             if (project == null)
-                throw new HttpRequestException($"PRIDE Archive returned an empty body for accession '{accession}'.");
+                throw new MzLibException($"PRIDE Archive returned an empty body for accession '{accession}'.");
+
+            // An empty JSON object deserializes to a fully-defaulted instance, which would otherwise be
+            // handed back as a successful result. The accession is always present on a real project, so its
+            // absence means the payload is not one.
+            if (string.IsNullOrEmpty(project.Accession))
+                throw new MzLibException(
+                    $"PRIDE Archive returned a payload with no accession for '{accession}'; the response is not a project.");
+
+            // NullValueHandling.Ignore suppresses null *values*, not null *elements*: PRIDE sending
+            // "instruments": [null] would otherwise put a null inside a collection the DTO documents as
+            // never-null, and NRE at the caller's first dereference.
+            RemoveNullElements(project);
 
             return (true, project);
         }
@@ -385,6 +413,34 @@ namespace UsefulProteomicsDatabases
         /// <exception cref="OperationCanceledException">The operation was cancelled via <paramref name="cancellationToken"/>.</exception>
         public async Task<MzSpectrum> GetSpectrumAsync(string usi, CancellationToken cancellationToken = default) =>
             await GetProxiSpectrumAsync(usi, cancellationToken).ConfigureAwait(false);
+
+        /// <summary>
+        /// Drops null elements from every collection on a deserialized <see cref="PrideProject"/>, so the
+        /// type's documented "never null" guarantee covers the elements and not merely the collections.
+        /// </summary>
+        private static void RemoveNullElements(PrideProject project)
+        {
+            project.ProjectTags.RemoveAll(x => x == null);
+            project.Keywords.RemoveAll(x => x == null);
+            project.Countries.RemoveAll(x => x == null);
+            project.Submitters.RemoveAll(x => x == null);
+            project.LabPIs.RemoveAll(x => x == null);
+            project.References.RemoveAll(x => x == null);
+            project.Instruments.RemoveAll(x => x == null);
+            project.Softwares.RemoveAll(x => x == null);
+            project.ExperimentTypes.RemoveAll(x => x == null);
+            project.QuantificationMethods.RemoveAll(x => x == null);
+            project.Organisms.RemoveAll(x => x == null);
+            project.OrganismParts.RemoveAll(x => x == null);
+            project.Diseases.RemoveAll(x => x == null);
+            project.IdentifiedPTMStrings.RemoveAll(x => x == null);
+            project.AdditionalAttributes.RemoveAll(x => x == null);
+            project.SampleAttributes.RemoveAll(x => x == null);
+
+            // A surviving sample attribute can still hold nulls in its own value list.
+            foreach (PrideSampleAttribute attribute in project.SampleAttributes)
+                attribute.Value.RemoveAll(x => x == null);
+        }
 
         /// <summary>Reads the PRIDE "total_records" response header, if present and numeric.</summary>
         private static bool TryGetTotalRecords(HttpResponseMessage response, out long total)

--- a/mzLib/UsefulProteomicsDatabases/PrideContact.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideContact.cs
@@ -1,0 +1,46 @@
+namespace UsefulProteomicsDatabases
+{
+    /// <summary>
+    /// A person associated with a PRIDE Archive project — a submitter or a lab principal
+    /// investigator — as returned by the PRIDE Archive REST API (v3 <c>projects/{accession}</c>).
+    /// A plain data object populated by JSON deserialization.
+    /// </summary>
+    /// <remarks>
+    /// PRIDE returns an empty string, not a missing field, for contact details the submitter chose
+    /// not to publish; <see cref="Orcid"/> is empty for most historical submissions. Every member
+    /// therefore defaults to the empty string rather than null.
+    /// </remarks>
+    public class PrideContact
+    {
+        /// <summary>The person's honorific (e.g. "Professor", "Dr"), if given.</summary>
+        public string Title { get; set; } = string.Empty;
+
+        /// <summary>The person's given name(s).</summary>
+        public string FirstName { get; set; } = string.Empty;
+
+        /// <summary>The person's family name.</summary>
+        public string LastName { get; set; } = string.Empty;
+
+        /// <summary>The full display name as PRIDE composes it (first name + last name).</summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>The person's institution.</summary>
+        public string Affiliation { get; set; } = string.Empty;
+
+        /// <summary>The person's contact e-mail, if published; otherwise empty.</summary>
+        public string Email { get; set; } = string.Empty;
+
+        /// <summary>The person's country.</summary>
+        public string Country { get; set; } = string.Empty;
+
+        /// <summary>The person's ORCID iD, if published; otherwise empty.</summary>
+        public string Orcid { get; set; } = string.Empty;
+
+        /// <summary>PRIDE's internal identifier for this person.</summary>
+        /// <remarks>
+        /// PRIDE emits this value twice, as both "id" and "identifier"; they have been observed to
+        /// agree. Only one is modeled here, bound to "id".
+        /// </remarks>
+        public string Id { get; set; } = string.Empty;
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/PrideProject.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideProject.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using MzLibUtil;
+
+namespace UsefulProteomicsDatabases
+{
+    /// <summary>
+    /// The metadata describing one PRIDE Archive project, as returned by the PRIDE Archive REST API
+    /// (v3 <c>projects/{accession}</c>). A plain data object populated by JSON deserialization;
+    /// controlled-vocabulary fields are modeled with <see cref="CvParam"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is the "inspect before you download" companion to
+    /// <see cref="PrideArchiveClient.GetProjectFilesAsync"/> — it lets a caller judge and cite a
+    /// dataset without fetching gigabytes of spectra.
+    /// <para>
+    /// Match every controlled-vocabulary member on its <see cref="CvParam.Accession"/>, not on its
+    /// <see cref="CvParam.Name"/>: the accession is stable across PRIDE releases and the display
+    /// name is not. Members PRIDE omits for a given project arrive as empty collections or empty
+    /// strings, never null.
+    /// </para>
+    /// </remarks>
+    public class PrideProject
+    {
+        /// <summary>The ProteomeXchange accession (e.g. "PXD012345").</summary>
+        public string Accession { get; set; } = string.Empty;
+
+        /// <summary>The project title.</summary>
+        public string Title { get; set; } = string.Empty;
+
+        /// <summary>The submitter's free-text description of the project.</summary>
+        public string ProjectDescription { get; set; } = string.Empty;
+
+        /// <summary>The submitter's description of how the sample was prepared.</summary>
+        public string SampleProcessingProtocol { get; set; } = string.Empty;
+
+        /// <summary>The submitter's description of how the data were searched and processed.</summary>
+        public string DataProcessingProtocol { get; set; } = string.Empty;
+
+        /// <summary>The dataset DOI, or empty if PRIDE has not minted one.</summary>
+        public string Doi { get; set; } = string.Empty;
+
+        /// <summary>Whether the submission is "COMPLETE" (identifications included) or "PARTIAL".</summary>
+        public string SubmissionType { get; set; } = string.Empty;
+
+        /// <summary>The license the data are released under.</summary>
+        public string License { get; set; } = string.Empty;
+
+        /// <summary>The date the project was submitted to PRIDE.</summary>
+        /// <remarks>
+        /// Typed as <see cref="DateTime"/>, not <see cref="DateTimeOffset"/> as on
+        /// <see cref="PrideArchiveFile"/>: this endpoint sends a bare calendar date ("2019-01-15")
+        /// with no time and no UTC offset, and parsing that into a <see cref="DateTimeOffset"/>
+        /// would silently attach whatever offset the executing machine happens to be in.
+        /// </remarks>
+        public DateTime SubmissionDate { get; set; }
+
+        /// <summary>The date the project became publicly visible. See <see cref="SubmissionDate"/> for why this is a <see cref="DateTime"/>.</summary>
+        public DateTime PublicationDate { get; set; }
+
+        /// <summary>PRIDE's coarse classification tags (e.g. "Technical", "Metaproteomics").</summary>
+        public List<string> ProjectTags { get; set; } = new();
+
+        /// <summary>The submitter's free-text keywords.</summary>
+        public List<string> Keywords { get; set; } = new();
+
+        /// <summary>The countries of the submitting laboratories.</summary>
+        public List<string> Countries { get; set; } = new();
+
+        /// <summary>The people who submitted the project.</summary>
+        public List<PrideContact> Submitters { get; set; } = new();
+
+        /// <summary>The principal investigators of the submitting laboratories.</summary>
+        public List<PrideContact> LabPIs { get; set; } = new();
+
+        /// <summary>The publications reporting this dataset.</summary>
+        public List<PrideReference> References { get; set; } = new();
+
+        /// <summary>The mass spectrometers used (e.g. accession "MS:1000449", name "LTQ Orbitrap").</summary>
+        public List<CvParam> Instruments { get; set; } = new();
+
+        /// <summary>The software used to process the data.</summary>
+        public List<CvParam> Softwares { get; set; } = new();
+
+        /// <summary>The kinds of experiment performed (e.g. "Shotgun proteomics").</summary>
+        public List<CvParam> ExperimentTypes { get; set; } = new();
+
+        /// <summary>The quantification methods used, if the project is quantitative.</summary>
+        public List<CvParam> QuantificationMethods { get; set; } = new();
+
+        /// <summary>The species the sample came from.</summary>
+        public List<CvParam> Organisms { get; set; } = new();
+
+        /// <summary>The tissues or anatomical parts the sample came from.</summary>
+        public List<CvParam> OrganismParts { get; set; } = new();
+
+        /// <summary>The diseases under study, if any.</summary>
+        public List<CvParam> Diseases { get; set; } = new();
+
+        /// <summary>
+        /// The post-translational modifications reported in the dataset. A project with none carries
+        /// the explicit term "PRIDE:0000398" ("No PTMs are included in the dataset") rather than an
+        /// empty list.
+        /// </summary>
+        public List<CvParam> IdentifiedPTMStrings { get; set; } = new();
+
+        /// <summary>Any further controlled-vocabulary annotations PRIDE attaches to the project.</summary>
+        public List<CvParam> AdditionalAttributes { get; set; } = new();
+
+        /// <summary>The sample characteristics, each a controlled-vocabulary key with one or more values.</summary>
+        public List<PrideSampleAttribute> SampleAttributes { get; set; } = new();
+
+        /// <summary>The number of times this project's files have been downloaded.</summary>
+        public long TotalFileDownloads { get; set; }
+
+        /// <summary>The portion of <see cref="TotalFileDownloads"/> attributed to automated crawlers.</summary>
+        public long BotCount { get; set; }
+
+        /// <summary>The portion of <see cref="TotalFileDownloads"/> attributed to aggregating hubs.</summary>
+        public long HubCount { get; set; }
+
+        /// <summary>The portion of <see cref="TotalFileDownloads"/> attributed to genuine human traffic.</summary>
+        public long OrganicCount { get; set; }
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/PrideReference.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideReference.cs
@@ -1,0 +1,25 @@
+namespace UsefulProteomicsDatabases
+{
+    /// <summary>
+    /// A publication associated with a PRIDE Archive project, as returned by the PRIDE Archive
+    /// REST API (v3 <c>projects/{accession}</c>). A plain data object populated by JSON
+    /// deserialization.
+    /// </summary>
+    /// <remarks>
+    /// PRIDE supplies the citation as a single pre-formatted line rather than as separate author,
+    /// journal, volume and page fields, so it is preserved verbatim in <see cref="ReferenceLine"/>
+    /// rather than parsed. A project may be published before its reference is registered, in which
+    /// case <see cref="PubmedId"/> is 0 and <see cref="Doi"/> is empty.
+    /// </remarks>
+    public class PrideReference
+    {
+        /// <summary>The full citation exactly as PRIDE formats it.</summary>
+        public string ReferenceLine { get; set; } = string.Empty;
+
+        /// <summary>The PubMed identifier, or 0 if the publication has none.</summary>
+        public int PubmedId { get; set; }
+
+        /// <summary>The publication DOI, or empty if it has none.</summary>
+        public string Doi { get; set; } = string.Empty;
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/PrideSampleAttribute.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideSampleAttribute.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using MzLibUtil;
+
+namespace UsefulProteomicsDatabases
+{
+    /// <summary>
+    /// One sample characteristic of a PRIDE Archive project — a controlled-vocabulary key paired
+    /// with one or more controlled-vocabulary values — as returned by the PRIDE Archive REST API
+    /// (v3 <c>projects/{accession}</c>). A plain data object populated by JSON deserialization.
+    /// </summary>
+    /// <remarks>
+    /// A single key carries a list of values because one characteristic can have several: the
+    /// "organism" key (OBI:0100026) on a metaproteomics project lists every species in the sample.
+    /// Match <see cref="Key"/> on its <see cref="CvParam.Accession"/> rather than its
+    /// <see cref="CvParam.Name"/> — the accession is stable, the display name is not.
+    /// PRIDE labels this object <c>"@type": "Tuple"</c> on the wire; that discriminator is ignored,
+    /// and the type is named for what it holds rather than for how PRIDE serializes it.
+    /// </remarks>
+    public class PrideSampleAttribute
+    {
+        /// <summary>The characteristic being described (e.g. accession "OBI:0100026", name "organism").</summary>
+        public CvParam Key { get; set; } = new();
+
+        /// <summary>
+        /// The value(s) of that characteristic. Named for the wire field <c>value</c> despite being a
+        /// list; not to be confused with <see cref="CvParam.Value"/> on an individual term.
+        /// </summary>
+        public List<CvParam> Value { get; set; } = new();
+    }
+}


### PR DESCRIPTION
Given a PRIDE accession, you can now read the dataset's metadata — title, protocols, instruments, species, publications, submitters — **without downloading any of it**. That is the "should I even want this data?" step that has been missing: `GetProjectFilesAsync` already tells you what files a project has, but nothing told you what the project *is*.

```csharp
using var client = new PrideArchiveClient();

PrideProject project = await client.GetProjectAsync("PXD012345");
Console.WriteLine(project.Title);
Console.WriteLine(project.Instruments.Single().Name);   // "LTQ Orbitrap"
Console.WriteLine(project.References.Single().Doi);

// ...or, when the accession came from a user and may not exist:
var (found, p) = await client.TryGetProjectAsync(accession);
if (!found) return $"No PRIDE project '{accession}'.";
```

New types: `PrideProject`, plus `PrideContact` (submitters / lab PIs), `PrideReference` (publications) and `PrideSampleAttribute` (sample characteristics). New methods on the existing `PrideArchiveClient`: `GetProjectAsync` and `TryGetProjectAsync`.

## Why it is shaped this way

**Nothing was reusable, and I checked hard.** mzIdentML's `PersonType` and `BibliographicReferenceType` look like the types I needed and are not: they are `xsd`-generated (`// <auto-generated> ... will be lost if regenerated`), triplicated across three schema namespaces (`mzIdentML110/111/120.Generated`), field-mismatched (`PersonType` covers 3 of the 8 fields PRIDE returns — no email, country or ORCID, and its `affiliation` is an `organization_ref` pointer, not text; `BibliographicReferenceType` has no `pubmedID`), and unreachable regardless — `MzIdentML` and `Readers` reference `UsefulProteomicsDatabases`, not the reverse, so using them would mean adding a new project-reference edge to borrow two XML classes. This is the same reasoning that produced the hand-written `MzLibUtil.CvParam` in #1087, which this PR reuses heavily for all nine controlled-vocabulary groups.

**The error contract is a deliberate pair, because this endpoint disagrees with its sibling.** Live-verified 2026-07-21:

| Request | Response |
|---|---|
| `projects/PXD999999999/files` | `200 []` |
| `projects/PXD999999999` | **`404`, empty body** |
| `projects/NOTANACCESSION` | **`404`, empty body** (no `400`, no error payload) |

So an unknown accession cannot be modeled the way the manifest models it. This ships `TryGetProjectAsync`, which reports a missing project as a value, and `GetProjectAsync`, which throws and delegates to it — the `int.Parse`/`int.TryParse` convention, so callers who already trust their accession are not taxed with a tuple.

**`Found` is false for a 404 and *only* a 404.** 5xx, timeouts, rate limits and transport faults still throw. Collapsing an outage into "no such project" would send a user hunting for a typo in a perfectly valid accession — and it would break #1090: `ExternalServiceTestHelper` skips a live test on `HttpRequestException`, so swallowing that exception would make the live canary **fail red during an EBI outage** instead of skipping. This also matches every other network path in the repo (`GetProxiSpectrumAsync`, Koina `InferenceRequest`); the lone counterexample, `ProteinDbRetriever`, returns null and cannot distinguish a bad ID from an outage.

**The two failure kinds get two exception types, and that distinction is load-bearing.** Getting the above right still left the mirror-image hole: if `GetProjectAsync` threw `HttpRequestException` for a genuine 404, then a *withdrawn accession* — a real contract regression — would be converted to `Assert.Ignore` by `ExternalServiceTestHelper` and pass unnoticed. So:

| Condition | Exception | Live test behavior |
|---|---|---|
| Unreachable, timeout, 5xx, non-404 status | `HttpRequestException` | **skips** — not our bug |
| No such project; empty body; payload with no accession | `MzLibException` | **fails** — contract broke |

A test pins that the not-found case is *not* an `HttpRequestException`, so the distinction cannot silently regress.

**Dates are `DateTime`, not the `DateTimeOffset` used on `PrideArchiveFile`.** The files endpoint sends `"2019-01-15T09:42:57.000+00:00"`; this one sends a bare `"2019-01-15"` — no time, no offset. Parsing that into a `DateTimeOffset` silently attaches whatever offset the executing machine is in, so an assertion would pass locally and fail in CI. A test pins both values.

**The DTOs copy `PrideArchiveFile` exactly** — plain class, `{ get; set; }`, inline `= string.Empty` / `= new()` defaults, no `[JsonProperty]` (Newtonsoft matches case-insensitively, per the policy documented on `CvParam`), CV fields as `CvParam`. Deliberately *not* `PrideProxiSpectrum`'s get-only `[JsonConstructor]` shape, which was forced by `MzSpectrum` lacking a parameterless ctor — no base class here, so that constraint does not apply. Deliberately not a `record` either: the generated equality would compare a `List<CvParam>` member by reference, so two identical projects would compare unequal.

## Tests

33 offline fixture tests over a payload captured live from `PXD012345` (real wire shape, including the nested `sampleAttributes` tuple and the `"@type"` discriminators), plus 2 live canaries under `[Category("ExternalService")][Category("Pride")]` routed through `ExternalServiceTestHelper.RunAsync`.

The exhaustive error-contract coverage is **offline**, deliberately: `RunAsync` converts `HttpRequestException` into `Assert.Ignore`, so a live-only negative test would be silently skipped rather than passed. The live canary is documented with what it *can* catch (a 404 becoming a 200-with-project → fails) and what it cannot (a 404 becoming 5xx → indistinguishable from an outage).

114 PRIDE offline tests green; solution builds clean. Coverlet/Release reports **100% patch coverage** on the changed lines, branches included.

## Scope

`PrideArchiveClient.cs` is touched **additively only** — two new methods and one new `using`. No existing member's body, signature or name changes.

Follows #1087 (`CvParam`), #1088 (manifest), #1093 (download) and #1099 (PROXI spectrum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
