### PR TITLE
Remove y ions from the ETD and ECD product sets (#1109)

### DIFF
--- a/mzLib/Omics/Fragmentation/Peptide/DissociationTypeCollection.cs
+++ b/mzLib/Omics/Fragmentation/Peptide/DissociationTypeCollection.cs
@@ -15,6 +15,9 @@ namespace Omics.Fragmentation.Peptide
             { DissociationType.CID, new List<ProductType>{ ProductType.b, ProductType.y } },
             { DissociationType.LowCID, new List<ProductType>{ ProductType.b, ProductType.y, ProductType.aStar, ProductType.bAmmoniaLoss, ProductType.yAmmoniaLoss, ProductType.aDegree, ProductType.bWaterLoss, ProductType.yWaterLoss } },
             { DissociationType.IRMPD, new List<ProductType>{ ProductType.b, ProductType.y } },
+            // ECD/ETD cleave the N-Cα backbone bond and produce c and z• ions only; the amide-cleavage b/y series
+            // requires vibrational activation. EThcD below deliberately keeps b and y because its supplemental
+            // collisional activation produces both together (b without y, or y without b, has no mechanism).
             { DissociationType.ECD, new List<ProductType>{ ProductType.c, ProductType.zDot } },
             { DissociationType.PQD, new List<ProductType>() },
             { DissociationType.ETD, new List<ProductType>{ ProductType.c, ProductType.zDot } },
@@ -87,14 +90,10 @@ namespace Omics.Fragmentation.Peptide
                         productList.Add(ProductType.yAmmoniaLoss);
                     }
                     break;
-                case DissociationType.ECD:
-                case DissociationType.ETD:
-                    if (fragmentationTerminus == FragmentationTerminus.C || fragmentationTerminus == FragmentationTerminus.Both)
-                    {
-                        productList.Add(ProductType.yWaterLoss);
-                        productList.Add(ProductType.yAmmoniaLoss);
-                    }
-                    break;
+                // ECD/ETD produce c and z• only (N-Cα cleavage), so there is no y series and therefore no
+                // y water/ammonia loss to report -- a y-derived loss ion with no parent y has no mechanism,
+                // the same argument that removed ProductType.y from the ECD/ETD product sets above. Falls
+                // through to default and returns an empty list.
                 default:
                     break;
             }

--- a/mzLib/Omics/Fragmentation/Peptide/DissociationTypeCollection.cs
+++ b/mzLib/Omics/Fragmentation/Peptide/DissociationTypeCollection.cs
@@ -15,9 +15,9 @@ namespace Omics.Fragmentation.Peptide
             { DissociationType.CID, new List<ProductType>{ ProductType.b, ProductType.y } },
             { DissociationType.LowCID, new List<ProductType>{ ProductType.b, ProductType.y, ProductType.aStar, ProductType.bAmmoniaLoss, ProductType.yAmmoniaLoss, ProductType.aDegree, ProductType.bWaterLoss, ProductType.yWaterLoss } },
             { DissociationType.IRMPD, new List<ProductType>{ ProductType.b, ProductType.y } },
-            { DissociationType.ECD, new List<ProductType>{ ProductType.c, ProductType.y, ProductType.zDot } },
+            { DissociationType.ECD, new List<ProductType>{ ProductType.c, ProductType.zDot } },
             { DissociationType.PQD, new List<ProductType>() },
-            { DissociationType.ETD, new List<ProductType>{ ProductType.c, ProductType.y, ProductType.zDot } },
+            { DissociationType.ETD, new List<ProductType>{ ProductType.c, ProductType.zDot } },
             { DissociationType.HCD, new List<ProductType>{ ProductType.b, ProductType.y } },//HCD often creates a-, aStar, and aDegree-ions and we should examine what other prominent algoroithms do to see if that would benefit our search results
             { DissociationType.AnyActivationType, new List<ProductType>{ ProductType.b, ProductType.y } },
             { DissociationType.EThcD, new List<ProductType>{ ProductType.b, ProductType.y, ProductType.c, ProductType.zDot } },

--- a/mzLib/Omics/Fragmentation/Peptide/DissociationTypeCollection.cs
+++ b/mzLib/Omics/Fragmentation/Peptide/DissociationTypeCollection.cs
@@ -92,8 +92,10 @@ namespace Omics.Fragmentation.Peptide
                     break;
                 // ECD/ETD produce c and z• only (N-Cα cleavage), so there is no y series and therefore no
                 // y water/ammonia loss to report -- a y-derived loss ion with no parent y has no mechanism,
-                // the same argument that removed ProductType.y from the ECD/ETD product sets above. Falls
-                // through to default and returns an empty list.
+                // the same argument that removed ProductType.y from the ECD/ETD product sets above.
+                case DissociationType.ECD:
+                case DissociationType.ETD:
+                    break;
                 default:
                     break;
             }

--- a/mzLib/Test/Omics/FragmentationTests/FragmentGenerationTests.cs
+++ b/mzLib/Test/Omics/FragmentationTests/FragmentGenerationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2012, 2013, 2014 Derek J. Bailey
+// Copyright 2012, 2013, 2014 Derek J. Bailey
 // Modified work copyright 2016 Stefan Solntsev
 //
 // This file (FragmentGenerationTests.cs) is part of Proteomics.
@@ -572,6 +572,24 @@ namespace Test.Omics.FragmentationTests
             List<Product> myFragments = new List<Product>();
             myPeptide.Fragment(dissociationType, FragmentationTerminus.Both, myFragments);
             Assert.AreEqual(fragmentCount, myFragments.Count());
+
+            // Pin the series, not just the total: for ETD the count of 11 is also satisfied by 6 y + 5 zDot,
+            // so a regression that dropped the c series instead of y would pass a count-only check.
+            List<ProductType> productTypesPresent = myFragments.Select(p => p.ProductType).Distinct().ToList();
+            switch (dissociationType)
+            {
+                case DissociationType.ETD:
+                case DissociationType.ECD:
+                    CollectionAssert.AreEquivalent(new[] { ProductType.c, ProductType.zDot }, productTypesPresent);
+                    break;
+                case DissociationType.HCD:
+                    CollectionAssert.AreEquivalent(new[] { ProductType.b, ProductType.y }, productTypesPresent);
+                    break;
+                case DissociationType.EThcD:
+                    CollectionAssert.AreEquivalent(
+                        new[] { ProductType.b, ProductType.y, ProductType.c, ProductType.zDot }, productTypesPresent);
+                    break;
+            }
         }
 
         [Test]
@@ -588,6 +606,15 @@ namespace Test.Omics.FragmentationTests
             CollectionAssert.AreEquivalent(new[] { ProductType.c, ProductType.zDot }, products);
             Assert.That(products, Does.Not.Contain(ProductType.y), "y ions require amide cleavage");
             Assert.That(products, Does.Not.Contain(ProductType.b), "b ions require amide cleavage");
+
+            // The water/ammonia-loss helper is a second, independent source of ETD/ECD product types, so
+            // pin it too: with no y series there is no y-derived loss, at any terminus. Otherwise a y-loss
+            // ion with no parent y could be reintroduced through this path with the suite still green.
+            foreach (FragmentationTerminus terminus in new[]
+                     { FragmentationTerminus.N, FragmentationTerminus.C, FragmentationTerminus.Both })
+                CollectionAssert.IsEmpty(
+                    DissociationTypeCollection.GetWaterAndAmmoniaLossProductTypesFromDissociation(dissociationType, terminus),
+                    $"ETD/ECD must yield no water/ammonia-loss ions ({terminus})");
         }
 
         [Test]
@@ -671,8 +698,10 @@ namespace Test.Omics.FragmentationTests
             CollectionAssert.AreEquivalent(new List<ProductType>() { ProductType.bWaterLoss, ProductType.bAmmoniaLoss, ProductType.yAmmoniaLoss, ProductType.yWaterLoss }, DissociationTypeCollection.GetWaterAndAmmoniaLossProductTypesFromDissociation(DissociationType.HCD, FragmentationTerminus.Both));
             CollectionAssert.AreEquivalent(new List<ProductType>() { ProductType.bWaterLoss, ProductType.bAmmoniaLoss, ProductType.yAmmoniaLoss, ProductType.yWaterLoss }, DissociationTypeCollection.GetWaterAndAmmoniaLossProductTypesFromDissociation(DissociationType.EThcD, FragmentationTerminus.Both));
 
-            CollectionAssert.AreEquivalent(new List<ProductType>() { ProductType.yAmmoniaLoss, ProductType.yWaterLoss }, DissociationTypeCollection.GetWaterAndAmmoniaLossProductTypesFromDissociation(DissociationType.ECD, FragmentationTerminus.Both));
-            CollectionAssert.AreEquivalent(new List<ProductType>() { ProductType.yAmmoniaLoss, ProductType.yWaterLoss }, DissociationTypeCollection.GetWaterAndAmmoniaLossProductTypesFromDissociation(DissociationType.ETD, FragmentationTerminus.Both));
+            // ECD/ETD produce c and z-dot only (N-Ca cleavage), so there is no y series and no y water/ammonia
+            // loss -- consistent with ProductType.y no longer being in the ECD/ETD product sets.
+            CollectionAssert.IsEmpty(DissociationTypeCollection.GetWaterAndAmmoniaLossProductTypesFromDissociation(DissociationType.ECD, FragmentationTerminus.Both));
+            CollectionAssert.IsEmpty(DissociationTypeCollection.GetWaterAndAmmoniaLossProductTypesFromDissociation(DissociationType.ETD, FragmentationTerminus.Both));
 
             CollectionAssert.AreEquivalent(new List<ProductType>() { ProductType.bWaterLoss, ProductType.bAmmoniaLoss }, DissociationTypeCollection.GetWaterAndAmmoniaLossProductTypesFromDissociation(DissociationType.CID, FragmentationTerminus.N));
             CollectionAssert.AreEquivalent(new List<ProductType>() { ProductType.yAmmoniaLoss, ProductType.yWaterLoss }, DissociationTypeCollection.GetWaterAndAmmoniaLossProductTypesFromDissociation(DissociationType.CID, FragmentationTerminus.C));

--- a/mzLib/Test/Omics/FragmentationTests/FragmentGenerationTests.cs
+++ b/mzLib/Test/Omics/FragmentationTests/FragmentGenerationTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2012, 2013, 2014 Derek J. Bailey
+﻿// Copyright 2012, 2013, 2014 Derek J. Bailey
 // Modified work copyright 2016 Stefan Solntsev
 //
 // This file (FragmentGenerationTests.cs) is part of Proteomics.
@@ -87,8 +87,8 @@ namespace Test.Omics.FragmentationTests
 
         [Test]
         [TestCase(DissociationType.HCD, new[] { ProductType.b, ProductType.y })]
-        [TestCase(DissociationType.ECD, new[] { ProductType.c, ProductType.y, ProductType.zDot })]
-        [TestCase(DissociationType.ETD, new[] { ProductType.c, ProductType.y, ProductType.zDot })]
+        [TestCase(DissociationType.ECD, new[] { ProductType.c, ProductType.zDot })]
+        [TestCase(DissociationType.ETD, new[] { ProductType.c, ProductType.zDot })]
         [TestCase(DissociationType.EThcD, new[] { ProductType.b, ProductType.y })]
         [TestCase(DissociationType.AnyActivationType, new[] { ProductType.b, ProductType.y })]
         public static void TestDissociationProductTypes(DissociationType dissociationType, IEnumerable<ProductType> expectedProductTypes)
@@ -261,7 +261,7 @@ namespace Test.Omics.FragmentationTests
             var theseTheoreticalFragments = new List<Product>();
             aPeptideWithSetModifications.Fragment(DissociationType.ETD, FragmentationTerminus.Both, theseTheoreticalFragments);
 
-            Assert.That(theseTheoreticalFragments.Count == 22);
+            Assert.That(theseTheoreticalFragments.Count == 15);
             Assert.That(theseTheoreticalFragments.Last().Annotation == "zDot8");
             Assert.That(theseTheoreticalFragments.Last().NeutralMass > 1842);
         }
@@ -453,9 +453,9 @@ namespace Test.Omics.FragmentationTests
             Assert.AreEqual(new List<ProductType> { ProductType.y }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.C].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.HCD]));
             Assert.AreEqual(new List<ProductType> { }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.None].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.HCD]));
 
-            Assert.AreEqual(new List<ProductType> { ProductType.c, ProductType.y, ProductType.zDot }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.Both].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ETD]));
+            Assert.AreEqual(new List<ProductType> { ProductType.c, ProductType.zDot }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.Both].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ETD]));
             Assert.AreEqual(new List<ProductType> { ProductType.c }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.N].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ETD]));
-            Assert.AreEqual(new List<ProductType> { ProductType.y, ProductType.zDot }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.C].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ETD]));
+            Assert.AreEqual(new List<ProductType> { ProductType.zDot }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.C].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ETD]));
             Assert.AreEqual(new List<ProductType> { }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.None].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.ETD]));
 
             Assert.AreEqual(new List<ProductType> { ProductType.b, ProductType.y }, TerminusSpecificProductTypes.ProductIonTypesFromSpecifiedTerminus[FragmentationTerminus.Both].Intersect(DissociationTypeCollection.ProductsFromDissociationType[DissociationType.CID]));
@@ -484,13 +484,13 @@ namespace Test.Omics.FragmentationTests
             Assert.AreEqual(new List<ProductType> { }, fragments.Select(b => b.ProductType).Distinct().ToList());
 
             p.Fragment(DissociationType.ETD, FragmentationTerminus.Both, fragments);
-            Assert.AreEqual(new List<ProductType> { ProductType.c, ProductType.y, ProductType.zDot }, fragments.Select(b => b.ProductType).Distinct().ToList());
+            Assert.AreEqual(new List<ProductType> { ProductType.c, ProductType.zDot }, fragments.Select(b => b.ProductType).Distinct().ToList());
 
             p.Fragment(DissociationType.ETD, FragmentationTerminus.N, fragments);
             Assert.AreEqual(new List<ProductType> { ProductType.c }, fragments.Select(b => b.ProductType).Distinct().ToList());
 
             p.Fragment(DissociationType.ETD, FragmentationTerminus.C, fragments);
-            Assert.AreEqual(new List<ProductType> { ProductType.y, ProductType.zDot }, fragments.Select(b => b.ProductType).Distinct().ToList());
+            Assert.AreEqual(new List<ProductType> { ProductType.zDot }, fragments.Select(b => b.ProductType).Distinct().ToList());
 
             p.Fragment(DissociationType.ETD, FragmentationTerminus.None, fragments);
             Assert.AreEqual(new List<ProductType> { }, fragments.Select(b => b.ProductType).Distinct().ToList());
@@ -560,8 +560,8 @@ namespace Test.Omics.FragmentationTests
 
         [Test]
         [TestCase(DissociationType.HCD, 12)]//the first part is the test case, the latter part is ther result of the assertion
-        [TestCase(DissociationType.ETD, 17)]//the first part is the test case, the latter part is ther result of the assertion
-        [TestCase(DissociationType.ECD, 17)]//the first part is the test case, the latter part is ther result of the assertion
+        [TestCase(DissociationType.ETD, 11)]//the first part is the test case, the latter part is ther result of the assertion
+        [TestCase(DissociationType.ECD, 11)]//the first part is the test case, the latter part is ther result of the assertion
         [TestCase(DissociationType.EThcD, 23)]//the first part is the test case, the latter part is ther result of the assertion
         public static void Test_ETD_ECD_EThcD_Fragmentation_No_FragmentsAtProline(DissociationType dissociationType, int fragmentCount)
         {
@@ -572,6 +572,33 @@ namespace Test.Omics.FragmentationTests
             List<Product> myFragments = new List<Product>();
             myPeptide.Fragment(dissociationType, FragmentationTerminus.Both, myFragments);
             Assert.AreEqual(fragmentCount, myFragments.Count());
+        }
+
+        [Test]
+        [TestCase(DissociationType.ETD)]
+        [TestCase(DissociationType.ECD)]
+        public static void ElectronTransferDissociationProducesCAndZDotOnly(DissociationType dissociationType)
+        {
+            // ETD and ECD cleave the N-Ca bond, which yields c and z-dot ions. The b and y ions come
+            // from amide cleavage under vibrational activation, so neither belongs here. If residual
+            // activation is to be modelled then b and y arrive together, which is what EThcD does --
+            // a y series with no b series has no fragmentation mechanism behind it.
+            List<ProductType> products = DissociationTypeCollection.ProductsFromDissociationType[dissociationType];
+
+            CollectionAssert.AreEquivalent(new[] { ProductType.c, ProductType.zDot }, products);
+            Assert.That(products, Does.Not.Contain(ProductType.y), "y ions require amide cleavage");
+            Assert.That(products, Does.Not.Contain(ProductType.b), "b ions require amide cleavage");
+        }
+
+        [Test]
+        public static void EThcDKeepsBAndYTogetherBecauseSupplementalActivationProducesBoth()
+        {
+            // The counterpart to the test above: supplemental HCD genuinely does add amide cleavage,
+            // so EThcD carries b and y alongside c and z-dot. This pins the asymmetry as deliberate.
+            List<ProductType> products = DissociationTypeCollection.ProductsFromDissociationType[DissociationType.EThcD];
+
+            CollectionAssert.AreEquivalent(
+                new[] { ProductType.b, ProductType.y, ProductType.c, ProductType.zDot }, products);
         }
 
         [Test]

--- a/mzLib/Test/Omics/FragmentationTests/FragmentGenerationTests.cs
+++ b/mzLib/Test/Omics/FragmentationTests/FragmentGenerationTests.cs
@@ -573,21 +573,32 @@ namespace Test.Omics.FragmentationTests
             myPeptide.Fragment(dissociationType, FragmentationTerminus.Both, myFragments);
             Assert.AreEqual(fragmentCount, myFragments.Count());
 
-            // Pin the series, not just the total: for ETD the count of 11 is also satisfied by 6 y + 5 zDot,
-            // so a regression that dropped the c series instead of y would pass a count-only check.
-            List<ProductType> productTypesPresent = myFragments.Select(p => p.ProductType).Distinct().ToList();
+            // Pin the per-series COUNTS, not the total or the distinct set: for ETD the total of 11 is
+            // equally satisfied by 6 y + 5 zDot, and even the distinct set { c, zDot } is satisfied by a
+            // 5 c / 6 zDot split -- so a regression moving the proline suppression from the z• series to
+            // the c series would slip through anything weaker than a per-series count.
+            int Count(ProductType t) => myFragments.Count(p => p.ProductType == t);
             switch (dissociationType)
             {
                 case DissociationType.ETD:
                 case DissociationType.ECD:
-                    CollectionAssert.AreEquivalent(new[] { ProductType.c, ProductType.zDot }, productTypesPresent);
+                    Assert.AreEqual(6, Count(ProductType.c));
+                    Assert.AreEqual(5, Count(ProductType.zDot));   // one z• suppressed at the proline
+                    Assert.AreEqual(0, Count(ProductType.b));
+                    Assert.AreEqual(0, Count(ProductType.y));
                     break;
                 case DissociationType.HCD:
-                    CollectionAssert.AreEquivalent(new[] { ProductType.b, ProductType.y }, productTypesPresent);
+                    Assert.AreEqual(6, Count(ProductType.b));
+                    Assert.AreEqual(6, Count(ProductType.y));
                     break;
                 case DissociationType.EThcD:
-                    CollectionAssert.AreEquivalent(
-                        new[] { ProductType.b, ProductType.y, ProductType.c, ProductType.zDot }, productTypesPresent);
+                    Assert.AreEqual(6, Count(ProductType.b));
+                    Assert.AreEqual(6, Count(ProductType.y));
+                    Assert.AreEqual(6, Count(ProductType.c));
+                    Assert.AreEqual(5, Count(ProductType.zDot));
+                    break;
+                default:
+                    Assert.Fail($"No expected per-series counts for {dissociationType}; add a case when adding a [TestCase].");
                     break;
             }
         }
@@ -608,10 +619,10 @@ namespace Test.Omics.FragmentationTests
             Assert.That(products, Does.Not.Contain(ProductType.b), "b ions require amide cleavage");
 
             // The water/ammonia-loss helper is a second, independent source of ETD/ECD product types, so
-            // pin it too: with no y series there is no y-derived loss, at any terminus. Otherwise a y-loss
-            // ion with no parent y could be reintroduced through this path with the suite still green.
-            foreach (FragmentationTerminus terminus in new[]
-                     { FragmentationTerminus.N, FragmentationTerminus.C, FragmentationTerminus.Both })
+            // pin it too: with no y series there is no y-derived loss, at ANY terminus. Drive the loop from
+            // every FragmentationTerminus value (including None) rather than a hand-written subset, so a
+            // reintroduced ETD/ECD arm returning y-losses for only one terminus cannot slip through green.
+            foreach (FragmentationTerminus terminus in Enum.GetValues<FragmentationTerminus>())
                 CollectionAssert.IsEmpty(
                     DissociationTypeCollection.GetWaterAndAmmoniaLossProductTypesFromDissociation(dissociationType, terminus),
                     $"ETD/ECD must yield no water/ammonia-loss ions ({terminus})");
@@ -622,10 +633,53 @@ namespace Test.Omics.FragmentationTests
         {
             // The counterpart to the test above: supplemental HCD genuinely does add amide cleavage,
             // so EThcD carries b and y alongside c and z-dot. This pins the asymmetry as deliberate.
+            // Assert CONTAINMENT, not an exact set: the invariant this test's name states is that b and y
+            // are retained ALONGSIDE c and z•, and EThcD is a row this PR does not otherwise own, so an
+            // unrelated later addition to it (e.g. zPlusOne) must not fail a b/y-togetherness test.
             List<ProductType> products = DissociationTypeCollection.ProductsFromDissociationType[DissociationType.EThcD];
 
-            CollectionAssert.AreEquivalent(
-                new[] { ProductType.b, ProductType.y, ProductType.c, ProductType.zDot }, products);
+            Assert.That(products, Does.Contain(ProductType.b));
+            Assert.That(products, Does.Contain(ProductType.y));
+            Assert.That(products, Does.Contain(ProductType.c));
+            Assert.That(products, Does.Contain(ProductType.zDot));
+        }
+
+        /// <summary>
+        /// The which-series-a-type-produces fact is hand-maintained in two places -- the
+        /// ProductsFromDissociationType rows and the GetWaterAndAmmoniaLossProductTypesFromDissociation
+        /// switch -- and the ECD/ETD drift between them is exactly what the first commit of this PR
+        /// missed. This pins the STRUCTURAL invariant across every row rather than naming ETD/ECD only,
+        /// so the same class of drift on any other row is caught: a neutral-loss ion may be returned
+        /// only if its parent series is in that type's product row. (One-directional: a row may carry a
+        /// series without the helper reporting a loss for it, e.g. LowCID, so the loss list is not
+        /// derived from the rows -- that would change LowCID and is out of scope.)
+        /// </summary>
+        [Test]
+        public static void GetWaterAndAmmoniaLoss_NeverReturnsALossWhoseParentSeriesIsAbsentFromTheRow()
+        {
+            var bSeriesLosses = new[] { ProductType.bWaterLoss, ProductType.bAmmoniaLoss };
+            var ySeriesLosses = new[] { ProductType.yWaterLoss, ProductType.yAmmoniaLoss };
+
+            foreach (var typeAndRow in DissociationTypeCollection.ProductsFromDissociationType)
+            {
+                DissociationType type = typeAndRow.Key;
+                List<ProductType> row = typeAndRow.Value;
+
+                // b and y are amide-cleavage complements: every row carries both or neither.
+                Assert.That(row.Contains(ProductType.b), Is.EqualTo(row.Contains(ProductType.y)),
+                    $"{type}: b and y must appear together or not at all");
+
+                foreach (FragmentationTerminus terminus in Enum.GetValues<FragmentationTerminus>())
+                {
+                    var losses = DissociationTypeCollection.GetWaterAndAmmoniaLossProductTypesFromDissociation(type, terminus);
+                    if (!row.Contains(ProductType.b))
+                        Assert.That(losses.Intersect(bSeriesLosses), Is.Empty,
+                            $"{type}/{terminus}: b-series loss returned but the row has no b");
+                    if (!row.Contains(ProductType.y))
+                        Assert.That(losses.Intersect(ySeriesLosses), Is.Empty,
+                            $"{type}/{terminus}: y-series loss returned but the row has no y");
+                }
+            }
         }
 
         [Test]

--- a/mzLib/Test/Omics/FragmentationTests/FragmentModificationTests.cs
+++ b/mzLib/Test/Omics/FragmentationTests/FragmentModificationTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2012, 2013, 2014 Derek J. Bailey
+﻿// Copyright 2012, 2013, 2014 Derek J. Bailey
 // Modified work copyright 2016 Stefan Solntsev
 //
 // This file (FragmentModificationTests.cs) is part of Proteomics.
@@ -552,9 +552,9 @@ namespace Test.Omics.FragmentationTests
 
             Assert.That(products.Count(p => p.NeutralLoss == 126 && p.ProductType == ProductType.zDot) == 10);
             Assert.That(products.Count(p => p.NeutralLoss == 126 && p.ProductType == ProductType.c) == 0);
-            Assert.That(products.Count(p => p.NeutralLoss == 126 && p.ProductType == ProductType.y) == 9);
+            Assert.That(products.Count(p => p.NeutralLoss == 126 && p.ProductType == ProductType.y) == 0);
             Assert.That(products.Count(p => p.NeutralLoss == 126 && p.ProductType == ProductType.M) == 1);
-            Assert.That(products.Count(p => p.NeutralLoss == 126) == 20);
+            Assert.That(products.Count(p => p.NeutralLoss == 126) == 11);
         }
     }
 }

--- a/mzLib/Test/Omics/FragmentationTests/FragmentModificationTests.cs
+++ b/mzLib/Test/Omics/FragmentationTests/FragmentModificationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2012, 2013, 2014 Derek J. Bailey
+// Copyright 2012, 2013, 2014 Derek J. Bailey
 // Modified work copyright 2016 Stefan Solntsev
 //
 // This file (FragmentModificationTests.cs) is part of Proteomics.

--- a/mzLib/Test/Omics/FragmentationTests/FragmentModificationTests.cs
+++ b/mzLib/Test/Omics/FragmentationTests/FragmentModificationTests.cs
@@ -555,6 +555,11 @@ namespace Test.Omics.FragmentationTests
             Assert.That(products.Count(p => p.NeutralLoss == 126 && p.ProductType == ProductType.y) == 0);
             Assert.That(products.Count(p => p.NeutralLoss == 126 && p.ProductType == ProductType.M) == 1);
             Assert.That(products.Count(p => p.NeutralLoss == 126) == 11);
+
+            // The assertions above are all gated on NeutralLoss == 126, so on their own they say nothing
+            // about y ions carrying no loss annotation. ETD produces no y at all -- assert it on the WHOLE
+            // product list, so a regression re-adding y to the ETD row (even loss-free y) fails here.
+            Assert.That(products.Count(p => p.ProductType == ProductType.y), Is.EqualTo(0));
         }
     }
 }

--- a/mzLib/Test/Omics/FragmentationTests/TestProductMassesMightHaveDuplicates.cs
+++ b/mzLib/Test/Omics/FragmentationTests/TestProductMassesMightHaveDuplicates.cs
@@ -57,7 +57,7 @@ namespace Test.Omics.FragmentationTests
 
             aPeptideWithSetModifications.Fragment(DissociationType.ECD, FragmentationTerminus.Both, fragments);
             allFragmentIonMzs = new HashSet<int>(fragments.Select(i => (int)Math.Round(i.NeutralMass.ToMz(1))));
-            Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { 115, 244, 120, 249, 104, 233 }));
+            Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { 115, 244, 104, 233 }));
 
             aPeptideWithSetModifications.Fragment(DissociationType.PQD, FragmentationTerminus.Both, fragments);
             allFragmentIonMzs = new HashSet<int>(fragments.Select(i => (int)Math.Round(i.NeutralMass.ToMz(1))));
@@ -65,7 +65,7 @@ namespace Test.Omics.FragmentationTests
 
             aPeptideWithSetModifications.Fragment(DissociationType.ETD, FragmentationTerminus.Both, fragments);
             allFragmentIonMzs = new HashSet<int>(fragments.Select(i => (int)Math.Round(i.NeutralMass.ToMz(1))));
-            Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { 115, 244, 120, 249, 104, 233 }));
+            Assert.IsTrue(allFragmentIonMzs.SetEquals(new HashSet<int> { 115, 244, 104, 233 }));
 
             aPeptideWithSetModifications.Fragment(DissociationType.HCD, FragmentationTerminus.Both, fragments);
             allFragmentIonMzs = new HashSet<int>(fragments.Select(i => (int)Math.Round(i.NeutralMass.ToMz(1))));


### PR DESCRIPTION
Closes #1109.

## The change

```diff
-{ DissociationType.ECD, new List<ProductType>{ ProductType.c, ProductType.y, ProductType.zDot } },
+{ DissociationType.ECD, new List<ProductType>{ ProductType.c, ProductType.zDot } },
-{ DissociationType.ETD, new List<ProductType>{ ProductType.c, ProductType.y, ProductType.zDot } },
+{ DissociationType.ETD, new List<ProductType>{ ProductType.c, ProductType.zDot } },
```

`EThcD` is deliberately left alone.

## Why

ETD and ECD cleave the **N–Cα** bond and yield c and z• ions. b and y come from **amide** cleavage under vibrational activation. If the y ions were modelling residual activation then b ions would come with them — which is exactly what the `EThcD` row does. **y without b has no fragmentation mechanism behind it**, and the ETD/ECD rows read like an edit of a `{ b, y }` row in which `b` became `c, zDot` and `y` was left behind.

## Impact

Human serum albumin P02768, tryptic, `FragmentationTerminus.Both`, ETD — a 31-mer peptide:

| series | before | after |
|---|---|---|
| c | 30 | 30 |
| zDot | 30 | 30 |
| **y** | **30** | **0** |

A third of every ETD/ECD theoretical fragment list was ions ETD does not produce. In a search those are matchable, so they can inflate matched-ion counts and scores on ETD and ECD data.

## Tests

Updated rather than deleted, so the diff shows exactly what behaviour changes:

- the ETD/ECD product-set `TestCase`s
- `Test_ETD_ECD_EThcD_Fragmentation_No_FragmentsAtProline`: **17 → 11** for ETD and ECD. `PEPTIDE` gives 6 c + 5 zDot, one z• already suppressed at the proline. **HCD 12 and EThcD 23 are unchanged**, which is a useful check that only the intended rows moved.
- `TestCTermEtd`: its subject is the extra zDot neutral loss; the y assertions were incidental. 9 → 0, total 20 → 11.
- `Test_UnmodifiedPeptide_AllProductType_fragmentMasses`: the ECD/ETD m/z sets lose `120` and `249`, which are the two y ions — the CID set still contains them.
- `Test_TerminusSpecificProductTypes`: ETD `Both` `{c, y, zDot}` → `{c, zDot}`, ETD `C` `{y, zDot}` → `{zDot}`.
- `Test_TerminusSpecificProductTypesFromPeptideWithSetMods`: same two expectations at the fragmentation level.
- the O-glycopeptide fragment count: 22 → 15.

Two new tests pin the intent so this cannot silently regress:

- `ElectronTransferDissociationProducesCAndZDotOnly` — ETD and ECD are exactly `{ c, zDot }`
- `EThcDKeepsBAndYTogetherBecauseSupplementalActivationProducesBoth` — EThcD keeps b **and** y alongside c and z•, pinning the asymmetry as deliberate

**Full suite: 5334 passed, 0 failed, 29 skipped.**

## Review follow-up (commit `bdabc170`)

A review round caught that the y removal was incomplete and tightened three assertions, with the scientific call unchanged:

- **The y-series neutral-loss path was still live.** `GetWaterAndAmmoniaLossProductTypesFromDissociation` had a `case ECD: case ETD:` arm that returned `yWaterLoss` and `yAmmoniaLoss` — coherent only while those rows carried `y`. Those are y-series ions, so a y-derived loss with no parent y has exactly the missing mechanism this PR uses to reject y. An ETD/ECD search with loss ions enabled kept generating them. The arm is deleted (falls through to an empty list), and `Test_WaterAndAmmoniaLossFragmentProductIons` now asserts **empty** for ECD/ETD instead of `{ yWaterLoss, yAmmoniaLoss }`; EThcD/CID/HCD/IRMPD are unchanged controls.
- **`ElectronTransferDissociationProducesCAndZDotOnly`** now also asserts the loss helper returns nothing for ETD/ECD across all three termini, so this second product-type entry point can no longer reintroduce a y-series ion with the suite green.
- **`Test_ETD_ECD_EThcD_Fragmentation_No_FragmentsAtProline`** asserted only a total count; for ETD, 11 is equally satisfied by `6 y + 5 zDot`, so it now pins the `ProductType` set per dissociation type (`ETD/ECD = { c, zDot }`).
- Added the N–Cα rationale as inline comments on the ECD/ETD rows and the loss-helper default arm (matching the existing HCD comment convention), and reverted the UTF-8 BOM this branch had prepended to two test files.

`TestDissociationProductTypes`' subset assertion was left as-is deliberately: tightening it to an exact set would break its intentionally-partial cases (e.g. the EThcD case lists only `{b, y}` though the row has four types), and `ElectronTransferDissociationProducesCAndZDotOnly` already carries the exact check.

## Note for reviewers

This changes search results for ETD/ECD data, so it is a scientific call as much as a code one — worth a second opinion from someone who runs ETD routinely before merging. The mechanism argument seems clear to me, but the consequence is real and I would rather it were confirmed than assumed.

Found while building [mzLibRust](https://github.com/smith-chem-wisc/mzLibRust); a parity test asserting "ETD produces c and z•, not b and y" failed against a recorded albumin digest. Related: #1110, #1111, #1112, #1113.
