### PR TITLE
IQuantifiableRecord.IsDecoy → bool? (a format without a decoy column can report "not provided")

### DIFF
--- a/mzLib/FlashLFQ/ResultsReading/MzLibExtensions.cs
+++ b/mzLib/FlashLFQ/ResultsReading/MzLibExtensions.cs
@@ -69,8 +69,10 @@ namespace FlashLFQ
                     ms2RetentionTimeInMinutes, 
                     precursorChargeState, 
                     proteinGroups, 
-                    useForProteinQuant: !record.IsDecoy, 
-                    decoy: record.IsDecoy,
+                    // A record whose format does not carry decoy info (IsDecoy == null) is treated as
+                    // a target for quantification, matching the pre-nullable behaviour.
+                    useForProteinQuant: !(record.IsDecoy ?? false),
+                    decoy: record.IsDecoy ?? false,
                     psmScore: score,
                     qValue: usePepQValue ? pepQValue : qValue);
                 identifications.Add(id);

--- a/mzLib/Readers/BaseClasses/IQuantifiableRecord.cs
+++ b/mzLib/Readers/BaseClasses/IQuantifiableRecord.cs
@@ -43,9 +43,11 @@ namespace Readers
         public int ChargeState { get; }
 
         /// <summary>
-        /// Defines whether or not the result is a decoy identification
+        /// Whether the result is a decoy identification: <c>true</c> = decoy, <c>false</c> = target,
+        /// <c>null</c> = the source format does not carry target/decoy information (e.g. MSFragger
+        /// psm.tsv, which has no decoy column). Consumers should treat <c>null</c> as not-a-decoy.
         /// </summary>
-        public bool IsDecoy { get; }
+        public bool? IsDecoy { get; }
 
         /// <summary>
         /// The mass of the monoisotopic peptide (i.e., no c13 or n15 atoms are present, the lowest possible mass)

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/MsFraggerPsm.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/MsFraggerPsm.cs
@@ -214,8 +214,9 @@ namespace Readers
 
         [Ignore] public int ChargeState => Charge;
 
-        // decoy reading isn't currently supported for MsFragger psms, this will be revisited later
-        [Ignore] public bool IsDecoy => false;
+        // MSFragger psm.tsv has no target/decoy column -- FragPipe/Philosopher strip decoys before
+        // writing it -- so decoy status is genuinely not provided. null (not a fake false) says so.
+        [Ignore] public bool? IsDecoy => null;
 
         [Ignore] public double MonoisotopicMass => CalculatedPeptideMass;
 

--- a/mzLib/Readers/InternalResults/IndividualResultRecords/LightWeightSpectralMatch.cs
+++ b/mzLib/Readers/InternalResults/IndividualResultRecords/LightWeightSpectralMatch.cs
@@ -33,6 +33,11 @@ namespace Readers
         public int ChargeState { get; }
         public double MonoisotopicMass { get; }
 
+        // The shared bool IsDecoy above satisfies ISpectralMatch (a parsed match always knows its
+        // decoy status). Explicit implementation presents it through the nullable IQuantifiableRecord
+        // contract without forcing the public property, or ISpectralMatch, to nullable.
+        bool? IQuantifiableRecord.IsDecoy => IsDecoy;
+
         // Additional fields for filtering / downstream use
         public double QValue { get; }
         public double PepQValue { get; }

--- a/mzLib/Readers/InternalResults/IndividualResultRecords/SpectrumMatchFromTsv.cs
+++ b/mzLib/Readers/InternalResults/IndividualResultRecords/SpectrumMatchFromTsv.cs
@@ -85,6 +85,11 @@ namespace Readers
         public string BaseSequence => BaseSeq;
         public int ChargeState => PrecursorCharge;
         public bool IsDecoy => DecoyContamTarget.Contains('D');
+
+        // A .psmtsv always carries decoy status, so the record view is never "not provided".
+        // Explicit implementation keeps the public bool (consumed directly, incl. by MetaMorpheus)
+        // while presenting the nullable IQuantifiableRecord contract.
+        bool? IQuantifiableRecord.IsDecoy => IsDecoy;
         public bool IsEntrapment => DecoyContamTarget.Contains('E');
         public double MonoisotopicMass => double.TryParse(MonoisotopicMassString.Split('|')[0], CultureInfo.InvariantCulture, out double monoMass) ? monoMass : -1;
         private List<(string proteinAccessions, string geneName, string organism)>? _proteinGroupInfos;

--- a/mzLib/Test/FileReadingTests/ExternalFileReading/TestMsFraggerResultFiles.cs
+++ b/mzLib/Test/FileReadingTests/ExternalFileReading/TestMsFraggerResultFiles.cs
@@ -83,6 +83,18 @@ namespace Test.FileReadingTests.ExternalFileReading
         }
 
         [Test]
+        public void MsFraggerPsm_IsDecoy_IsNull_BecauseFormatHasNoDecoyColumn()
+        {
+            string filePath = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                @"FileReadingTests\ExternalFileTypes\FraggerPsm_FragPipev21.1_psm.tsv");
+            MsFraggerPsmFile file = new MsFraggerPsmFile(filePath);
+
+            // MSFragger psm.tsv carries no target/decoy column, so decoy status is "not provided", not false.
+            foreach (MsFraggerPsm psm in file)
+                Assert.That(((IQuantifiableRecord)psm).IsDecoy, Is.Null);
+        }
+
+        [Test]
         public void TestMsFraggerPsmFirstAndLastCorrect()
         {
             string filePath = Path.Combine(TestContext.CurrentContext.TestDirectory,

--- a/mzLib/Test/FlashLFQ/TestIdentificationAdapter.cs
+++ b/mzLib/Test/FlashLFQ/TestIdentificationAdapter.cs
@@ -197,6 +197,43 @@ namespace Test.FlashLFQ
         }
 
         [Test]
+        public void MakeIdentifications_IsDecoyNullOrTrueOrFalse_MapsToTargetDecoyCorrectly()
+        {
+            // null = the source format does not provide decoy info (e.g. MSFragger psm.tsv). It must
+            // be treated as a target so the record is still quantified, matching pre-nullable behaviour.
+            var records = new List<IQuantifiableRecord>
+            {
+                MakeMock("NOTPROVIDED", isDecoy: null),
+                MakeMock("KNOWNTARGET",  isDecoy: false),
+                MakeMock("KNOWNDECOY",   isDecoy: true),
+            };
+            var spectraFiles = new List<SpectraFileInfo> { new SpectraFileInfo("file1.mzML", "", 0, 0, 0) };
+
+            var result = MzLibExtensions.MakeIdentifications(new MockQuantifiableResultFile(records), spectraFiles);
+
+            var notProvided = result.Single(i => i.BaseSequence == "NOTPROVIDED");
+            Assert.That(notProvided.IsDecoy, Is.False, "null IsDecoy must be treated as a target");
+            Assert.That(notProvided.UseForProteinQuant, Is.True);
+
+            Assert.That(result.Single(i => i.BaseSequence == "KNOWNTARGET").IsDecoy, Is.False);
+            var decoy = result.Single(i => i.BaseSequence == "KNOWNDECOY");
+            Assert.That(decoy.IsDecoy, Is.True);
+            Assert.That(decoy.UseForProteinQuant, Is.False);
+        }
+
+        private static MockQuantifiableRecord MakeMock(string baseSeq, bool? isDecoy) => new MockQuantifiableRecord
+        {
+            BaseSequence = baseSeq,
+            FullSequence = baseSeq,
+            RetentionTime = 5.0,
+            MonoisotopicMass = 500.0,
+            ChargeState = 2,
+            FileName = "file1.mzML",
+            IsDecoy = isDecoy,
+            ProteinGroupInfos = new List<(string proteinAccessions, string geneName, string organism)> { ("P1", "Gene1", "Org1") }
+        };
+
+        [Test]
         public void SpectraFileNotFound()
         {
             var quantifiableRecords = new List<IQuantifiableRecord>
@@ -335,7 +372,7 @@ namespace Test.FlashLFQ
         public int ChargeState { get; set; }
         public List<(string proteinAccessions, string geneName, string organism)> ProteinGroupInfos { get; set; }
         public string FileName { get; set; }
-        public bool IsDecoy { get; set; }
+        public bool? IsDecoy { get; set; }
     }
 
 }


### PR DESCRIPTION
Closes #1117.

## The change

`IQuantifiableRecord.IsDecoy` was `bool`, forcing every record to claim a target/decoy status even when its source format has no such column. MSFragger `psm.tsv` has no decoy column (FragPipe/Philosopher strip decoys before writing), so `MsFraggerPsm.IsDecoy` returned a hardcoded `false` — which every consumer reads as **"known target"** when the truthful answer is **"not provided."**

```diff
-public bool IsDecoy { get; }
+public bool? IsDecoy { get; }   // true = decoy, false = target, null = format does not provide it
```

It is harmless for FlashLFQ today (an all-targets file quantifies fine), so this is not a bug fix — it is a contract fix. The interface could not express *"this format does not say,"* and the Python / Rust / R bridges over `Readers`/`FlashLFQ` would otherwise each reinvent the same per-bridge stop-gap. The fix belongs once, in the shared contract.

## Why `bool?`

It matches how mzLib already expresses an optional record field:
- `Proteomics.UniProtSequenceAttributes.IsPrecursor` — `bool?`, commented `//optional`
- `Omics.SpectralMatch.ISpectralMatch.Intensities` — `double[]?`, "null if no quantification was performed"

And each target language has a first-class "missing" for booleans, so it projects with **no per-bridge stop-gap**: C# `bool?`, Python `Optional[bool]`/`None`, Rust `Option<bool>`, R logical `NA`.

| `IsDecoy` | meaning | consumer policy |
|---|---|---|
| `true` | known decoy | exclude from quant |
| `false` | known target | include |
| `null` | format does not provide it | treated as not-a-decoy (`?? false`) — preserves today's behaviour |

## Kept contained to mzLib — no MetaMorpheus break

`LightWeightSpectralMatch` implements **both** `IQuantifiableRecord` and `Omics.SpectralMatch.ISpectralMatch` through one `bool IsDecoy`, and `SpectrumMatchFromTsv`'s public `bool IsDecoy` is consumed by MetaMorpheus. Rather than cascade the nullable into `ISpectralMatch` / `BaseSpectralMatch` (and MM), **only `IQuantifiableRecord.IsDecoy` changes**; those two implementers get an **explicit interface implementation** (`bool? IQuantifiableRecord.IsDecoy => IsDecoy;`) so their public `bool` API is untouched. The two `ISpectralMatch` interfaces stay `bool` — a parsed spectral match always knows its decoy status.

## Touched

- `IQuantifiableRecord.IsDecoy` → `bool?` (+ doc).
- `MsFraggerPsm.IsDecoy` → `null` (no decoy column) instead of `false`.
- `SpectrumMatchFromTsv`, `LightWeightSpectralMatch` → explicit `IQuantifiableRecord` impl; public `bool IsDecoy` unchanged.
- `FlashLFQ/ResultsReading/MzLibExtensions.cs` → collapse to `bool` at the boundary with `?? false` (the established decoy idiom, cf. `Protein.cs`); `FlashLFQ.Identification.IsDecoy` stays `bool`.
- Test double `MockQuantifiableRecord.IsDecoy` → `bool?`.

## Tests

- `MakeIdentifications_IsDecoyNullOrTrueOrFalse_MapsToTargetDecoyCorrectly` — `null` → target (quantified, `UseForProteinQuant` true); `true` → decoy (not used for quant); `false` → target.
- `MsFraggerPsm_IsDecoy_IsNull_BecauseFormatHasNoDecoyColumn` — the reader reports `null` through the interface.

Full solution builds; all FlashLFQ / MsFragger / lightweight-PSM adapter tests pass.

## Context

Surfaced from #1115 while building [pyMzLib](https://github.com/smith-chem-wisc/pyMzLib) and planning the Rust/R siblings: the recurring shape is *a record value whose availability varies by format*, and the efficient home for the fix is the shared contract, not each bridge. A per-format "capability descriptor" was considered and rejected as premature — `IsDecoy` is currently the only availability-varying field; revisit if more surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp7uYMFdRCEWvg7sWZHFr2
