### PR TITLE
Convert MSFragger retention time from seconds to minutes

### DIFF
--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/MsFraggerPsm.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/MsFraggerPsm.cs
@@ -46,16 +46,10 @@ namespace Readers
         public int Charge { get; set; }
 
         /// <summary>
-        /// The raw "Retention" column, in SECONDS — the unit MSFragger writes.
+        /// The raw "Retention" column, in seconds, which is the unit MSFragger writes.
+        /// The verbatim value is kept here so the file round-trips on write; conversion to
+        /// minutes for <see cref="IQuantifiableRecord.RetentionTime"/> happens at the interface below.
         /// </summary>
-        /// <remarks>
-        /// Named for its unit because the unit is the whole problem. mzLib's convention for
-        /// retention time is minutes (see <see cref="IQuantifiableRecord.RetentionTime"/>, and the
-        /// spectra readers, which all divide by 60), but this column is not in minutes, and reading
-        /// it as though it were made FlashLFQ search for every peptide at a sixtieth of its true
-        /// elution time. Keep the raw value here so the file round-trips on write, and convert at
-        /// the interface boundary below.
-        /// </remarks>
         [Name("Retention")]
         public double RetentionTimeInSeconds { get; set; }
 
@@ -226,21 +220,11 @@ namespace Readers
         [Ignore] public int ChargeState => Charge;
 
         /// <summary>
-        /// The retention time in MINUTES, converted from the seconds MSFragger writes.
+        /// The retention time in minutes, per the <see cref="IQuantifiableRecord.RetentionTime"/>
+        /// convention, converted from the seconds MSFragger writes in <see cref="RetentionTimeInSeconds"/>.
+        /// This mirrors the seconds-to-minutes conversion the spectra readers already do at their
+        /// own boundary (BrukerFileReader, MsAlign, Mgf, Mzml).
         /// </summary>
-        /// <remarks>
-        /// <see cref="IQuantifiableRecord.RetentionTime"/> is documented as minutes and every
-        /// consumer treats it that way — <c>MzLibExtensions.MakeIdentifications</c> assigns it
-        /// straight to a variable named <c>ms2RetentionTimeInMinutes</c>, and FlashLFQ then builds
-        /// a ±2 minute peak-finding window around it. Passing MSFragger's seconds through
-        /// unconverted therefore looked for a peptide eluting at 60 minutes at the 1 minute mark,
-        /// and quantification collapsed toward zero rather than failing.
-        /// <para>
-        /// This mirrors what the spectra readers already do at their own boundary
-        /// (<c>BrukerFileReader</c>, <c>MsAlign</c>, <c>Mgf</c>, <c>Mzml</c> all normalise to
-        /// minutes), so both halves of the library now agree on the unit.
-        /// </para>
-        /// </remarks>
         [Ignore] public double RetentionTime => RetentionTimeInSeconds / 60.0;
 
         // decoy reading isn't currently supported for MsFragger psms, this will be revisited later

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/MsFraggerPsm.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/MsFraggerPsm.cs
@@ -45,8 +45,19 @@ namespace Readers
         [Name("Charge")]
         public int Charge { get; set; }
 
+        /// <summary>
+        /// The raw "Retention" column, in SECONDS — the unit MSFragger writes.
+        /// </summary>
+        /// <remarks>
+        /// Named for its unit because the unit is the whole problem. mzLib's convention for
+        /// retention time is minutes (see <see cref="IQuantifiableRecord.RetentionTime"/>, and the
+        /// spectra readers, which all divide by 60), but this column is not in minutes, and reading
+        /// it as though it were made FlashLFQ search for every peptide at a sixtieth of its true
+        /// elution time. Keep the raw value here so the file round-trips on write, and convert at
+        /// the interface boundary below.
+        /// </remarks>
         [Name("Retention")]
-        public double RetentionTime { get; set; }
+        public double RetentionTimeInSeconds { get; set; }
 
         [Name("Observed Mass")]
         public double ObservedMass { get; set; }
@@ -213,6 +224,24 @@ namespace Readers
         [Ignore] private List<(string, string, string)> _proteinGroupInfos;
 
         [Ignore] public int ChargeState => Charge;
+
+        /// <summary>
+        /// The retention time in MINUTES, converted from the seconds MSFragger writes.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="IQuantifiableRecord.RetentionTime"/> is documented as minutes and every
+        /// consumer treats it that way — <c>MzLibExtensions.MakeIdentifications</c> assigns it
+        /// straight to a variable named <c>ms2RetentionTimeInMinutes</c>, and FlashLFQ then builds
+        /// a ±2 minute peak-finding window around it. Passing MSFragger's seconds through
+        /// unconverted therefore looked for a peptide eluting at 60 minutes at the 1 minute mark,
+        /// and quantification collapsed toward zero rather than failing.
+        /// <para>
+        /// This mirrors what the spectra readers already do at their own boundary
+        /// (<c>BrukerFileReader</c>, <c>MsAlign</c>, <c>Mgf</c>, <c>Mzml</c> all normalise to
+        /// minutes), so both halves of the library now agree on the unit.
+        /// </para>
+        /// </remarks>
+        [Ignore] public double RetentionTime => RetentionTimeInSeconds / 60.0;
 
         // decoy reading isn't currently supported for MsFragger psms, this will be revisited later
         [Ignore] public bool IsDecoy => false;

--- a/mzLib/Test/FileReadingTests/ExternalFileReading/TestMsFraggerResultFiles.cs
+++ b/mzLib/Test/FileReadingTests/ExternalFileReading/TestMsFraggerResultFiles.cs
@@ -513,11 +513,24 @@ namespace Test.FileReadingTests.ExternalFileReading
                 "FileReadingTests", "ExternalFileTypes", "FraggerPsm_FragPipev21.1_psm.tsv");
             MsFraggerPsmFile file = FileReader.ReadFile<MsFraggerPsmFile>(filePath);
 
-            foreach (MsFraggerPsm psm in file)
+            List<MsFraggerPsm> psms = file.ToList();
+            // Guard against a vacuous pass: an empty fixture would satisfy every per-record assertion below.
+            Assert.That(psms, Has.Count.EqualTo(5));
+
+            // Assert against literals read from the fixture, not against the property under test, so a
+            // wrong divisor is caught. The last scan is 19.114 s in the file; in minutes that is 19.114/60.
+            Assert.That(psms.Last().RetentionTime, Is.EqualTo(19.114 / 60.0).Within(1e-12));
+
+            // The five scans span 19.114 - 1.9398 = 17.1742 s in the file; expressing that span in minutes
+            // pins the divisor at 60 (dividing by 600 or 3600 would fail this even though every value would
+            // still be < 1).
+            double spanInMinutes = psms.Last().RetentionTime - psms.First().RetentionTime;
+            Assert.That(spanInMinutes, Is.EqualTo((19.114 - 1.9398) / 60.0).Within(1e-9));
+
+            foreach (MsFraggerPsm psm in psms)
             {
                 Assert.That(psm.RetentionTime, Is.LessThan(1.0),
                     "scans seconds apart cannot be minutes apart");
-                Assert.That(psm.RetentionTime, Is.EqualTo(psm.RetentionTimeInSeconds / 60.0).Within(1e-12));
             }
         }
     }

--- a/mzLib/Test/FileReadingTests/ExternalFileReading/TestMsFraggerResultFiles.cs
+++ b/mzLib/Test/FileReadingTests/ExternalFileReading/TestMsFraggerResultFiles.cs
@@ -100,7 +100,7 @@ namespace Test.FileReadingTests.ExternalFileReading
             Assert.That(first.NextAminoAcid, Is.EqualTo('K'));
             Assert.That(first.PeptideLength, Is.EqualTo(7));
             Assert.That(first.Charge, Is.EqualTo(2));
-            Assert.That(first.RetentionTime, Is.EqualTo(1.9398));
+            Assert.That(first.RetentionTimeInSeconds, Is.EqualTo(1.9398));
             Assert.That(first.ObservedMass, Is.EqualTo(669.4164));
             Assert.That(first.CalibratedObservedMass, Is.EqualTo(669.4123));
             Assert.That(first.ObservedMz, Is.EqualTo(335.7155));
@@ -141,7 +141,7 @@ namespace Test.FileReadingTests.ExternalFileReading
             Assert.That(last.NextAminoAcid, Is.EqualTo('V'));
             Assert.That(last.PeptideLength, Is.EqualTo(7));
             Assert.That(last.Charge, Is.EqualTo(2));
-            Assert.That(last.RetentionTime, Is.EqualTo(19.114));
+            Assert.That(last.RetentionTimeInSeconds, Is.EqualTo(19.114));
             Assert.That(last.ObservedMass, Is.EqualTo(724.3984));
             Assert.That(last.CalibratedObservedMass, Is.EqualTo
             (724.3949));
@@ -476,6 +476,48 @@ namespace Test.FileReadingTests.ExternalFileReading
                 var original = JsonConvert.SerializeObject(file2.ElementAt(i));
                 var written = JsonConvert.SerializeObject(outFile.ElementAt(i));
                 Assert.That(original, Is.EqualTo(written));
+            }
+        }
+
+        /// <summary>
+        /// MSFragger writes retention time in seconds; mzLib's IQuantifiableRecord contract is
+        /// minutes. Nothing enforced that, so the seconds reached FlashLFQ unconverted and every
+        /// peptide was searched for at a sixtieth of its true elution time.
+        /// </summary>
+        [Test]
+        public static void MsFraggerPsm_RetentionTime_IsConvertedFromSecondsToMinutes()
+        {
+            string filePath = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                "FileReadingTests", "ExternalFileTypes", "FraggerPsm_FragPipev21.1_psm.tsv");
+            MsFraggerPsmFile file = FileReader.ReadFile<MsFraggerPsmFile>(filePath);
+            MsFraggerPsm first = file.First();
+
+            // The raw column, unchanged, so the file still round-trips on write.
+            Assert.That(first.RetentionTimeInSeconds, Is.EqualTo(1.9398));
+
+            // The interface member, in the unit the interface documents.
+            Assert.That(first.RetentionTime, Is.EqualTo(1.9398 / 60.0).Within(1e-12));
+            Assert.That(((IQuantifiableRecord)first).RetentionTime,
+                Is.EqualTo(first.RetentionTime), "the interface must see the converted value");
+        }
+
+        /// <summary>
+        /// The gradient sanity check that would have caught this from the data alone: these five
+        /// scans span 17 seconds of an LTQ Orbitrap Velos run at roughly one scan per second. Read
+        /// as minutes they would imply a whole HeLa run of about eighty scans.
+        /// </summary>
+        [Test]
+        public static void MsFraggerPsm_RetentionTimesAreAPlausibleGradientInMinutes()
+        {
+            string filePath = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                "FileReadingTests", "ExternalFileTypes", "FraggerPsm_FragPipev21.1_psm.tsv");
+            MsFraggerPsmFile file = FileReader.ReadFile<MsFraggerPsmFile>(filePath);
+
+            foreach (MsFraggerPsm psm in file)
+            {
+                Assert.That(psm.RetentionTime, Is.LessThan(1.0),
+                    "scans seconds apart cannot be minutes apart");
+                Assert.That(psm.RetentionTime, Is.EqualTo(psm.RetentionTimeInSeconds / 60.0).Within(1e-12));
             }
         }
     }

--- a/mzLib/Test/FlashLFQ/TestIdentificationAdapter.cs
+++ b/mzLib/Test/FlashLFQ/TestIdentificationAdapter.cs
@@ -55,7 +55,10 @@ namespace Test.FlashLFQ
             Identification identification1 = identifications[0];
             Assert.That(identification1.BaseSequence, Is.EqualTo("KPVGAAK"));
             Assert.That(identification1.ModifiedSequence, Is.EqualTo("KPVGAAK"));
-            Assert.That(identification1.Ms2RetentionTimeInMinutes, Is.EqualTo(1.9398));
+            // MSFragger's "Retention" column is 1.9398 SECONDS. This assertion previously read
+            // Is.EqualTo(1.9398), pinning the seconds value into a property named for minutes —
+            // the bug itself, encoded as an expectation.
+            Assert.That(identification1.Ms2RetentionTimeInMinutes, Is.EqualTo(1.9398 / 60.0).Within(1e-12));
             Assert.That(identification1.MonoisotopicMass, Is.EqualTo(669.4173));
             Assert.That(identification1.PrecursorChargeState, Is.EqualTo(2));
 
@@ -68,7 +71,7 @@ namespace Test.FlashLFQ
             Identification identification5 = identifications[4];
             Assert.That(identification5.BaseSequence, Is.EqualTo("VVTHGGR"));
             Assert.That(identification5.ModifiedSequence, Is.EqualTo("VVTHGGR"));
-            Assert.That(identification5.Ms2RetentionTimeInMinutes, Is.EqualTo(19.114));
+            Assert.That(identification5.Ms2RetentionTimeInMinutes, Is.EqualTo(19.114 / 60.0).Within(1e-12));
             Assert.That(identification5.MonoisotopicMass, Is.EqualTo(724.398));
             Assert.That(identification5.PrecursorChargeState, Is.EqualTo(2));
         }

--- a/mzLib/Test/FlashLFQ/TestIdentificationAdapter.cs
+++ b/mzLib/Test/FlashLFQ/TestIdentificationAdapter.cs
@@ -55,9 +55,7 @@ namespace Test.FlashLFQ
             Identification identification1 = identifications[0];
             Assert.That(identification1.BaseSequence, Is.EqualTo("KPVGAAK"));
             Assert.That(identification1.ModifiedSequence, Is.EqualTo("KPVGAAK"));
-            // MSFragger's "Retention" column is 1.9398 SECONDS. This assertion previously read
-            // Is.EqualTo(1.9398), pinning the seconds value into a property named for minutes —
-            // the bug itself, encoded as an expectation.
+            // MSFragger's "Retention" column is in seconds (1.9398), so the expected value in minutes is 1.9398 / 60.
             Assert.That(identification1.Ms2RetentionTimeInMinutes, Is.EqualTo(1.9398 / 60.0).Within(1e-12));
             Assert.That(identification1.MonoisotopicMass, Is.EqualTo(669.4173));
             Assert.That(identification1.PrecursorChargeState, Is.EqualTo(2));


### PR DESCRIPTION
Fixes #1115.

`IQuantifiableRecord.RetentionTime` is documented as minutes and every consumer treats it as minutes, but `MsFraggerPsm` passed MSFragger's `Retention` column through unconverted — and MSFragger writes **seconds**.

`MzLibExtensions.MakeIdentifications` then assigns it to a variable literally named `ms2RetentionTimeInMinutes`, and `FlashLfqEngine` builds a **±2 minute** peak-finding window around it. So a peptide eluting at 60 minutes was searched for at 1 minute ± 2. Quantification collapses toward zero rather than failing — the most damaging way for this to be wrong, because the run still "succeeds".

Of the three types implementing `IQuantifiableResultFile`, MetaMorpheus `.psmtsv`/`.osmtsv` are genuinely in minutes and were always fine. MSFragger was the only one wrong, and it is the main reason someone reaches for the interface from outside MetaMorpheus.

## The fix

The raw column keeps a property of its own, now **named for its unit**:

```csharp
[Name("Retention")]
public double RetentionTimeInSeconds { get; set; }      // raw, as MSFragger wrote it

[Ignore] public double RetentionTime => RetentionTimeInSeconds / 60.0;   // the interface contract
```

Keeping the raw value means the file still round-trips on write (the existing round-trip test covers this) and anyone wanting the tool's verbatim number still has it. The conversion happens at the interface boundary — which is exactly what the spectra readers already do: `BrukerFileReader.cs:318` ("Bruker records retention time in seconds; mzLib's convention is minutes"), `MsAlign.cs:435`, `Mgf.cs:191`, `Mzml.cs:459`. Both halves of the library now agree on the unit.

## The bug was pinned by tests

Worth flagging, because it explains how this survived:

- `TestIdentificationAdapter.cs:58` asserted `Ms2RetentionTimeInMinutes == 1.9398` — the seconds value, sitting in a property named for minutes.
- `TestMsFraggerResultFiles.cs:103` asserted the same number on the record.

Both are corrected. Two new tests pin the *contract* rather than the number: that the interface value is the raw one over 60, and a gradient sanity check on the whole fixture (the five scans are ~1.1 s apart on an LTQ Orbitrap Velos, which read as minutes would imply a whole HeLa run of about 80 scans). The gradient test was tightened in review — see the follow-up below.

## Not in this PR

Two more unenforced contracts on the same interface, found alongside this and described in #1115. Both change semantics FlashLFQ consumes, so they deserve their own review:

- `MsFraggerPsm.IsDecoy` is hardcoded `false` — consumers cannot tell "target" from "unknown".
- `MsFraggerPsm.MonoisotopicMass` returns `CalculatedPeptideMass` (theoretical) while the psmtsv readers return the observed mass.

Also worth considering separately: no test asserted retention-time units for *any* result format, which is why this passed CI. TopPIC has the same seconds convention (`ToppicPrsm.cs:55`) and only escapes the bug because it does not implement `IQuantifiableRecord`.

## Review follow-up (commit `6c04e01f`)

A local review round hardened the tests and trimmed documentation, with no change to production behavior:

- **The gradient test now pins the divisor.** As first written, `MsFraggerPsm_RetentionTimesAreAPlausibleGradientInMinutes` only asserted `RetentionTime < 1.0` (true for *any* divisor ≥ 60, so a `/600` or `/3600` bug would still pass) and `RetentionTime == RetentionTimeInSeconds / 60.0` (a restatement of the getter, so it can't fail), with its assertions inside a `foreach` that an empty fixture would satisfy vacuously. It now guards `Has.Count.EqualTo(5)` and asserts against fixture literals external to the property under test — the last scan equals `19.114 / 60` and the first-to-last span equals `(19.114 − 1.9398) / 60` — so a wrong conversion factor fails the test.
- **Trimmed documentation that would rot.** The new `<remarks>` on `MsFraggerPsm` had narrated the bug history and hard-coded FlashLFQ internals (a consumer method name, one of its locals, the ±2-minute window) into a `Readers` record; they're reduced to the unit contract in the spectra-readers' style, and non-ASCII typography removed. The change-narration comment in `TestIdentificationAdapter` is trimmed to the durable fact that the column is seconds. That history stays in the commit message and this PR body, where it belongs.

Patch coverage remains 100% (2/2 changed lines).

## Testing

833 tests pass across the file-reading, quantifiable, FlashLFQ and identification-adapter suites.

Found while building a Python binding over `Readers`/`FlashLFQ` ([pyMzLib](https://github.com/smith-chem-wisc/pyMzLib)), which is why it is written up from the outside — but it affects any mzLib caller quantifying MSFragger results, including directly in C#.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp7uYMFdRCEWvg7sWZHFr2

