### PR TITLE
fix(flashlfq): bound each peak window to one charge state

### DIFF
--- a/mzLib/FlashLFQ/FlashLFQResults.cs
+++ b/mzLib/FlashLFQ/FlashLFQResults.cs
@@ -715,9 +715,10 @@ namespace FlashLFQ
 
         /// <summary>
         /// Writes one row per MS1 peak observed around each quantified chromatographic peak: every peak between the
-        /// chromatographic peak's first and last retention time, from mzExpansion below the lowest m/z observed for
-        /// that peak to mzExpansion above the highest. Peaks belonging to other species are included, so the output
-        /// shows the interference and co-elution surrounding each quantified precursor.
+        /// first and last retention time the peak was traced at a given charge state, from mzExpansion below the
+        /// lowest m/z observed at that charge state to mzExpansion above the highest. Peaks belonging to other
+        /// species are included, so the output shows the interference and co-elution surrounding each quantified
+        /// precursor. A peak traced at several charge states contributes one such window per charge state.
         ///
         /// This is not part of WriteResults because it re-reads each spectra file: FlashLfqEngine discards the raw
         /// data once quantification finishes, and holding the extracted peaks in memory instead would cost far more
@@ -770,15 +771,17 @@ namespace FlashLFQ
                     foreach (ChromatographicPeak peak in peaksInFile.OrderByDescending(p => p.Intensity))
                     {
                         peakId++;
-                        PeakWindow window = PeakWindow.Create(peak, dataFile, ms1ScanNumberMap, mzExpansion);
-                        if (window == null)
-                        {
-                            continue;
-                        }
 
-                        foreach (string row in window.ToTsvRows(peakId))
+                        // One window per charge state the peak was traced at. They share the peak's id and are told
+                        // apart by the Peak Charge column, because a peptide's m/z at one charge is unrelated to its
+                        // m/z at another and a single window bounding both would span the gap between them.
+                        foreach (PeakWindow window in PeakWindow.CreateForEachChargeState(peak, dataFile,
+                            ms1ScanNumberMap, mzExpansion))
                         {
-                            output.WriteLine(row);
+                            foreach (string row in window.ToTsvRows(peakId))
+                            {
+                                output.WriteLine(row);
+                            }
                         }
                     }
 

--- a/mzLib/FlashLFQ/PeakWindow.cs
+++ b/mzLib/FlashLFQ/PeakWindow.cs
@@ -9,11 +9,16 @@ using System.Text;
 namespace FlashLFQ
 {
     /// <summary>
-    /// A rectangular slice of the MS1 data surrounding a single ChromatographicPeak. The slice spans the scans the
-    /// peak was observed in, and runs from mzExpansion below the lowest m/z observed for the peak to mzExpansion
-    /// above the highest. Every MS1 peak in that region is retained, including peaks that belong to species other
-    /// than the quantified precursor, which is the point of the type: it captures the co-eluting and interfering
-    /// signal that quantification discards.
+    /// A rectangular slice of the MS1 data surrounding one charge state of a single ChromatographicPeak. The slice
+    /// spans the scans that charge state was observed in, and runs from mzExpansion below the lowest m/z observed
+    /// for it to mzExpansion above the highest. Every MS1 peak in that region is retained, including peaks that
+    /// belong to species other than the quantified precursor, which is the point of the type: it captures the
+    /// co-eluting and interfering signal that quantification discards.
+    ///
+    /// The window is per charge state rather than per peak because a ChromatographicPeak carries one isotopic
+    /// envelope per scan per charge state, and the m/z of a peptide at one charge is nowhere near its m/z at
+    /// another. Bounding all of them at once would produce a window hundreds of daltons wide spanning the gap
+    /// between the charge states, whose contents are the rest of the spectrum rather than the peak's neighbours.
     ///
     /// The peaks are read straight out of the spectra file rather than out of a PeakIndexingEngine. The index is
     /// organized m/z-major and scan-minor, so a contiguous m/z slice of a handful of consecutive scans costs one
@@ -24,6 +29,13 @@ namespace FlashLFQ
         public const double DefaultMzExpansion = 0.5;
 
         public ChromatographicPeak Peak { get; }
+
+        /// <summary>
+        /// The charge state whose isotopic envelopes bound this window. A peak traced at more than one charge state
+        /// produces one window per charge state, all of them describing the same peak.
+        /// </summary>
+        public int ChargeState { get; }
+
         public double MinMz { get; }
         public double MaxMz { get; }
         public double MinRetentionTime { get; }
@@ -41,10 +53,11 @@ namespace FlashLFQ
         /// </summary>
         public int PeakCount { get; }
 
-        private PeakWindow(ChromatographicPeak peak, double minMz, double maxMz, double apexRetentionTime,
-            PeakWindowScan[] scans, int peakCount)
+        private PeakWindow(ChromatographicPeak peak, int chargeState, double minMz, double maxMz,
+            double apexRetentionTime, PeakWindowScan[] scans, int peakCount)
         {
             Peak = peak;
+            ChargeState = chargeState;
             MinMz = minMz;
             MaxMz = maxMz;
             ApexRetentionTime = apexRetentionTime;
@@ -72,31 +85,61 @@ namespace FlashLFQ
         }
 
         /// <summary>
-        /// Extracts the window of MS1 data surrounding a chromatographic peak. Returns null for peaks that have no
-        /// isotopic envelopes, as those have no observed m/z or scan to build a window around.
+        /// Extracts one window per charge state the peak was traced at, in ascending charge order. Peaks with no
+        /// isotopic envelopes yield nothing, as those have no observed m/z or scan to build a window around.
+        /// </summary>
+        /// <param name="peak"> the quantified peak to build windows around </param>
+        /// <param name="dataFile"> the loaded spectra file the peak was quantified from </param>
+        /// <param name="ms1ScanNumberMap"> the map built by BuildMs1ScanNumberMap for that same file </param>
+        /// <param name="mzExpansion"> how far below the lowest and above the highest observed m/z each window extends </param>
+        public static IEnumerable<PeakWindow> CreateForEachChargeState(ChromatographicPeak peak, MsDataFile dataFile,
+            int[] ms1ScanNumberMap, double mzExpansion = DefaultMzExpansion)
+        {
+            if (peak == null || dataFile == null || ms1ScanNumberMap == null)
+                yield break;
+
+            foreach (int chargeState in peak.IsotopicEnvelopes.Select(e => e.ChargeState).Distinct().OrderBy(z => z))
+            {
+                PeakWindow window = Create(peak, dataFile, ms1ScanNumberMap, chargeState, mzExpansion);
+                if (window != null)
+                    yield return window;
+            }
+        }
+
+        /// <summary>
+        /// Extracts the window of MS1 data surrounding one charge state of a chromatographic peak. Returns null when
+        /// the peak was not traced at that charge state, as there is then no observed m/z or scan to build a window
+        /// around, and when the scans it was traced in fall outside the supplied map.
         /// </summary>
         /// <param name="peak"> the quantified peak to build a window around </param>
         /// <param name="dataFile"> the loaded spectra file the peak was quantified from </param>
         /// <param name="ms1ScanNumberMap"> the map built by BuildMs1ScanNumberMap for that same file </param>
+        /// <param name="chargeState"> the charge state whose isotopic envelopes bound the window </param>
         /// <param name="mzExpansion"> how far below the lowest and above the highest observed m/z the window extends </param>
         public static PeakWindow Create(ChromatographicPeak peak, MsDataFile dataFile, int[] ms1ScanNumberMap,
-            double mzExpansion = DefaultMzExpansion)
+            int chargeState, double mzExpansion = DefaultMzExpansion)
         {
-            if (peak == null || dataFile == null || ms1ScanNumberMap == null || !peak.IsotopicEnvelopes.Any())
+            if (peak == null || dataFile == null || ms1ScanNumberMap == null)
                 return null;
 
-            double minMz = peak.IsotopicEnvelopes.Min(e => e.IndexedPeak.M) - mzExpansion;
-            double maxMz = peak.IsotopicEnvelopes.Max(e => e.IndexedPeak.M) + mzExpansion;
+            // Only this charge state's envelopes bound the window. A peptide's m/z at one charge is unrelated to its
+            // m/z at another, so bounding every envelope at once would span the gap between the charge states.
+            List<IsotopicEnvelope> envelopes = peak.IsotopicEnvelopes.Where(e => e.ChargeState == chargeState).ToList();
+            if (envelopes.Count == 0)
+                return null;
 
-            int firstMs1Index = peak.IsotopicEnvelopes.Min(e => e.IndexedPeak.ZeroBasedScanIndex);
-            int lastMs1Index = peak.IsotopicEnvelopes.Max(e => e.IndexedPeak.ZeroBasedScanIndex);
+            double minMz = envelopes.Min(e => e.IndexedPeak.M) - mzExpansion;
+            double maxMz = envelopes.Max(e => e.IndexedPeak.M) + mzExpansion;
+
+            int firstMs1Index = envelopes.Min(e => e.IndexedPeak.ZeroBasedScanIndex);
+            int lastMs1Index = envelopes.Max(e => e.IndexedPeak.ZeroBasedScanIndex);
             if (firstMs1Index < 0 || lastMs1Index >= ms1ScanNumberMap.Length)
                 return null;
 
             // The m/z values FlashLFQ traced, grouped by the scan they were found in, so that the peaks it actually
             // used can be flagged as the window is written out.
             var peakfindingMzByScanNumber = new Dictionary<int, HashSet<float>>();
-            foreach (IsotopicEnvelope envelope in peak.IsotopicEnvelopes)
+            foreach (IsotopicEnvelope envelope in envelopes)
             {
                 int scanNumber = ms1ScanNumberMap[envelope.IndexedPeak.ZeroBasedScanIndex];
                 if (!peakfindingMzByScanNumber.TryGetValue(scanNumber, out HashSet<float> mzValues))
@@ -120,17 +163,16 @@ namespace FlashLFQ
                 peakCount += windowScan.Mz.Length;
             }
 
+            // The apex of this charge state, not of the peak as a whole: the peak's apex can belong to a different
+            // charge state, whose scan is not necessarily inside this window.
             double apexRetentionTime = double.NaN;
-            if (peak.Apex != null)
+            int apexMs1Index = envelopes.MaxBy(e => e.Intensity).IndexedPeak.ZeroBasedScanIndex;
+            if (apexMs1Index >= 0 && apexMs1Index < ms1ScanNumberMap.Length)
             {
-                int apexMs1Index = peak.Apex.IndexedPeak.ZeroBasedScanIndex;
-                if (apexMs1Index >= 0 && apexMs1Index < ms1ScanNumberMap.Length)
-                {
-                    apexRetentionTime = dataFile.GetOneBasedScan(ms1ScanNumberMap[apexMs1Index]).RetentionTime;
-                }
+                apexRetentionTime = dataFile.GetOneBasedScan(ms1ScanNumberMap[apexMs1Index]).RetentionTime;
             }
 
-            return new PeakWindow(peak, minMz, maxMz, apexRetentionTime, scans, peakCount);
+            return new PeakWindow(peak, chargeState, minMz, maxMz, apexRetentionTime, scans, peakCount);
         }
 
         public static string TabSeparatedHeader => string.Join("\t",
@@ -140,9 +182,9 @@ namespace FlashLFQ
             "Full Sequence",
             "Peak Detection Type",
             "Peak Charge",
-            "Peak RT Start",
-            "Peak RT Apex",
-            "Peak RT End",
+            "Window RT Start",
+            "Window RT Apex",
+            "Window RT End",
             "Window Min MZ",
             "Window Max MZ",
             "Scan Number",
@@ -155,7 +197,8 @@ namespace FlashLFQ
         /// One tab separated line per MS1 peak in the window. Rows are yielded rather than returned as a list so
         /// that a caller writing many windows never holds more than one window's worth of text at a time.
         /// </summary>
-        /// <param name="peakId"> an identifier distinguishing this window's peak from the file's other peaks </param>
+        /// <param name="peakId"> an identifier distinguishing this window's peak from the file's other peaks. All of
+        /// a peak's charge states share it, and are told apart by the Peak Charge column. </param>
         public IEnumerable<string> ToTsvRows(int peakId)
         {
             // Everything to the left of the scan columns is constant across the window, so it is built once.
@@ -165,7 +208,7 @@ namespace FlashLFQ
             peakColumns.Append(string.Join("|", Peak.Identifications.Select(p => p.BaseSequence).Distinct()) + "\t");
             peakColumns.Append(string.Join("|", Peak.Identifications.Select(p => p.ModifiedSequence).Distinct()) + "\t");
             peakColumns.Append(Peak.DetectionType.ToString() + "\t");
-            peakColumns.Append((Peak.Apex?.ChargeState ?? 0).ToString(CultureInfo.InvariantCulture) + "\t");
+            peakColumns.Append(ChargeState.ToString(CultureInfo.InvariantCulture) + "\t");
             peakColumns.Append(MinRetentionTime.ToString(CultureInfo.InvariantCulture) + "\t");
             peakColumns.Append(ApexRetentionTime.ToString(CultureInfo.InvariantCulture) + "\t");
             peakColumns.Append(MaxRetentionTime.ToString(CultureInfo.InvariantCulture) + "\t");
@@ -192,8 +235,8 @@ namespace FlashLFQ
 
         public override string ToString()
         {
-            return Peak.Identifications.First().ModifiedSequence + "; " + PeakCount + " peaks in " + Scans.Length
-                + " scans; " + MinMz.ToString("F2") + "-" + MaxMz.ToString("F2") + " m/z; "
+            return Peak.Identifications.First().ModifiedSequence + "; z=" + ChargeState + "; " + PeakCount
+                + " peaks in " + Scans.Length + " scans; " + MinMz.ToString("F2") + "-" + MaxMz.ToString("F2") + " m/z; "
                 + MinRetentionTime.ToString("F2") + "-" + MaxRetentionTime.ToString("F2") + " min";
         }
     }

--- a/mzLib/Test/FlashLFQ/TestPeakWindow.cs
+++ b/mzLib/Test/FlashLFQ/TestPeakWindow.cs
@@ -85,6 +85,17 @@ namespace Test.FlashLFQ
         private static ChromatographicPeak BuildPeak(SpectraFileInfo file, string sequence,
             params (double Mz, int ZeroBasedScanIndex, double RetentionTime)[] envelopePeaks)
         {
+            return BuildMultiChargePeak(file, sequence,
+                envelopePeaks.Select(p => (p.Mz, 2, p.ZeroBasedScanIndex, p.RetentionTime)).ToArray());
+        }
+
+        /// <summary>
+        /// As BuildPeak, but each envelope carries its own charge state, so a test can build the peak FlashLFQ
+        /// produces for a peptide traced at more than one charge.
+        /// </summary>
+        private static ChromatographicPeak BuildMultiChargePeak(SpectraFileInfo file, string sequence,
+            params (double Mz, int ChargeState, int ZeroBasedScanIndex, double RetentionTime)[] envelopePeaks)
+        {
             var pg = new ProteinGroup("MyProtein", "gene", "org");
             var id = new Identification(file, sequence, sequence, 1350.65681, 1.0, 2, new List<ProteinGroup> { pg });
             var peak = new ChromatographicPeak(id, file);
@@ -93,7 +104,7 @@ namespace Test.FlashLFQ
             {
                 peak.IsotopicEnvelopes.Add(new IsotopicEnvelope(
                     new IndexedMassSpectralPeak(envelopePeak.Mz, 1e6, envelopePeak.ZeroBasedScanIndex,
-                        envelopePeak.RetentionTime), 2, 1e6, 1.0));
+                        envelopePeak.RetentionTime), envelopePeak.ChargeState, 1e6, 1.0));
             }
             peak.CalculateIntensityForThisFeature(false);
             return peak;
@@ -216,15 +227,18 @@ namespace Test.FlashLFQ
             dataFile.LoadAllStaticData();
             int[] map = PeakWindow.BuildMs1ScanNumberMap(dataFile);
 
-            PeakWindow window = PeakWindow.Create(peak, dataFile, map, mzExpansion: 2.0);
+            int chargeState = peak.Apex.ChargeState;
+            var envelopes = peak.IsotopicEnvelopes.Where(e => e.ChargeState == chargeState).ToList();
+            PeakWindow window = PeakWindow.Create(peak, dataFile, map, chargeState, mzExpansion: 2.0);
+            Assert.AreEqual(chargeState, window.ChargeState);
 
-            // the window is bounded by the peak's observed m/z values, expanded by mzExpansion on either side
-            Assert.AreEqual(peak.IsotopicEnvelopes.Min(e => e.IndexedPeak.M) - 2.0, window.MinMz, 1e-6);
-            Assert.AreEqual(peak.IsotopicEnvelopes.Max(e => e.IndexedPeak.M) + 2.0, window.MaxMz, 1e-6);
+            // the window is bounded by the charge state's observed m/z values, expanded by mzExpansion on either side
+            Assert.AreEqual(envelopes.Min(e => e.IndexedPeak.M) - 2.0, window.MinMz, 1e-6);
+            Assert.AreEqual(envelopes.Max(e => e.IndexedPeak.M) + 2.0, window.MaxMz, 1e-6);
 
-            // and it covers exactly the scans the peak was observed in
-            int firstMs1Index = peak.IsotopicEnvelopes.Min(e => e.IndexedPeak.ZeroBasedScanIndex);
-            int lastMs1Index = peak.IsotopicEnvelopes.Max(e => e.IndexedPeak.ZeroBasedScanIndex);
+            // and it covers exactly the scans that charge state was observed in
+            int firstMs1Index = envelopes.Min(e => e.IndexedPeak.ZeroBasedScanIndex);
+            int lastMs1Index = envelopes.Max(e => e.IndexedPeak.ZeroBasedScanIndex);
             Assert.AreEqual(lastMs1Index - firstMs1Index + 1, window.Scans.Length);
             Assert.AreEqual(map[firstMs1Index], window.Scans.First().OneBasedScanNumber);
             Assert.AreEqual(map[lastMs1Index], window.Scans.Last().OneBasedScanNumber);
@@ -232,7 +246,8 @@ namespace Test.FlashLFQ
             // retention times are the scans' own, taken from the file
             Assert.AreEqual(dataFile.GetOneBasedScan(map[firstMs1Index]).RetentionTime, window.MinRetentionTime);
             Assert.AreEqual(dataFile.GetOneBasedScan(map[lastMs1Index]).RetentionTime, window.MaxRetentionTime);
-            Assert.AreEqual(dataFile.GetOneBasedScan(map[peak.Apex.IndexedPeak.ZeroBasedScanIndex]).RetentionTime,
+            Assert.AreEqual(dataFile.GetOneBasedScan(
+                    map[envelopes.MaxBy(e => e.Intensity).IndexedPeak.ZeroBasedScanIndex]).RetentionTime,
                 window.ApexRetentionTime);
 
             // each scan's slice is the m/z window of that scan's spectrum, parallel arrays and all
@@ -251,28 +266,121 @@ namespace Test.FlashLFQ
                 CollectionAssert.AreEqual(expected, scan.Mz);
             }
 
-            // every peak FlashLFQ used to trace the feature is flagged, and nothing else is
-            Assert.AreEqual(peak.IsotopicEnvelopes.Select(e => e.IndexedPeak).Distinct().Count(),
+            // every peak FlashLFQ used to trace this charge state is flagged, and nothing else is
+            Assert.AreEqual(envelopes.Select(e => e.IndexedPeak).Distinct().Count(),
                 window.Scans.Sum(s => s.IsPeakfindingPeak.Count(f => f)));
 
             // and the window holds far more than those, which is the whole point of the output
             Assert.IsTrue(window.PeakCount > window.Scans.Sum(s => s.IsPeakfindingPeak.Count(f => f)));
 
             // a wider window is a superset of a narrower one
-            PeakWindow narrowWindow = PeakWindow.Create(peak, dataFile, map, mzExpansion: 0.5);
+            PeakWindow narrowWindow = PeakWindow.Create(peak, dataFile, map, chargeState, mzExpansion: 0.5);
             Assert.IsTrue(narrowWindow.PeakCount <= window.PeakCount);
             Assert.AreEqual(window.Scans.Length, narrowWindow.Scans.Length);
             var wideMzs = window.Scans.SelectMany(s => s.Mz).ToHashSet();
             Assert.IsTrue(narrowWindow.Scans.SelectMany(s => s.Mz).All(mz => wideMzs.Contains(mz)));
 
-            // peaks with no isotopic envelopes have no window, and neither do missing arguments
+            // peaks with no isotopic envelopes have no window, and neither do missing arguments or a charge state
+            // the peak was never traced at
             var pg = new ProteinGroup("MyProtein", "gene", "org");
             var emptyPeak = new ChromatographicPeak(new Identification(mzml, "PEPTIDE", "PEPTIDE", 799.36, 94.1, 2,
                 new List<ProteinGroup> { pg }), mzml);
-            Assert.IsNull(PeakWindow.Create(emptyPeak, dataFile, map));
-            Assert.IsNull(PeakWindow.Create(null, dataFile, map));
-            Assert.IsNull(PeakWindow.Create(peak, null, map));
-            Assert.IsNull(PeakWindow.Create(peak, dataFile, null));
+            Assert.IsNull(PeakWindow.Create(emptyPeak, dataFile, map, chargeState));
+            Assert.IsNull(PeakWindow.Create(null, dataFile, map, chargeState));
+            Assert.IsNull(PeakWindow.Create(peak, null, map, chargeState));
+            Assert.IsNull(PeakWindow.Create(peak, dataFile, null, chargeState));
+            Assert.IsNull(PeakWindow.Create(peak, dataFile, map, chargeState: 97));
+
+            // and the same holds for the per-charge-state enumeration
+            Assert.IsFalse(PeakWindow.CreateForEachChargeState(emptyPeak, dataFile, map).Any());
+            Assert.IsFalse(PeakWindow.CreateForEachChargeState(null, dataFile, map).Any());
+            Assert.IsFalse(PeakWindow.CreateForEachChargeState(peak, null, map).Any());
+            Assert.IsFalse(PeakWindow.CreateForEachChargeState(peak, dataFile, null).Any());
+        }
+
+        /// <summary>
+        /// A ChromatographicPeak holds one isotopic envelope per scan per charge state, and a peptide's m/z at one
+        /// charge is nowhere near its m/z at another. Bounding every envelope at once would produce a single window
+        /// spanning the gap between the charge states - hundreds of daltons of unrelated spectrum - so each charge
+        /// state gets its own window instead.
+        /// </summary>
+        [Test]
+        public static void TestPeakWindowIsBoundedPerChargeState()
+        {
+            // one peak every 0.5 m/z from 400 to 1400, so a window's width is directly readable from its peak count
+            var mzs = Enumerable.Range(0, 2001).Select(i => 400.0 + i * 0.5).ToArray();
+            SpectraFileInfo file = WriteSyntheticMzml("peakWindowMultiCharge.mzML", new[] { mzs, mzs, mzs });
+
+            MsDataFile dataFile = LoadDataFile(file);
+            int[] map = PeakWindow.BuildMs1ScanNumberMap(dataFile);
+
+            // EGFQVADGPLYR, 1350.66 Da, traced at z=2 (676.3 m/z) and z=3 (451.2 m/z) - both entirely ordinary
+            ChromatographicPeak peak = BuildMultiChargePeak(file, "EGFQVADGPLYR",
+                (676.3, 2, 0, 1.0), (451.2, 3, 0, 1.0),
+                (676.3, 2, 1, 1.1), (451.2, 3, 1, 1.1),
+                (676.3, 2, 2, 1.2), (451.2, 3, 2, 1.2));
+            Assert.AreEqual(2, peak.NumChargeStatesObserved);
+
+            var windows = PeakWindow.CreateForEachChargeState(peak, dataFile, map).ToList();
+
+            // one window per charge state, in ascending charge order
+            Assert.AreEqual(2, windows.Count);
+            CollectionAssert.AreEqual(new[] { 2, 3 }, windows.Select(w => w.ChargeState).ToArray());
+
+            // each window is mzExpansion wide on either side of its own charge state's m/z, and nowhere near the other
+            // indexed peaks narrow m/z to float, so the bounds carry float precision - hence the loose deltas
+            const double floatDelta = 1e-3;
+            foreach (PeakWindow chargeWindow in windows)
+            {
+                Assert.AreEqual(2 * PeakWindow.DefaultMzExpansion, chargeWindow.MaxMz - chargeWindow.MinMz, floatDelta);
+                Assert.AreEqual(3, chargeWindow.Scans.Length);
+
+                // 1 m/z of a spectrum with a peak every 0.5 m/z: 2 peaks per scan, over 3 scans
+                Assert.AreEqual(6, chargeWindow.PeakCount);
+                Assert.AreEqual(6, chargeWindow.ToTsvRows(1).Count());
+            }
+
+            Assert.AreEqual(675.8, windows[0].MinMz, floatDelta);
+            Assert.AreEqual(676.8, windows[0].MaxMz, floatDelta);
+            Assert.AreEqual(450.7, windows[1].MinMz, floatDelta);
+            Assert.AreEqual(451.7, windows[1].MaxMz, floatDelta);
+
+            // the regression this guards: a single window bounding both charge states would have run from 450.7 to
+            // 676.8 m/z - 226 Da - and swept in the whole spectrum between them
+            Assert.IsTrue(windows.Sum(w => w.PeakCount) < 50);
+        }
+
+        /// <summary>
+        /// Each charge state's window is centred on that charge state's own apex scan, not on the peak's overall
+        /// apex, which can belong to a different charge state and lie outside the window entirely.
+        /// </summary>
+        [Test]
+        public static void TestPeakWindowApexIsPerChargeState()
+        {
+            var mzs = new[] { 499.9, 500.0, 500.1, 599.9, 600.0, 600.1 };
+            SpectraFileInfo file = WriteSyntheticMzml("peakWindowPerChargeApex.mzML", new[] { mzs, mzs, mzs });
+
+            MsDataFile dataFile = LoadDataFile(file);
+            int[] map = PeakWindow.BuildMs1ScanNumberMap(dataFile);
+
+            var pg = new ProteinGroup("MyProtein", "gene", "org");
+            var id = new Identification(file, "PEPTIDE", "PEPTIDE", 1350.65681, 1.0, 2, new List<ProteinGroup> { pg });
+            var peak = new ChromatographicPeak(id, file);
+
+            // z=2 is most intense in the first scan; z=3 is most intense in the last one
+            peak.IsotopicEnvelopes.Add(new IsotopicEnvelope(new IndexedMassSpectralPeak(500.0, 9e6, 0, 1.0), 2, 9e6, 1.0));
+            peak.IsotopicEnvelopes.Add(new IsotopicEnvelope(new IndexedMassSpectralPeak(500.0, 1e6, 2, 1.2), 2, 1e6, 1.0));
+            peak.IsotopicEnvelopes.Add(new IsotopicEnvelope(new IndexedMassSpectralPeak(600.0, 1e5, 0, 1.0), 3, 1e5, 1.0));
+            peak.IsotopicEnvelopes.Add(new IsotopicEnvelope(new IndexedMassSpectralPeak(600.0, 5e6, 2, 1.2), 3, 5e6, 1.0));
+            peak.CalculateIntensityForThisFeature(false);
+
+            var windows = PeakWindow.CreateForEachChargeState(peak, dataFile, map).ToList();
+            Assert.AreEqual(2, windows.Count);
+
+            // the peak's own apex is the z=2 envelope in scan 1, but the z=3 window apexes in scan 3
+            Assert.AreEqual(2, peak.Apex.ChargeState);
+            Assert.AreEqual(dataFile.GetOneBasedScan(map[0]).RetentionTime, windows[0].ApexRetentionTime, 1e-6);
+            Assert.AreEqual(dataFile.GetOneBasedScan(map[2]).RetentionTime, windows[1].ApexRetentionTime, 1e-6);
         }
 
         /// <summary>
@@ -289,12 +397,14 @@ namespace Test.FlashLFQ
             MsDataFile dataFile = MsDataFileReader.GetDataFile(SlicedMzmlPath);
             dataFile.LoadAllStaticData();
             int[] map = PeakWindow.BuildMs1ScanNumberMap(dataFile);
-            PeakWindow window = PeakWindow.Create(peak, dataFile, map, mzExpansion: 0.5);
+            int chargeState = peak.Apex.ChargeState;
+            var envelopes = peak.IsotopicEnvelopes.Where(e => e.ChargeState == chargeState).ToList();
+            PeakWindow window = PeakWindow.Create(peak, dataFile, map, chargeState, mzExpansion: 0.5);
 
             PeakIndexingEngine engine = PeakIndexingEngine.InitializeIndexingEngine(mzml);
             var indexedPeaks = engine.GetPeaksInRange(window.MinMz, window.MaxMz,
-                peak.IsotopicEnvelopes.Min(e => e.IndexedPeak.ZeroBasedScanIndex),
-                peak.IsotopicEnvelopes.Max(e => e.IndexedPeak.ZeroBasedScanIndex));
+                envelopes.Min(e => e.IndexedPeak.ZeroBasedScanIndex),
+                envelopes.Max(e => e.IndexedPeak.ZeroBasedScanIndex));
 
             const double edgeMargin = 1e-3;
             var fromFile = window.Scans
@@ -336,7 +446,7 @@ namespace Test.FlashLFQ
 
             // the peak is traced through the first and last scan, so the window spans all four
             ChromatographicPeak peak = BuildPeak(file, "PEPTIDE", (500.0, 0, 1.0), (500.0, 3, 1.3));
-            PeakWindow window = PeakWindow.Create(peak, dataFile, map);
+            PeakWindow window = PeakWindow.CreateForEachChargeState(peak, dataFile, map).Single();
 
             Assert.AreEqual(499.5, window.MinMz, 1e-6);
             Assert.AreEqual(500.5, window.MaxMz, 1e-6);
@@ -375,7 +485,8 @@ namespace Test.FlashLFQ
 
             // an envelope in a scan the file does not have cannot be translated to a scan number
             ChromatographicPeak beyondEnd = BuildPeak(file, "PEPTIDE", (500.0, 0, 1.0), (500.0, 99, 1.3));
-            Assert.IsNull(PeakWindow.Create(beyondEnd, dataFile, map));
+            Assert.IsNull(PeakWindow.Create(beyondEnd, dataFile, map, chargeState: 2));
+            Assert.IsFalse(PeakWindow.CreateForEachChargeState(beyondEnd, dataFile, map).Any());
         }
 
         [Test]
@@ -388,11 +499,13 @@ namespace Test.FlashLFQ
             });
 
             MsDataFile dataFile = LoadDataFile(file);
-            PeakWindow window = PeakWindow.Create(BuildPeak(file, "PEPTIDE", (500.0, 0, 1.0), (500.0, 1, 1.1)),
-                dataFile, PeakWindow.BuildMs1ScanNumberMap(dataFile));
+            PeakWindow window = PeakWindow.CreateForEachChargeState(
+                BuildPeak(file, "PEPTIDE", (500.0, 0, 1.0), (500.0, 1, 1.1)),
+                dataFile, PeakWindow.BuildMs1ScanNumberMap(dataFile)).Single();
 
             string description = window.ToString();
             StringAssert.Contains("PEPTIDE", description);
+            StringAssert.Contains("z=2", description);
             StringAssert.Contains("6 peaks in 2 scans", description);
             StringAssert.Contains("m/z", description);
             StringAssert.Contains("min", description);
@@ -423,10 +536,11 @@ namespace Test.FlashLFQ
             int scanNumberColumn = Array.IndexOf(headerColumns, "Scan Number");
             int minMzColumn = Array.IndexOf(headerColumns, "Window Min MZ");
             int maxMzColumn = Array.IndexOf(headerColumns, "Window Max MZ");
-            int rtStartColumn = Array.IndexOf(headerColumns, "Peak RT Start");
-            int rtEndColumn = Array.IndexOf(headerColumns, "Peak RT End");
+            int rtStartColumn = Array.IndexOf(headerColumns, "Window RT Start");
+            int rtEndColumn = Array.IndexOf(headerColumns, "Window RT End");
             int peakfindingColumn = Array.IndexOf(headerColumns, "Is Peakfinding Peak");
             int fullSequenceColumn = Array.IndexOf(headerColumns, "Full Sequence");
+            int chargeColumn = Array.IndexOf(headerColumns, "Peak Charge");
 
             MsDataFile dataFile = MsDataFileReader.GetDataFile(SlicedMzmlPath);
             dataFile.LoadAllStaticData();
@@ -452,6 +566,10 @@ namespace Test.FlashLFQ
                 Assert.AreEqual(1, sourceScan.MsnOrder);
                 Assert.AreEqual(sourceScan.RetentionTime, rt);
 
+                // every row names the charge state of the window it came from, not the peak's apex charge
+                int rowCharge = int.Parse(cells[chargeColumn], CultureInfo.InvariantCulture);
+                Assert.IsTrue(peak.IsotopicEnvelopes.Any(e => e.ChargeState == rowCharge));
+
                 if (bool.Parse(cells[peakfindingColumn]))
                 {
                     peakfindingRows++;
@@ -461,6 +579,12 @@ namespace Test.FlashLFQ
             // the rows FlashLFQ actually quantified are flagged, and they are a strict subset of what was written
             Assert.AreEqual(peak.IsotopicEnvelopes.Select(e => e.IndexedPeak).Distinct().Count(), peakfindingRows);
             Assert.IsTrue(lines.Length - 1 > peakfindingRows);
+
+            // every charge state the peak was traced at contributed rows
+            CollectionAssert.AreEquivalent(
+                peak.IsotopicEnvelopes.Select(e => e.ChargeState).Distinct().OrderBy(z => z).ToArray(),
+                lines.Skip(1).Select(l => int.Parse(l.Split('\t')[chargeColumn], CultureInfo.InvariantCulture))
+                    .Distinct().OrderBy(z => z).ToArray());
 
             File.Delete(outputPath);
         }


### PR DESCRIPTION
@Alexander-Sol — this targets `PeakEnvelopeOutput`, so it lands inside #1122 rather than alongside it. It's the one blocking item from my review there; the other four findings are design calls I've left to you.

### The problem

`ChromatographicPeak.IsotopicEnvelopes` holds one envelope per scan **per charge state** — that is what `NumChargeStatesObserved` counts. `PeakWindow.Create` took a single `Min`/`Max` of `IndexedPeak.M` across all of them, so a peptide traced at more than one charge got one window spanning the *gap between* the charge states.

Measured on `PeakEnvelopeOutput` before this change, with EGFQVADGPLYR (1350.66 Da) at z=2 (676.3 m/z) and z=3 (451.2 m/z), over a synthetic MS1 with one peak every 0.5 m/z:

```
NumChargeStatesObserved = 2
Window    = 450.700 - 676.800 m/z   (width 226.1 Da)
PeakCount = 1356 over 3 scans       (452 peaks/scan)
TSV rows for this ONE peak = 1356

[same peptide, single charge] width 1.0 Da, PeakCount = 6, rows = 6
```

226x the rows, and essentially none of that 226 Da is co-elution around the precursor — it's the rest of the spectrum. On real Orbitrap MS1 data (10-50k peaks over 350-1500 m/z) the output is effectively unbounded. I suspect the 200 Da window you benchmarked in the PR description is exactly this rather than a pathological case.

### The change

- `PeakWindow.Create` now takes the `chargeState` whose envelopes bound the window, and only those envelopes set `MinMz`/`MaxMz`, the scan span, and the peakfinding flags.
- `PeakWindow.CreateForEachChargeState` yields one window per traced charge state, ascending.
- `PeakWindow.ChargeState` is exposed, and the `Peak Charge` column now carries the **window's** charge state rather than `Apex?.ChargeState ?? 0`.
- `WritePeakWindows` writes every charge state of a peak under that peak's single `peakId`, distinguished by `Peak Charge`. The correspondence with QuantifiedPeaks that the comment there promises is unchanged.
- `ApexRetentionTime` is now the apex of the window's own charge state. The peak's overall apex can belong to a different charge state whose scan lies outside the window entirely, which would have put an out-of-range RT in the `RT Apex` column.
- `Peak RT Start` / `Peak RT Apex` / `Peak RT End` renamed to `Window RT *`, since they describe the window's scan span and that span is now per charge state.

### Tests

Your 13 tests still pass, updated for the new signature. Two added:

- `TestPeakWindowIsBoundedPerChargeState` — the regression above. Builds the two-charge peak over a spectrum with a peak every 0.5 m/z, asserts two windows in ascending charge order, each exactly `2 * mzExpansion` wide and centred on its own m/z, and that the total peak count stays under 50 where the old bounding box swept in ~1356.
- `TestPeakWindowApexIsPerChargeState` — z=2 apexes in the first scan and z=3 in the last; asserts each window reports its own apex rather than the peak's.

`TestWritePeakWindows` additionally asserts every row's `Peak Charge` is a charge the peak was actually traced at, and that every traced charge state contributed rows.

Also added `BuildMultiChargePeak`, so a test can build the peak FlashLFQ actually produces for a multiply-charged peptide; `BuildPeak` now delegates to it and is unchanged for callers.

### Verification

- Solution builds clean, `x64|Debug`, 0 errors.
- All 15 tests in `TestPeakWindow` pass.
- Patch coverage over the whole of #1122 plus this change, Coverlet/Release against `upstream/master`: **98.99%** (196/198 changed executable lines), target 90. No file below the bar.

Take it, adapt it, or close it — whichever is least friction for you.
