### PR TITLE
Add PrideArchiveClient.GetProjectFilesFromFtpAsync for the complete PRIDE file list

### DIFF
--- a/mzLib/Test/DatabaseTests/PrideFtpListingTests.cs
+++ b/mzLib/Test/DatabaseTests/PrideFtpListingTests.cs
@@ -179,8 +179,10 @@ public class PrideFtpListingTests
     [Test]
     public void ASelfReferentialSubdirectoryHitsTheDepthCapInsteadOfRecursingForever()
     {
-        // A listing whose only entry links back to itself would recurse until the stack overflows; the
-        // depth cap turns that into a throwable HttpRequestException, and the walk stays bounded.
+        // A listing whose only entry links to a deeper copy of itself grows the URL each level, so the
+        // visited-set cannot prune it — the depth cap is the backstop. It throws MzLibException (a broken
+        // listing is a contract violation, NOT an HttpRequestException a live test would skip as an
+        // outage), and the walk stays bounded to MaxFtpDirectoryDepth (64) levels plus the root = 65.
         int dirFetches = 0;
         var handler = new StubHandler(uri =>
         {
@@ -191,12 +193,12 @@ public class PrideFtpListingTests
         });
         using var client = new PrideArchiveClient(new HttpClient(handler));
 
-        var ex = Assert.ThrowsAsync<HttpRequestException>(async () =>
+        var ex = Assert.ThrowsAsync<MzLibException>(async () =>
             await client.GetProjectFilesFromFtpAsync("PXD000001"));
         Assert.Multiple(() =>
         {
             Assert.That(ex!.Message, Does.Contain("nesting exceeded"));
-            Assert.That(dirFetches, Is.LessThan(200), "the walk must be bounded, not runaway");
+            Assert.That(dirFetches, Is.EqualTo(65), "the walk must stop at the depth cap, not run away");
         });
     }
 
@@ -254,9 +256,80 @@ public class PrideFtpListingTests
         using PrideArchiveClient client = StubbedClient(out _);
         List<PrideFtpFile> files = await client.GetProjectFilesFromFtpAsync("PXD000001");
 
-        // Sums every file including the one under generated/, matching the REST-side TotalSizeBytes.
-        Assert.That(files.TotalApproximateSizeBytes(), Is.EqualTo(files.Sum(f => f.ApproximateSizeBytes)));
-        Assert.That(files.TotalApproximateSizeBytes(), Is.GreaterThan(0));
+        // Pinned to the literal expected total (README 1.6K + run1 210M + hidden 429M + the nested
+        // generated/summary 844K), so the assertion can fail on a real regression rather than
+        // re-deriving the implementation's own Sum. Proves the helper sums the WHOLE tree, subdir included.
+        const long expected = 1638L + 210L * 1024 * 1024 + 429L * 1024 * 1024 + 864256L;
+        Assert.That(files.TotalApproximateSizeBytes(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public async Task ADescriptionColumnDoesNotStealTheSizeCell()
+    {
+        // A stock Apache template also right-aligns the (empty) Description column, so the LAST
+        // right-aligned cell is not the size. The parser picks the first cell that parses as a size.
+        const string rowWithDescription =
+            """<tr><td><a href="d.raw">d.raw</a></td><td align="right">2021-10-20 04:56  </td><td align="right">2.0M</td><td align="right">&nbsp;</td></tr>""";
+        var handler = new StubHandler(uri =>
+        {
+            if (uri.EndsWith("/projects/PXD000001", StringComparison.Ordinal)) return Ok(ProjectJson);
+            if (uri == RootUrl) return Ok(Index(rowWithDescription));
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        PrideFtpFile file = (await client.GetProjectFilesFromFtpAsync("PXD000001")).Single();
+        Assert.That(file.ApproximateSizeBytes, Is.EqualTo(2L * 1024 * 1024),
+            "the empty Description column must not shadow the Size cell");
+    }
+
+    [Test]
+    public async Task HtmlEntitiesInNamesAreDecoded()
+    {
+        var handler = new StubHandler(uri =>
+        {
+            if (uri.EndsWith("/projects/PXD000001", StringComparison.Ordinal)) return Ok(ProjectJson);
+            if (uri == RootUrl) return Ok(Index(Row("a&amp;b.raw", "1.0K")));
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        PrideFtpFile file = (await client.GetProjectFilesFromFtpAsync("PXD000001")).Single();
+        Assert.That(file.FileName, Is.EqualTo("a&b.raw"), "an HTML entity in the href must decode for the name");
+    }
+
+    [Test]
+    public async Task SizeSuffixesGAndBareByteCountsParse()
+    {
+        var handler = new StubHandler(uri =>
+        {
+            if (uri.EndsWith("/projects/PXD000001", StringComparison.Ordinal)) return Ok(ProjectJson);
+            if (uri == RootUrl) return Ok(Index(Row("big.raw", "1.2G"), Row("tiny.txt", "512")));
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        Dictionary<string, PrideFtpFile> byPath =
+            (await client.GetProjectFilesFromFtpAsync("PXD000001")).ToDictionary(f => f.RelativePath);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(byPath["big.raw"].ApproximateSizeBytes, Is.EqualTo((long)Math.Round(1.2 * 1024 * 1024 * 1024)));
+            Assert.That(byPath["tiny.txt"].ApproximateSizeBytes, Is.EqualTo(512L), "a bare byte count carries no suffix");
+        });
+    }
+
+    [Test]
+    public void APreCancelledTokenStopsTheWalk()
+    {
+        using PrideArchiveClient client = StubbedClient(out _);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // CatchAsync, not ThrowsAsync: the concrete type is TaskCanceledException, which derives from
+        // OperationCanceledException but would fail an exact-type ThrowsAsync match.
+        Assert.CatchAsync<OperationCanceledException>(async () =>
+            await client.GetProjectFilesFromFtpAsync("PXD000001", cts.Token));
     }
 }
 
@@ -282,11 +355,16 @@ public class PrideFtpListingLiveTests
             List<PrideFtpFile> ftpFiles = await client.GetProjectFilesFromFtpAsync("PXD000001");
             List<PrideArchiveFile> restFiles = await client.GetProjectFilesAsync("PXD000001");
 
-            // The whole point: the FTP tree is more complete than the REST manifest PRIDE serves.
-            // Asserted as a comparison rather than a hard-coded 13, so it survives PRIDE re-curating the
-            // dataset while still failing if the autoindex parse breaks (which would yield zero files).
+            HashSet<string> ftpNames = ftpFiles.Select(f => f.FileName).ToHashSet();
+
+            // The whole point: the FTP tree is a strict SUPERSET of the REST manifest — it contains
+            // every file REST reports AND more. Asserted structurally (not a hard-coded 13), so it
+            // survives PRIDE re-curating the dataset while still failing if the parse breaks (zero files)
+            // or ever drops a file REST does list.
+            Assert.That(restFiles.Select(r => r.FileName), Is.SubsetOf(ftpNames),
+                "the FTP tree should contain every file the REST manifest lists");
             Assert.That(ftpFiles.Count, Is.GreaterThan(restFiles.Count),
-                "the FTP tree should hold more files than the REST manifest");
+                $"FTP tree ({ftpFiles.Count}) should hold more files than the REST manifest ({restFiles.Count})");
             Assert.That(ftpFiles, Is.Not.Empty);
             Assert.That(ftpFiles.All(f => !string.IsNullOrEmpty(f.RelativePath) && !string.IsNullOrEmpty(f.Url)));
             Assert.That(ftpFiles.Any(f => f.ApproximateSizeBytes > 0), "at least one file should have a parsed size");

--- a/mzLib/Test/DatabaseTests/PrideFtpListingTests.cs
+++ b/mzLib/Test/DatabaseTests/PrideFtpListingTests.cs
@@ -331,6 +331,53 @@ public class PrideFtpListingTests
         Assert.CatchAsync<OperationCanceledException>(async () =>
             await client.GetProjectFilesFromFtpAsync("PXD000001", cts.Token));
     }
+
+    [Test]
+    public void AProjectWithNoPublicationDateIsAnMzLibException()
+    {
+        // Without a publication date there is no year/month to locate the FTP directory. That is a
+        // broken contract (MzLibException), reported before any FTP request is attempted.
+        const string noDateJson = """{ "accession": "PXD000001" }""";
+        var handler = new StubHandler(uri =>
+            uri.EndsWith("/projects/PXD000001", StringComparison.Ordinal)
+                ? Ok(noDateJson)
+                : new HttpResponseMessage(HttpStatusCode.NotFound));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        var ex = Assert.ThrowsAsync<MzLibException>(async () =>
+            await client.GetProjectFilesFromFtpAsync("PXD000001"));
+        Assert.That(ex!.Message, Does.Contain("no publication date"));
+    }
+
+    [Test]
+    public void TotalApproximateSizeBytesRejectsANullSequence()
+    {
+        Assert.Throws<ArgumentNullException>(() => ((IEnumerable<PrideFtpFile>)null).TotalApproximateSizeBytes());
+    }
+
+    [Test]
+    public async Task ATSuffixParsesAndAnUnrecognisedSizeCellIsZeroNotAFailure()
+    {
+        var handler = new StubHandler(uri =>
+        {
+            if (uri.EndsWith("/projects/PXD000001", StringComparison.Ordinal)) return Ok(ProjectJson);
+            if (uri == RootUrl) return Ok(Index(Row("huge.raw", "1.5T"), Row("weird.dat", "N/A")));
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        Dictionary<string, PrideFtpFile> byPath =
+            (await client.GetProjectFilesFromFtpAsync("PXD000001")).ToDictionary(f => f.RelativePath);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(byPath["huge.raw"].ApproximateSizeBytes,
+                Is.EqualTo((long)Math.Round(1.5 * 1024 * 1024 * 1024 * 1024)));
+            // A cell that is not a recognisable size leaves the file listed with an unknown (0) size
+            // rather than dropping it or throwing — the list stays complete.
+            Assert.That(byPath["weird.dat"].ApproximateSizeBytes, Is.EqualTo(0L));
+        });
+    }
 }
 
 /// <summary>

--- a/mzLib/Test/DatabaseTests/PrideFtpListingTests.cs
+++ b/mzLib/Test/DatabaseTests/PrideFtpListingTests.cs
@@ -1,0 +1,201 @@
+using MzLibUtil;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using UsefulProteomicsDatabases;
+
+namespace Test.DatabaseTests;
+
+/// <summary>
+/// Tests for <see cref="PrideArchiveClient.GetProjectFilesFromFtpAsync"/> — the complete file list read
+/// by walking a project's FTP directory tree, for the cases where PRIDE's REST manifest is incomplete.
+/// Offline: a stub handler serves a recorded project payload and Apache autoindex pages, so no network.
+/// </summary>
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class PrideFtpListingTests
+{
+    /// <summary>An HttpMessageHandler that dispatches by request URI and records what was requested.</summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<string, HttpResponseMessage> _byUri;
+        public List<string> RequestedUris { get; } = new();
+
+        public StubHandler(Func<string, HttpResponseMessage> byUri) => _byUri = byUri;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string uri = request.RequestUri!.ToString();
+            RequestedUris.Add(uri);
+            return Task.FromResult(_byUri(uri));
+        }
+    }
+
+    private static HttpResponseMessage Ok(string body) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(body) };
+
+    private const string ProjectJson =
+        """{ "accession": "PXD000001", "publicationDate": "2012-03-13" }""";
+
+    // A standard Apache autoindex table: a sort-header row (href "?C=..."), a "Parent Directory" row
+    // (absolute href "/..."), three files, and a subdirectory. Each entry's size is the LAST
+    // right-aligned cell; the first right-aligned cell is the last-modified date, as PRIDE serves it.
+    private const string RootIndexHtml = """
+        <html><head><title>Index of /pride/data/archive/2012/03/PXD000001</title></head><body>
+        <table>
+        <tr><th><a href="?C=N;O=D">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th><th><a href="?C=S;O=A">Size</a></th></tr>
+        <tr><th colspan="5"><hr></th></tr>
+        <tr><td><a href="/pride/data/archive/2012/03/">Parent Directory</a></td><td>&nbsp;</td><td align="right">  - </td></tr>
+        <tr><td><a href="README.txt">README.txt</a></td><td align="right">2021-10-20 04:56  </td><td align="right">1.6K</td></tr>
+        <tr><td><a href="run1.raw">run1.raw</a></td><td align="right">2021-10-20 04:56  </td><td align="right">210M</td></tr>
+        <tr><td><a href="hidden_from_rest.mzML">hidden_from_rest.mzML</a></td><td align="right">2021-10-20 04:56  </td><td align="right">429M</td></tr>
+        <tr><td><a href="generated/">generated/</a></td><td align="right">2021-10-20 04:56  </td><td align="right">  - </td></tr>
+        </table></body></html>
+        """;
+
+    private const string GeneratedIndexHtml = """
+        <html><head><title>Index of /pride/data/archive/2012/03/PXD000001/generated</title></head><body>
+        <table>
+        <tr><th><a href="?C=N;O=D">Name</a></th></tr>
+        <tr><td><a href="/pride/data/archive/2012/03/PXD000001/">Parent Directory</a></td><td align="right">  - </td></tr>
+        <tr><td><a href="summary.mztab">summary.mztab</a></td><td align="right">2021-10-20 04:56  </td><td align="right">844K</td></tr>
+        </table></body></html>
+        """;
+
+    private const string RootUrl = "https://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/";
+    private const string GeneratedUrl = RootUrl + "generated/";
+
+    /// <summary>A client that serves the recorded project + autoindex pages, and 404s an unknown project.</summary>
+    private static PrideArchiveClient StubbedClient(out StubHandler handler)
+    {
+        handler = new StubHandler(uri =>
+        {
+            if (uri.EndsWith("/projects/PXD000001", StringComparison.Ordinal)) return Ok(ProjectJson);
+            if (uri.Contains("/projects/")) return new HttpResponseMessage(HttpStatusCode.NotFound);
+            if (uri == RootUrl) return Ok(RootIndexHtml);
+            if (uri == GeneratedUrl) return Ok(GeneratedIndexHtml);
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+        return new PrideArchiveClient(new HttpClient(handler));
+    }
+
+    [Test]
+    public async Task WalksTheWholeTreeAndReportsFilesTheRestManifestOmits()
+    {
+        using PrideArchiveClient client = StubbedClient(out _);
+
+        List<PrideFtpFile> files = await client.GetProjectFilesFromFtpAsync("PXD000001");
+        Dictionary<string, PrideFtpFile> byPath = files.ToDictionary(f => f.RelativePath);
+
+        Assert.Multiple(() =>
+        {
+            // The complete set: three top-level files plus the one inside generated/. The "Parent
+            // Directory" link, the column-sort links, and the subdirectory row itself are NOT files.
+            Assert.That(byPath.Keys, Is.EquivalentTo(new[]
+            {
+                "README.txt", "run1.raw", "hidden_from_rest.mzML", "generated/summary.mztab",
+            }));
+
+            // The whole reason this method exists: a file the REST manifest hides is present here.
+            Assert.That(byPath.ContainsKey("hidden_from_rest.mzML"), Is.True);
+
+            // Recursion: a nested file carries its subdirectory in the relative path but a bare leaf name.
+            PrideFtpFile nested = byPath["generated/summary.mztab"];
+            Assert.That(nested.FileName, Is.EqualTo("summary.mztab"));
+            Assert.That(nested.Url, Is.EqualTo(GeneratedUrl + "summary.mztab"));
+
+            // The URL is the HTTPS location a caller can download from.
+            Assert.That(byPath["run1.raw"].Url, Is.EqualTo(RootUrl + "run1.raw"));
+        });
+    }
+
+    [Test]
+    public async Task ApproximateSizesAreParsedFromTheIndexSuffixes()
+    {
+        using PrideArchiveClient client = StubbedClient(out _);
+
+        Dictionary<string, PrideFtpFile> byPath =
+            (await client.GetProjectFilesFromFtpAsync("PXD000001")).ToDictionary(f => f.RelativePath);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(byPath["README.txt"].ApproximateSizeBytes, Is.EqualTo((long)Math.Round(1.6 * 1024)));
+            Assert.That(byPath["run1.raw"].ApproximateSizeBytes, Is.EqualTo(210L * 1024 * 1024));
+            Assert.That(byPath["hidden_from_rest.mzML"].ApproximateSizeBytes, Is.EqualTo(429L * 1024 * 1024));
+        });
+    }
+
+    [Test]
+    public void AnUnknownAccessionIsAnMzLibExceptionNotAnOutage()
+    {
+        using PrideArchiveClient client = StubbedClient(out _);
+
+        // GetProjectAsync answers a 404 project with MzLibException (not HttpRequestException, which a
+        // live test would skip). Walking the FTP tree must inherit that contract.
+        Assert.ThrowsAsync<MzLibException>(async () =>
+            await client.GetProjectFilesFromFtpAsync("PXD999999"));
+    }
+
+    [Test]
+    public void ABlankAccessionIsAnArgumentExceptionBeforeAnyRequest()
+    {
+        using PrideArchiveClient client = StubbedClient(out StubHandler handler);
+
+        Assert.ThrowsAsync<ArgumentException>(async () => await client.GetProjectFilesFromFtpAsync("   "));
+        Assert.That(handler.RequestedUris, Is.Empty, "a blank accession must be rejected before any HTTP request");
+    }
+
+    [Test]
+    public void AFailedDirectoryListingIsAnHttpRequestException()
+    {
+        // Project resolves, but its FTP directory returns non-success: that is an outage-shaped failure.
+        var handler = new StubHandler(uri =>
+            uri.EndsWith("/projects/PXD000001", StringComparison.Ordinal)
+                ? Ok(ProjectJson)
+                : new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        Assert.ThrowsAsync<HttpRequestException>(async () =>
+            await client.GetProjectFilesFromFtpAsync("PXD000001"));
+    }
+}
+
+/// <summary>
+/// Live canary against the real PRIDE FTP tree. [Category("ExternalService")] keeps it out of the
+/// required unit run (see the sibling <see cref="PrideArchiveClientLiveTests"/>);
+/// <see cref="ExternalServiceTestHelper.RunAsync"/> SKIPS it on a PRIDE outage but lets a genuine
+/// format drift FAIL. This is what catches EBI changing its Apache autoindex layout — the one thing
+/// the offline fixtures cannot.
+/// </summary>
+[TestFixture]
+[Category("ExternalService")]
+[Category("Pride")]
+[ExcludeFromCodeCoverage]
+public class PrideFtpListingLiveTests
+{
+    [Test]
+    public Task GetProjectFilesFromFtp_LivePxd000001_IsMoreCompleteThanTheRestManifest() =>
+        ExternalServiceTestHelper.RunAsync("PRIDE", async () =>
+        {
+            using var client = new PrideArchiveClient();
+
+            List<PrideFtpFile> ftpFiles = await client.GetProjectFilesFromFtpAsync("PXD000001");
+            List<PrideArchiveFile> restFiles = await client.GetProjectFilesAsync("PXD000001");
+
+            // The whole point: the FTP tree is more complete than the REST manifest PRIDE serves.
+            // Asserted as a comparison rather than a hard-coded 13, so it survives PRIDE re-curating the
+            // dataset while still failing if the autoindex parse breaks (which would yield zero files).
+            Assert.That(ftpFiles.Count, Is.GreaterThan(restFiles.Count),
+                "the FTP tree should hold more files than the REST manifest");
+            Assert.That(ftpFiles, Is.Not.Empty);
+            Assert.That(ftpFiles.All(f => !string.IsNullOrEmpty(f.RelativePath) && !string.IsNullOrEmpty(f.Url)));
+            Assert.That(ftpFiles.Any(f => f.ApproximateSizeBytes > 0), "at least one file should have a parsed size");
+        });
+}

--- a/mzLib/Test/DatabaseTests/PrideFtpListingTests.cs
+++ b/mzLib/Test/DatabaseTests/PrideFtpListingTests.cs
@@ -86,6 +86,16 @@ public class PrideFtpListingTests
         return new PrideArchiveClient(new HttpClient(handler));
     }
 
+    /// <summary>A minimal Apache-autoindex page wrapping the given entry rows.</summary>
+    private static string Index(params string[] rows) =>
+        "<html><body><table>\n" +
+        """<tr><th><a href="?C=N;O=D">Name</a></th></tr>""" + "\n" +
+        string.Join("\n", rows) + "\n</table></body></html>";
+
+    /// <summary>One autoindex row for an entry (a trailing "/" in <paramref name="href"/> makes it a directory).</summary>
+    private static string Row(string href, string size) =>
+        $"""<tr><td><a href="{href}">{href}</a></td><td align="right">2021-10-20 04:56  </td><td align="right">{size}</td></tr>""";
+
     [Test]
     public async Task WalksTheWholeTreeAndReportsFilesTheRestManifestOmits()
     {
@@ -164,6 +174,89 @@ public class PrideFtpListingTests
 
         Assert.ThrowsAsync<HttpRequestException>(async () =>
             await client.GetProjectFilesFromFtpAsync("PXD000001"));
+    }
+
+    [Test]
+    public void ASelfReferentialSubdirectoryHitsTheDepthCapInsteadOfRecursingForever()
+    {
+        // A listing whose only entry links back to itself would recurse until the stack overflows; the
+        // depth cap turns that into a throwable HttpRequestException, and the walk stays bounded.
+        int dirFetches = 0;
+        var handler = new StubHandler(uri =>
+        {
+            if (uri.EndsWith("/projects/PXD000001", StringComparison.Ordinal)) return Ok(ProjectJson);
+            if (uri.Contains("/projects/")) return new HttpResponseMessage(HttpStatusCode.NotFound);
+            dirFetches++;
+            return Ok(Index(Row("loop/", "-")));
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        var ex = Assert.ThrowsAsync<HttpRequestException>(async () =>
+            await client.GetProjectFilesFromFtpAsync("PXD000001"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex!.Message, Does.Contain("nesting exceeded"));
+            Assert.That(dirFetches, Is.LessThan(200), "the walk must be bounded, not runaway");
+        });
+    }
+
+    [Test]
+    public async Task ARelativeParentLinkIsRefusedSoTheWalkStaysInsideTheProject()
+    {
+        // A "../" would resolve (via Uri normalisation) to the project's PARENT directory and pull in
+        // unrelated files. It must be skipped; only plain child directories are followed.
+        const string parentUrl = "https://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/";
+        var handler = new StubHandler(uri =>
+        {
+            if (uri.EndsWith("/projects/PXD000001", StringComparison.Ordinal)) return Ok(ProjectJson);
+            if (uri == RootUrl) return Ok(Index(Row("../", "-"), Row("keep.raw", "1.0K")));
+            if (uri == parentUrl) return Ok(Index(Row("escaped.raw", "9.9M")));
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        List<PrideFtpFile> files = await client.GetProjectFilesFromFtpAsync("PXD000001");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(handler.RequestedUris, Does.Not.Contain(parentUrl),
+                "a '../' link must not be followed out of the project subtree");
+            Assert.That(files.Select(f => f.RelativePath), Is.EquivalentTo(new[] { "keep.raw" }));
+        });
+    }
+
+    [Test]
+    public async Task PercentEncodedNamesAreDecodedWhileTheUrlStaysEncoded()
+    {
+        var handler = new StubHandler(uri =>
+        {
+            if (uri.EndsWith("/projects/PXD000001", StringComparison.Ordinal)) return Ok(ProjectJson);
+            if (uri == RootUrl) return Ok(Index(Row("my%20run%20(1).raw", "1.0K")));
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        PrideFtpFile file = (await client.GetProjectFilesFromFtpAsync("PXD000001")).Single();
+
+        Assert.Multiple(() =>
+        {
+            // The human-readable name is percent-decoded; the URL keeps the encoding so it stays a
+            // valid, downloadable path.
+            Assert.That(file.FileName, Is.EqualTo("my run (1).raw"));
+            Assert.That(file.RelativePath, Is.EqualTo("my run (1).raw"));
+            Assert.That(file.Url, Is.EqualTo(RootUrl + "my%20run%20(1).raw"));
+        });
+    }
+
+    [Test]
+    public async Task TotalApproximateSizeBytesSumsTheWholeTree()
+    {
+        using PrideArchiveClient client = StubbedClient(out _);
+        List<PrideFtpFile> files = await client.GetProjectFilesFromFtpAsync("PXD000001");
+
+        // Sums every file including the one under generated/, matching the REST-side TotalSizeBytes.
+        Assert.That(files.TotalApproximateSizeBytes(), Is.EqualTo(files.Sum(f => f.ApproximateSizeBytes)));
+        Assert.That(files.TotalApproximateSizeBytes(), Is.GreaterThan(0));
     }
 }
 

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -185,15 +185,17 @@ namespace UsefulProteomicsDatabases
                 PrideArchiveExtensions.PrideFtpHost, project.PublicationDate, accession);
 
             var files = new List<PrideFtpFile>();
-            await CollectFtpFilesAsync(rootUrl, relativePrefix: "", depth: 0, files, cancellationToken).ConfigureAwait(false);
+            await CollectFtpFilesAsync(new Uri(rootUrl), relativePrefix: "", depth: 0, files, cancellationToken)
+                .ConfigureAwait(false);
             return files;
         }
 
         /// <summary>
-        /// A hard cap on how deep the FTP walk descends, guarding against a cyclic or self-referential
-        /// listing (a symlink loop) the way <see cref="MaxPages"/> guards the REST pager. No real PRIDE
-        /// project nests anywhere near this deep; exceeding it throws rather than recursing to a
-        /// process-killing <see cref="StackOverflowException"/>.
+        /// A hard cap on how deep the FTP walk descends. A symlink cycle is normally pruned by the
+        /// visited-URL set, so this is only a last-resort backstop for a genuinely (and implausibly)
+        /// deep tree; no real PRIDE project nests anywhere near this deep, and exceeding it is treated
+        /// as a broken listing (<see cref="MzLibException"/>) rather than left to a process-killing
+        /// <see cref="StackOverflowException"/>.
         /// </summary>
         private const int MaxFtpDirectoryDepth = 64;
 
@@ -203,60 +205,66 @@ namespace UsefulProteomicsDatabases
         /// project root down to this directory, so nested files carry a full relative path;
         /// <paramref name="depth"/> bounds the recursion.
         /// </summary>
-        private async Task CollectFtpFilesAsync(string directoryUrl, string relativePrefix, int depth,
+        private async Task CollectFtpFilesAsync(Uri directoryUri, string relativePrefix, int depth,
             List<PrideFtpFile> files, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            // The traversal guard below only ever appends a single non-".." segment, so the URL strictly
+            // deepens and can never revisit an earlier directory — no visited-set is needed. A cyclic
+            // listing (a self-linking symlink) therefore grows the URL without bound and is caught here.
+            // A broken listing is a contract violation (MzLibException) — NOT an HttpRequestException,
+            // which ExternalServiceTestHelper would misread as a service outage.
             if (depth > MaxFtpDirectoryDepth)
-                throw new HttpRequestException(
-                    $"PRIDE FTP directory nesting exceeded {MaxFtpDirectoryDepth} levels at '{directoryUrl}'; the listing may be cyclic.");
+                throw new MzLibException(
+                    $"PRIDE FTP directory nesting exceeded {MaxFtpDirectoryDepth} levels at '{directoryUri}'; the listing may be cyclic.");
 
-            using HttpResponseMessage response = await _httpClient.GetAsync(directoryUrl, cancellationToken).ConfigureAwait(false);
+            using HttpResponseMessage response = await _httpClient.GetAsync(directoryUri, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
                 throw new HttpRequestException(
-                    $"PRIDE FTP directory listing failed with status {(int)response.StatusCode} {response.ReasonPhrase} for '{directoryUrl}'.");
+                    $"PRIDE FTP directory listing failed with status {(int)response.StatusCode} {response.ReasonPhrase} for '{directoryUri}'.");
 
             string html = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
-            foreach ((string href, string sizeText) in ParseAutoIndexRows(html))
+            foreach ((string rawHref, string sizeText) in ParseAutoIndexRows(html))
             {
-                // The href is HTML-decoded but still URL-encoded — Apache percent-encodes special
-                // characters in the link. Keep the encoded form for the URL (a valid, downloadable path)
-                // and decode it only for the human-readable name, so a file called "my file.raw" does not
-                // surface as "my%20file.raw".
+                // rawHref is the link's attribute value, still URL-encoded. Resolve HTML entities, then
+                // compose the child URL with Uri joining (which escapes and handles the base's trailing
+                // slash safely), and decode only for the human-readable name — so "my%20file.raw"
+                // downloads from an encoded URL but surfaces as "my file.raw".
+                string href = WebUtility.HtmlDecode(rawHref);
                 string name = Uri.UnescapeDataString(href);
+                bool isDirectory = href.EndsWith("/", StringComparison.Ordinal);
+                string segment = isDirectory ? name.TrimEnd('/') : name;
 
-                if (href.EndsWith("/", StringComparison.Ordinal))
-                {
-                    // Descend only into a plain child directory — a single "<name>/" segment. A "../" or
-                    // "./" link, or any multi-segment path, would walk OUT of the project subtree (the Uri
-                    // class normalises "../" against the base), so it is refused; the depth cap above is
-                    // the backstop for a child that links back to itself.
-                    string segment = name.TrimEnd('/');
-                    if (segment.Length == 0 || segment == "." || segment == ".." || segment.Contains('/'))
-                        continue;
+                // Refuse a "." / ".." traversal (which the Uri join would normalise OUT of the project
+                // subtree) and any decoded segment that gained a path separator (an encoded "%2F"),
+                // before it is used to build either the URL or the relative path.
+                if (segment.Length == 0 || segment == "." || segment == ".." || segment.Contains('/'))
+                    continue;
 
-                    await CollectFtpFilesAsync(directoryUrl + href, relativePrefix + name, depth + 1, files, cancellationToken)
+                Uri childUri = new(directoryUri, href);
+
+                if (isDirectory)
+                    await CollectFtpFilesAsync(childUri, relativePrefix + name, depth + 1, files, cancellationToken)
                         .ConfigureAwait(false);
-                }
                 else
-                {
-                    files.Add(new PrideFtpFile(relativePrefix + name, ParseAutoIndexSize(sizeText), directoryUrl + href));
-                }
+                    files.Add(new PrideFtpFile(relativePrefix + name, ParseAutoIndexSize(sizeText), childUri.AbsoluteUri));
             }
         }
 
         // The PRIDE FTP host serves a standard Apache autoindex table over HTTPS: one <tr> per entry,
-        // whose <a href> is the (relative) name and whose LAST right-aligned cell is the size. The sort
-        // headers link to "?C=...", and "Parent Directory" links to an absolute "/..." path; both are
-        // skipped so only real entries survive.
+        // whose <a href> is the (relative) name and whose right-aligned cells are the last-modified date
+        // and the size. The sort headers link to "?C=...", and "Parent Directory" links to an absolute
+        // "/..." path; both are skipped so only real entries survive.
         private static readonly Regex RowRegex = new(@"<tr[^>]*>(.*?)</tr>", RegexOptions.Singleline | RegexOptions.IgnoreCase);
         private static readonly Regex HrefRegex = new("<a\\s+href=\"([^\"]+)\"", RegexOptions.IgnoreCase);
         private static readonly Regex RightCellRegex = new("<td[^>]*align=\"right\"[^>]*>(.*?)</td>", RegexOptions.Singleline | RegexOptions.IgnoreCase);
+        // A size cell is "-" (a directory) or a number optionally suffixed K/M/G/T — never a date.
+        private static readonly Regex SizeRegex = new(@"^(-|\d+(\.\d+)?[KMGT]?)$", RegexOptions.IgnoreCase);
 
-        /// <summary>Yields (href, sizeText) for each real entry in an Apache autoindex table.</summary>
-        private static IEnumerable<(string Href, string SizeText)> ParseAutoIndexRows(string html)
+        /// <summary>Yields the raw href and the size text for each real entry in an Apache autoindex table.</summary>
+        private static IEnumerable<(string RawHref, string SizeText)> ParseAutoIndexRows(string html)
         {
             foreach (Match row in RowRegex.Matches(html))
             {
@@ -264,17 +272,28 @@ namespace UsefulProteomicsDatabases
                 if (!href.Success)
                     continue;
 
-                string h = WebUtility.HtmlDecode(href.Groups[1].Value);
-                // Skip the column-sort links ("?C=N;O=D"), the absolute-path "Parent Directory", and anchors.
-                if (h.Length == 0 || h[0] == '/' || h[0] == '?' || h[0] == '#')
+                string raw = href.Groups[1].Value;
+                // Skip the column-sort links ("?C=N;O=D"), the absolute-path "Parent Directory", and
+                // anchors. Test the leading char on the decoded form; the RAW href is what the caller joins.
+                string decoded = WebUtility.HtmlDecode(raw);
+                if (decoded.Length == 0 || decoded[0] == '/' || decoded[0] == '?' || decoded[0] == '#')
                     continue;
 
-                // The size is the last right-aligned cell (the first is the last-modified date).
+                // Pick the FIRST right-aligned cell whose text parses as a size, NOT blindly the last: a
+                // stock Apache template also right-aligns the (empty) Description column, and the date cell
+                // is right-aligned too — neither of which looks like a size.
                 string sizeText = string.Empty;
                 foreach (Match cell in RightCellRegex.Matches(row.Groups[1].Value))
-                    sizeText = cell.Groups[1].Value;
+                {
+                    string text = WebUtility.HtmlDecode(cell.Groups[1].Value).Trim();
+                    if (SizeRegex.IsMatch(text))
+                    {
+                        sizeText = text;
+                        break;
+                    }
+                }
 
-                yield return (h, sizeText.Trim());
+                yield return (raw, sizeText);
             }
         }
 
@@ -289,7 +308,9 @@ namespace UsefulProteomicsDatabases
             if (sizeText.Length == 0 || sizeText == "-")
                 return 0;
 
-            double multiplier = char.ToUpperInvariant(sizeText[sizeText.Length - 1]) switch
+            char last = char.ToUpperInvariant(sizeText[sizeText.Length - 1]);
+            bool hasSuffix = last is 'K' or 'M' or 'G' or 'T';
+            double multiplier = last switch
             {
                 'K' => 1024d,
                 'M' => 1024d * 1024,
@@ -297,7 +318,7 @@ namespace UsefulProteomicsDatabases
                 'T' => 1024d * 1024 * 1024 * 1024,
                 _ => 1d,
             };
-            string number = multiplier == 1d ? sizeText : sizeText.Substring(0, sizeText.Length - 1);
+            string number = hasSuffix ? sizeText.Substring(0, sizeText.Length - 1) : sizeText;
             return double.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
                 ? (long)Math.Round(value * multiplier)
                 : 0;

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using MassSpectrometry;
@@ -141,6 +143,139 @@ namespace UsefulProteomicsDatabases
             }
 
             return files;
+        }
+
+        /// <summary>
+        /// Returns the COMPLETE list of a project's files by walking its FTP directory tree — for the
+        /// cases where <see cref="GetProjectFilesAsync"/> is not enough. PRIDE's REST manifest is
+        /// knowingly incomplete (for PXD000001 it lists 8 files while the FTP tree holds 13, omitting
+        /// the two largest), so a caller that must know everything a project contains — or its true
+        /// size — reads the tree instead of trusting the manifest.
+        /// </summary>
+        /// <remarks>
+        /// The tree lives at <c>https://{PrideFtpHost}/pride/data/archive/{yyyy}/{MM}/{accession}/</c>,
+        /// where the year and month are the project's <see cref="PrideProject.PublicationDate"/>. The FTP
+        /// host also serves that path over HTTPS — the same fact <see cref="DownloadFileAsync"/> relies
+        /// on — so the whole walk goes over this client's reused <see cref="HttpClient"/>. Subdirectories
+        /// are followed; each returned file's <see cref="PrideFtpFile.RelativePath"/> is relative to the
+        /// project root. Sizes are PRIDE's rounded index sizes — see <see cref="PrideFtpFile.ApproximateSizeBytes"/>.
+        /// </remarks>
+        /// <param name="accession">The PRIDE project accession, e.g. "PXD012345".</param>
+        /// <param name="cancellationToken">Cancels the (multi-request) walk.</param>
+        /// <returns>Every file under the project's FTP root, subdirectories included. Never null.</returns>
+        /// <exception cref="ArgumentException">The accession is null, empty, or whitespace.</exception>
+        /// <exception cref="MzLibException">No project has that accession, or it carries no publication date to locate its FTP directory.</exception>
+        /// <exception cref="HttpRequestException">A directory could not be listed (non-success status).</exception>
+        /// <exception cref="OperationCanceledException">The operation was cancelled via <paramref name="cancellationToken"/>.</exception>
+        public async Task<List<PrideFtpFile>> GetProjectFilesFromFtpAsync(string accession,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(accession))
+                throw new ArgumentException("A PRIDE project accession is required.", nameof(accession));
+
+            // GetProjectAsync gives the publication date AND the right failure contract: an unknown
+            // accession is an MzLibException (not an HttpRequestException that a live test would skip).
+            PrideProject project = await GetProjectAsync(accession, cancellationToken).ConfigureAwait(false);
+            if (project.PublicationDate == default)
+                throw new MzLibException(
+                    $"PRIDE project '{accession}' has no publication date, so its FTP directory cannot be located.");
+
+            string rootUrl = string.Format(CultureInfo.InvariantCulture,
+                "https://{0}/pride/data/archive/{1:yyyy}/{1:MM}/{2}/",
+                PrideArchiveExtensions.PrideFtpHost, project.PublicationDate, accession);
+
+            var files = new List<PrideFtpFile>();
+            await CollectFtpFilesAsync(rootUrl, relativePrefix: "", files, cancellationToken).ConfigureAwait(false);
+            return files;
+        }
+
+        /// <summary>
+        /// Lists one FTP directory (over HTTPS), appends its files to <paramref name="files"/>, and
+        /// recurses into each subdirectory. <paramref name="relativePrefix"/> is the path from the
+        /// project root down to this directory, so nested files carry a full relative path.
+        /// </summary>
+        private async Task CollectFtpFilesAsync(string directoryUrl, string relativePrefix,
+            List<PrideFtpFile> files, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using HttpResponseMessage response = await _httpClient.GetAsync(directoryUrl, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+                throw new HttpRequestException(
+                    $"PRIDE FTP directory listing failed with status {(int)response.StatusCode} {response.ReasonPhrase} for '{directoryUrl}'.");
+
+            string html = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            foreach ((string href, string sizeText) in ParseAutoIndexRows(html))
+            {
+                if (href.EndsWith("/", StringComparison.Ordinal))
+                {
+                    // A subdirectory (e.g. "generated/"): descend. ParseAutoIndexRows has already
+                    // dropped the "Parent Directory" link and the column-sort links.
+                    await CollectFtpFilesAsync(directoryUrl + href, relativePrefix + href, files, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    files.Add(new PrideFtpFile(relativePrefix + href, ParseAutoIndexSize(sizeText), directoryUrl + href));
+                }
+            }
+        }
+
+        // The PRIDE FTP host serves a standard Apache autoindex table over HTTPS: one <tr> per entry,
+        // whose <a href> is the (relative) name and whose LAST right-aligned cell is the size. The sort
+        // headers link to "?C=...", and "Parent Directory" links to an absolute "/..." path; both are
+        // skipped so only real entries survive.
+        private static readonly Regex RowRegex = new(@"<tr[^>]*>(.*?)</tr>", RegexOptions.Singleline | RegexOptions.IgnoreCase);
+        private static readonly Regex HrefRegex = new("<a\\s+href=\"([^\"]+)\"", RegexOptions.IgnoreCase);
+        private static readonly Regex RightCellRegex = new("<td[^>]*align=\"right\"[^>]*>(.*?)</td>", RegexOptions.Singleline | RegexOptions.IgnoreCase);
+
+        /// <summary>Yields (href, sizeText) for each real entry in an Apache autoindex table.</summary>
+        private static IEnumerable<(string Href, string SizeText)> ParseAutoIndexRows(string html)
+        {
+            foreach (Match row in RowRegex.Matches(html))
+            {
+                Match href = HrefRegex.Match(row.Groups[1].Value);
+                if (!href.Success)
+                    continue;
+
+                string h = WebUtility.HtmlDecode(href.Groups[1].Value);
+                // Skip the column-sort links ("?C=N;O=D"), the absolute-path "Parent Directory", and anchors.
+                if (h.Length == 0 || h[0] == '/' || h[0] == '?' || h[0] == '#')
+                    continue;
+
+                // The size is the last right-aligned cell (the first is the last-modified date).
+                string sizeText = string.Empty;
+                foreach (Match cell in RightCellRegex.Matches(row.Groups[1].Value))
+                    sizeText = cell.Groups[1].Value;
+
+                yield return (h, sizeText.Trim());
+            }
+        }
+
+        /// <summary>
+        /// Parses one Apache autoindex size cell ("1.6K", "20M", "9.3M", "1.2G", a bare byte count, or
+        /// "-" for a directory) into an APPROXIMATE byte count. The index rounds to ~3 significant
+        /// figures, so this is not exact — see <see cref="PrideFtpFile.ApproximateSizeBytes"/>.
+        /// </summary>
+        private static long ParseAutoIndexSize(string sizeText)
+        {
+            sizeText = sizeText.Trim();
+            if (sizeText.Length == 0 || sizeText == "-")
+                return 0;
+
+            double multiplier = char.ToUpperInvariant(sizeText[sizeText.Length - 1]) switch
+            {
+                'K' => 1024d,
+                'M' => 1024d * 1024,
+                'G' => 1024d * 1024 * 1024,
+                'T' => 1024d * 1024 * 1024 * 1024,
+                _ => 1d,
+            };
+            string number = multiplier == 1d ? sizeText : sizeText.Substring(0, sizeText.Length - 1);
+            return double.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
+                ? (long)Math.Round(value * multiplier)
+                : 0;
         }
 
         /// <summary>

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
@@ -148,9 +148,9 @@ namespace UsefulProteomicsDatabases
         /// <summary>
         /// Returns the COMPLETE list of a project's files by walking its FTP directory tree — for the
         /// cases where <see cref="GetProjectFilesAsync"/> is not enough. PRIDE's REST manifest is
-        /// knowingly incomplete (for PXD000001 it lists 8 files while the FTP tree holds 13, omitting
-        /// the two largest), so a caller that must know everything a project contains — or its true
-        /// size — reads the tree instead of trusting the manifest.
+        /// knowingly incomplete (for PXD000001 it lists 8 files while the FTP tree holds 13 — it omits
+        /// five, including the two largest), so a caller that must know everything a project contains —
+        /// or its true size — reads the tree instead of trusting the manifest.
         /// </summary>
         /// <remarks>
         /// The tree lives at <c>https://{PrideFtpHost}/pride/data/archive/{yyyy}/{MM}/{accession}/</c>,
@@ -165,7 +165,7 @@ namespace UsefulProteomicsDatabases
         /// <returns>Every file under the project's FTP root, subdirectories included. Never null.</returns>
         /// <exception cref="ArgumentException">The accession is null, empty, or whitespace.</exception>
         /// <exception cref="MzLibException">No project has that accession, or it carries no publication date to locate its FTP directory.</exception>
-        /// <exception cref="HttpRequestException">A directory could not be listed (non-success status).</exception>
+        /// <exception cref="HttpRequestException">The project or a directory could not be fetched (non-success status), or the directory nesting exceeded the cyclic-listing guard.</exception>
         /// <exception cref="OperationCanceledException">The operation was cancelled via <paramref name="cancellationToken"/>.</exception>
         public async Task<List<PrideFtpFile>> GetProjectFilesFromFtpAsync(string accession,
             CancellationToken cancellationToken = default)
@@ -185,19 +185,32 @@ namespace UsefulProteomicsDatabases
                 PrideArchiveExtensions.PrideFtpHost, project.PublicationDate, accession);
 
             var files = new List<PrideFtpFile>();
-            await CollectFtpFilesAsync(rootUrl, relativePrefix: "", files, cancellationToken).ConfigureAwait(false);
+            await CollectFtpFilesAsync(rootUrl, relativePrefix: "", depth: 0, files, cancellationToken).ConfigureAwait(false);
             return files;
         }
 
         /// <summary>
-        /// Lists one FTP directory (over HTTPS), appends its files to <paramref name="files"/>, and
-        /// recurses into each subdirectory. <paramref name="relativePrefix"/> is the path from the
-        /// project root down to this directory, so nested files carry a full relative path.
+        /// A hard cap on how deep the FTP walk descends, guarding against a cyclic or self-referential
+        /// listing (a symlink loop) the way <see cref="MaxPages"/> guards the REST pager. No real PRIDE
+        /// project nests anywhere near this deep; exceeding it throws rather than recursing to a
+        /// process-killing <see cref="StackOverflowException"/>.
         /// </summary>
-        private async Task CollectFtpFilesAsync(string directoryUrl, string relativePrefix,
+        private const int MaxFtpDirectoryDepth = 64;
+
+        /// <summary>
+        /// Lists one FTP directory (over HTTPS), appends its files to <paramref name="files"/>, and
+        /// recurses into each child subdirectory. <paramref name="relativePrefix"/> is the path from the
+        /// project root down to this directory, so nested files carry a full relative path;
+        /// <paramref name="depth"/> bounds the recursion.
+        /// </summary>
+        private async Task CollectFtpFilesAsync(string directoryUrl, string relativePrefix, int depth,
             List<PrideFtpFile> files, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (depth > MaxFtpDirectoryDepth)
+                throw new HttpRequestException(
+                    $"PRIDE FTP directory nesting exceeded {MaxFtpDirectoryDepth} levels at '{directoryUrl}'; the listing may be cyclic.");
 
             using HttpResponseMessage response = await _httpClient.GetAsync(directoryUrl, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
@@ -208,16 +221,28 @@ namespace UsefulProteomicsDatabases
 
             foreach ((string href, string sizeText) in ParseAutoIndexRows(html))
             {
+                // The href is HTML-decoded but still URL-encoded — Apache percent-encodes special
+                // characters in the link. Keep the encoded form for the URL (a valid, downloadable path)
+                // and decode it only for the human-readable name, so a file called "my file.raw" does not
+                // surface as "my%20file.raw".
+                string name = Uri.UnescapeDataString(href);
+
                 if (href.EndsWith("/", StringComparison.Ordinal))
                 {
-                    // A subdirectory (e.g. "generated/"): descend. ParseAutoIndexRows has already
-                    // dropped the "Parent Directory" link and the column-sort links.
-                    await CollectFtpFilesAsync(directoryUrl + href, relativePrefix + href, files, cancellationToken)
+                    // Descend only into a plain child directory — a single "<name>/" segment. A "../" or
+                    // "./" link, or any multi-segment path, would walk OUT of the project subtree (the Uri
+                    // class normalises "../" against the base), so it is refused; the depth cap above is
+                    // the backstop for a child that links back to itself.
+                    string segment = name.TrimEnd('/');
+                    if (segment.Length == 0 || segment == "." || segment == ".." || segment.Contains('/'))
+                        continue;
+
+                    await CollectFtpFilesAsync(directoryUrl + href, relativePrefix + name, depth + 1, files, cancellationToken)
                         .ConfigureAwait(false);
                 }
                 else
                 {
-                    files.Add(new PrideFtpFile(relativePrefix + href, ParseAutoIndexSize(sizeText), directoryUrl + href));
+                    files.Add(new PrideFtpFile(relativePrefix + name, ParseAutoIndexSize(sizeText), directoryUrl + href));
                 }
             }
         }

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveExtensions.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveExtensions.cs
@@ -142,6 +142,20 @@ namespace UsefulProteomicsDatabases
             return files.Where(f => f != null).Sum(f => f.FileSizeBytes);
         }
 
+        /// <summary>
+        /// The estimated total size in bytes of a project's FTP tree (from
+        /// <see cref="PrideArchiveClient.GetProjectFilesFromFtpAsync"/>), nulls ignored. APPROXIMATE for
+        /// the same reason the per-file value is — see <see cref="PrideFtpFile.ApproximateSizeBytes"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">The sequence is null.</exception>
+        public static long TotalApproximateSizeBytes(this IEnumerable<PrideFtpFile> files)
+        {
+            if (files == null)
+                throw new ArgumentNullException(nameof(files));
+
+            return files.Where(f => f != null).Sum(f => f.ApproximateSizeBytes);
+        }
+
         // ---- PROXI spectrum metadata -------------------------------------------------------------------
         //
         // The PSI-MS accessions PROXI uses to describe a spectrum. Matched on accession, never on name (see

--- a/mzLib/UsefulProteomicsDatabases/PrideFtpFile.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideFtpFile.cs
@@ -3,9 +3,9 @@ namespace UsefulProteomicsDatabases
     /// <summary>
     /// One file found by walking a PRIDE project's FTP directory tree — the COMPLETE listing. PRIDE's
     /// REST manifest (<see cref="PrideArchiveClient.GetProjectFilesAsync"/>) is knowingly incomplete:
-    /// for PXD000001 it returns 8 files while the FTP tree holds 13, omitting the two largest. When a
-    /// caller must know everything a project actually contains — or its true size — this is the
-    /// authoritative list.
+    /// for PXD000001 it returns 8 files while the FTP tree holds 13 — it omits five, including the two
+    /// largest. When a caller must know everything a project actually contains — or its true size —
+    /// this is the authoritative list.
     /// </summary>
     public sealed class PrideFtpFile
     {

--- a/mzLib/UsefulProteomicsDatabases/PrideFtpFile.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideFtpFile.cs
@@ -1,0 +1,42 @@
+namespace UsefulProteomicsDatabases
+{
+    /// <summary>
+    /// One file found by walking a PRIDE project's FTP directory tree — the COMPLETE listing. PRIDE's
+    /// REST manifest (<see cref="PrideArchiveClient.GetProjectFilesAsync"/>) is knowingly incomplete:
+    /// for PXD000001 it returns 8 files while the FTP tree holds 13, omitting the two largest. When a
+    /// caller must know everything a project actually contains — or its true size — this is the
+    /// authoritative list.
+    /// </summary>
+    public sealed class PrideFtpFile
+    {
+        /// <param name="relativePath">The path relative to the project's FTP root (see <see cref="RelativePath"/>).</param>
+        /// <param name="approximateSizeBytes">PRIDE's rounded index size in bytes (see <see cref="ApproximateSizeBytes"/>).</param>
+        /// <param name="url">The file's HTTPS download URL.</param>
+        public PrideFtpFile(string relativePath, long approximateSizeBytes, string url)
+        {
+            RelativePath = relativePath;
+            ApproximateSizeBytes = approximateSizeBytes;
+            Url = url;
+        }
+
+        /// <summary>
+        /// The path relative to the project's FTP root, e.g. "run1.raw" or, for a file in a
+        /// subdirectory, "generated/summary.mztab".
+        /// </summary>
+        public string RelativePath { get; }
+
+        /// <summary>The bare file name — the last segment of <see cref="RelativePath"/>.</summary>
+        public string FileName => RelativePath.Substring(RelativePath.LastIndexOf('/') + 1);
+
+        /// <summary>
+        /// The file's size as PRIDE's FTP directory index reports it, ROUNDED to about three
+        /// significant figures (its "429M" becomes 449 839 104). It is good for a project-size
+        /// estimate but is NOT exact — deliberately named to say so. For the precise transfer size of a
+        /// single file, issue an HTTP HEAD against <see cref="Url"/> and read its Content-Length.
+        /// </summary>
+        public long ApproximateSizeBytes { get; }
+
+        /// <summary>The HTTPS URL the file can be downloaded from.</summary>
+        public string Url { get; }
+    }
+}


### PR DESCRIPTION
## Why

PRIDE's REST manifest is knowingly incomplete. For **PXD000001**, `GetProjectFilesAsync` returns **8** files while the project's FTP tree holds **13**, omitting the two largest. A caller that must know everything a project actually contains — or its true size — has no way to get it from the REST API today, and is left to open the FTP directory in a browser by hand.

## What

Adds **`PrideArchiveClient.GetProjectFilesFromFtpAsync(accession)`**, which walks the project's FTP directory tree and returns the complete list.

- The tree lives at `https://ftp.pride.ebi.ac.uk/pride/data/archive/{yyyy}/{MM}/{accession}/` (year/month from `PrideProject.PublicationDate`). The PRIDE FTP host also serves that path over **HTTPS** — the same fact `DownloadFileAsync` already relies on — so the whole walk goes over the client's reused `HttpClient`. **Subdirectories are followed.**
- Returns `List<PrideFtpFile>` (`RelativePath`, `FileName`, `Url`, `ApproximateSizeBytes`).
- **Sizes are honest about their precision.** PRIDE's Apache autoindex rounds to ~3 significant figures ("429M"), so the field is named `ApproximateSizeBytes` and its doc points a caller wanting exact transfer bytes at an HTTP HEAD on `Url`.

### Failure contract (matches the rest of the client)
- Blank accession → `ArgumentException`, before any request.
- Unknown accession → `MzLibException` (via `GetProjectAsync`), **not** an `HttpRequestException` a live test would skip as an outage.
- A failed directory listing → `HttpRequestException`.
- Honors `CancellationToken`; `ConfigureAwait(false)` throughout.

## Tests

- **5 offline** (`StubHandler`, no network): the full tree walk, recursion into a subdirectory, a REST-hidden file surfacing, autoindex size parsing, and all three failure contracts.
- **1 live canary** — `[Category("ExternalService")]`/`[Category("Pride")]`, routed through `ExternalServiceTestHelper.RunAsync` so a PRIDE outage skips rather than fails. It asserts the FTP tree is **more complete than the REST manifest** for real PXD000001 (a comparison, not a hard-coded 13, so it survives re-curation) — which also catches EBI changing its autoindex layout, the one drift offline fixtures can't.

Full PRIDE suite (126 tests) green locally, live canary included.

## Note on HTML parsing

The FTP directory is a standard Apache autoindex served over HTTPS; there is no structured (JSON) endpoint for it. Parsing is isolated to two small, commented regex helpers and pinned by both a recorded-fixture offline test and the live canary above.