### PR TITLE
Consider all in-tolerance peaks when matching isotopes, not only the nearest

### DIFF
--- a/mzLib/MassSpectrometry/Deconvolution/Algorithms/ClassicDeconvolutionAlgorithm.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Algorithms/ClassicDeconvolutionAlgorithm.cs
@@ -188,26 +188,40 @@ namespace MassSpectrometry
             for (int indexToLookAt = 1; indexToLookAt < theoreticalIntensities.Length; indexToLookAt++) //cycle through all theoretical peaks in this envelope from most intense to least intense
             {
                 double theorMassThatTryingToFind = theoreticalMasses[indexToLookAt] + differenceBetweenTheorAndActualMass; //get the expected mass of the next most intense peak
-                int closestPeakToTheorMass = spectrum.GetClosestPeakIndex(theorMassThatTryingToFind.ToMz(chargeState)); //find the experimental peak for that mass
-                double closestPeakmz = spectrum.XArray[closestPeakToTheorMass];
-                double closestPeakIntensity = spectrum.YArray[closestPeakToTheorMass];
-                double closestPeakMass = closestPeakmz.ToMass(chargeState);
-                //if the peak is within the deconvolution tolerance, has the correct intensity, and hasn't already been observed
-                if (Math.Abs(closestPeakMass - theorMassThatTryingToFind) / theorMassThatTryingToFind * 1e6 <= deconvolutionTolerancePpm
-                    && Peak2satisfiesRatio(theoreticalIntensities[0], theoreticalIntensities[indexToLookAt], candidateForMostIntensePeakIntensity, closestPeakIntensity, intensityRatioLimit)
-                    && !listOfObservedPeaks.Contains((closestPeakmz, closestPeakIntensity)))
-                {
-                    //Found a match to an isotope peak for this charge state!
-                    listOfObservedPeaks.Add((closestPeakmz, closestPeakIntensity)); //add to observed list
-                    totalIntensity += closestPeakIntensity; //add intensity
-                    listOfRatios.Add(theoreticalIntensities[indexToLookAt] / closestPeakIntensity); //add ratio
-                    double monoisotopicMassFromThisPeak = monoisotopicMass + closestPeakMass - theorMassThatTryingToFind;
-                    monoisotopicMassPredictions.Add(monoisotopicMassFromThisPeak);
-                }
-                else
+                int matchedPeakIndex = spectrum.GetClosestPeakIndex(theorMassThatTryingToFind.ToMz(chargeState)); //find the experimental peak for that mass
+                double matchedPeakMz = spectrum.XArray[matchedPeakIndex];
+                double matchedPeakIntensity = spectrum.YArray[matchedPeakIndex];
+                double matchedPeakMass = matchedPeakMz.ToMass(chargeState);
+
+                //the nearest peak is out of tolerance, and it bounds every other peak's distance from the sought mass
+                if (Math.Abs(matchedPeakMass - theorMassThatTryingToFind) / theorMassThatTryingToFind * 1e6 > deconvolutionTolerancePpm)
                 {
                     break;
                 }
+
+                //the nearest peak is unusable, but issue #245: a usable isotope may sit just behind it, still in tolerance
+                if (!Peak2satisfiesRatio(theoreticalIntensities[0], theoreticalIntensities[indexToLookAt], candidateForMostIntensePeakIntensity, matchedPeakIntensity, intensityRatioLimit)
+                    || listOfObservedPeaks.Contains((matchedPeakMz, matchedPeakIntensity)))
+                {
+                    matchedPeakIndex = FindUsablePeakNearTheorMass(theorMassThatTryingToFind, chargeState, deconvolutionTolerancePpm,
+                        theoreticalIntensities[0], theoreticalIntensities[indexToLookAt], candidateForMostIntensePeakIntensity,
+                        intensityRatioLimit, listOfObservedPeaks);
+                    if (matchedPeakIndex < 0)
+                    {
+                        break;
+                    }
+
+                    matchedPeakMz = spectrum.XArray[matchedPeakIndex];
+                    matchedPeakIntensity = spectrum.YArray[matchedPeakIndex];
+                    matchedPeakMass = matchedPeakMz.ToMass(chargeState);
+                }
+
+                //Found a match to an isotope peak for this charge state!
+                listOfObservedPeaks.Add((matchedPeakMz, matchedPeakIntensity)); //add to observed list
+                totalIntensity += matchedPeakIntensity; //add intensity
+                listOfRatios.Add(theoreticalIntensities[indexToLookAt] / matchedPeakIntensity); //add ratio
+                double monoisotopicMassFromThisPeak = monoisotopicMass + matchedPeakMass - theorMassThatTryingToFind;
+                monoisotopicMassPredictions.Add(monoisotopicMassFromThisPeak);
             }
 
             return new IsotopicEnvelope(listOfObservedPeaks, monoisotopicMass, chargeState, totalIntensity, listOfRatios.StandardDeviation());
@@ -292,6 +306,62 @@ namespace MassSpectrometry
             return (
                 spectrum.XArray.GetClosestIndex(minX, ArraySearchOption.Next),
                 spectrum.XArray.GetClosestIndex(maxX, ArraySearchOption.Previous));
+        }
+
+        /// <summary>
+        /// Nearest peak to <paramref name="theorMass"/> that is in tolerance, matches the predicted intensity and is
+        /// unclaimed, or -1 if there is none. Called only when the closest peak itself is unusable (issue #245).
+        /// </summary>
+        private int FindUsablePeakNearTheorMass(double theorMass, int chargeState, double deconvolutionTolerancePpm,
+            double peak1TheorIntensity, double peak2TheorIntensity, double peak1Intensity,
+            double intensityRatioLimit, List<(double, double)> alreadyObservedPeaks)
+        {
+            int nearestIndex = spectrum.GetClosestPeakIndex(theorMass.ToMz(chargeState));
+
+            //bound the window in the mass domain, since the acceptance test is a ppm check on neutral mass; converting
+            //the other way would clip it by the proton offset
+            double windowRadius = theorMass * deconvolutionTolerancePpm / 1e6;
+            double minMz = (theorMass - windowRadius).ToMz(chargeState);
+            double maxMz = (theorMass + windowRadius).ToMz(chargeState);
+
+            int startIndex = nearestIndex;
+            while (startIndex > 0 && spectrum.XArray[startIndex - 1] >= minMz)
+            {
+                startIndex--;
+            }
+
+            int endIndex = nearestIndex;
+            while (endIndex < spectrum.XArray.Length - 1 && spectrum.XArray[endIndex + 1] <= maxMz)
+            {
+                endIndex++;
+            }
+
+            int bestIndex = -1;
+            double bestMassError = double.PositiveInfinity;
+
+            for (int index = startIndex; index <= endIndex; index++)
+            {
+                double candidateMz = spectrum.XArray[index];
+                double candidateIntensity = spectrum.YArray[index];
+                double massError = Math.Abs(candidateMz.ToMass(chargeState) - theorMass);
+
+                //rank survivors by mass error: the ratio test has already screened out implausible abundances
+                if (massError / theorMass * 1e6 > deconvolutionTolerancePpm
+                    || candidateIntensity <= 0
+                    || !Peak2satisfiesRatio(peak1TheorIntensity, peak2TheorIntensity, peak1Intensity, candidateIntensity, intensityRatioLimit)
+                    || alreadyObservedPeaks.Contains((candidateMz, candidateIntensity)))
+                {
+                    continue;
+                }
+
+                if (massError < bestMassError)
+                {
+                    bestIndex = index;
+                    bestMassError = massError;
+                }
+            }
+
+            return bestIndex;
         }
 
         private bool Peak2satisfiesRatio(double peak1theorIntensity, double peak2theorIntensity, double peak1intensity, double peak2intensity, double intensityRatio)

--- a/mzLib/Test/Deconvolution/TestDeconvolutionPeakChoiceWithinTolerance.cs
+++ b/mzLib/Test/Deconvolution/TestDeconvolutionPeakChoiceWithinTolerance.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Chemistry;
+using MassSpectrometry;
+using MzLibUtil;
+using NUnit.Framework;
+
+namespace Test
+{
+    /// <summary>
+    /// Issue #245: the isotope walk only ever examined the single nearest peak to the sought isotope, so an
+    /// interferer nearer to the theoretical m/z masked a usable isotope sitting just behind it. Because the walk
+    /// breaks on the first miss, that did not merely swap one isotope - it truncated the envelope and shifted the
+    /// reported monoisotopic mass by a whole isotope.
+    /// </summary>
+    public class TestDeconvolutionPeakChoiceWithinTolerance
+    {
+        private const int Charge = 2;
+        private const double TolerancePpm = 20;
+        private const double IntensityRatioLimit = 3;
+        private static readonly MzRange WholeSpectrum = new MzRange(0, 5000);
+
+        /// <summary>
+        /// An exact averagine envelope for <paramref name="mostIntenseMass"/>, with the second-most-intense
+        /// isotope displaced by <paramref name="realPeakPpmError"/> so that an interferer can be placed nearer
+        /// to the theoretical m/z than the real peak is.
+        /// </summary>
+        private static (MzSpectrum Spectrum, double TargetMz, double ExpectedIntensity) Build(
+            double mostIntenseMass, double realPeakPpmError, double interfererPpmError, double interfererFoldIntensity)
+        {
+            var averagine = new Averagine();
+            int massIndex = averagine.GetMostIntenseMassIndex(mostIntenseMass);
+            double[] theorMasses = averagine.GetAllTheoreticalMasses(massIndex);
+            double[] theorIntensities = averagine.GetAllTheoreticalIntensities(massIndex);
+            double shift = mostIntenseMass - theorMasses[0];
+
+            double targetMz = (theorMasses[1] + shift).ToMz(Charge);
+            double expectedIntensity = 1e6 * theorIntensities[1] / theorIntensities[0];
+
+            var peaks = new List<(double Mz, double Intensity)>();
+            for (int i = 0; i < Math.Min(6, theorMasses.Length); i++)
+            {
+                double mz = i == 1
+                    ? targetMz * (1 + realPeakPpmError / 1e6)
+                    : (theorMasses[i] + shift).ToMz(Charge);
+                peaks.Add((mz, 1e6 * theorIntensities[i] / theorIntensities[0]));
+            }
+
+            if (interfererFoldIntensity > 0)
+            {
+                peaks.Add((targetMz * (1 + interfererPpmError / 1e6), expectedIntensity * interfererFoldIntensity));
+            }
+
+            var ordered = peaks.OrderBy(p => p.Mz).ToList();
+            return (new MzSpectrum(ordered.Select(p => p.Mz).ToArray(), ordered.Select(p => p.Intensity).ToArray(), false),
+                targetMz, expectedIntensity);
+        }
+
+        private static string[] Describe(IEnumerable<IsotopicEnvelope> envelopes) => envelopes
+            .Select(e => $"z={e.Charge} mono={e.MonoisotopicMass:F4} peaks={e.Peaks.Count}")
+            .OrderBy(s => s)
+            .ToArray();
+
+        /// <summary>
+        /// An interferer that is nearer to the theoretical m/z but has the wrong intensity must not displace
+        /// the real isotope, whether it is far too intense or far too weak.
+        /// </summary>
+        [TestCase(20.0)]
+        [TestCase(1.0 / 20.0)]
+        public void AnInterfererNearerToTheoreticalDoesNotDisplaceTheRealIsotope(double interfererFoldIntensity)
+        {
+            var parameters = new ClassicDeconvolutionParameters(1, 6, TolerancePpm, IntensityRatioLimit);
+
+            var clean = Build(1600.0, realPeakPpmError: 12, interfererPpmError: 0, interfererFoldIntensity: 0);
+            var withInterferer = Build(1600.0, realPeakPpmError: 12, interfererPpmError: -4, interfererFoldIntensity);
+
+            string[] expected = Describe(Deconvoluter.Deconvolute(clean.Spectrum, parameters, WholeSpectrum));
+            string[] actual = Describe(Deconvoluter.Deconvolute(withInterferer.Spectrum, parameters, WholeSpectrum));
+
+            Assert.That(expected, Is.Not.Empty, "the clean envelope must deconvolute, or the test proves nothing");
+            Assert.That(expected.Single(), Does.Contain("mono=1600.0000").And.Contain("peaks=6"));
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// The surviving peak feeds the monoisotopic mass estimate, so the envelope must contain the real
+        /// isotope's m/z and not the interferer's.
+        /// </summary>
+        [Test]
+        public void TheEnvelopeContainsTheRealIsotopeNotTheNearerInterferer()
+        {
+            var parameters = new ClassicDeconvolutionParameters(1, 6, TolerancePpm, IntensityRatioLimit);
+            var built = Build(1600.0, realPeakPpmError: 12, interfererPpmError: -4, interfererFoldIntensity: 20);
+
+            double realMz = built.TargetMz * (1 + 12e-6);
+            double interfererMz = built.TargetMz * (1 - 4e-6);
+
+            var envelope = Deconvoluter.Deconvolute(built.Spectrum, parameters, WholeSpectrum)
+                .OrderByDescending(e => e.Peaks.Count)
+                .First();
+
+            Assert.That(envelope.Peaks.Select(p => p.mz), Has.Member(realMz));
+            Assert.That(envelope.Peaks.Select(p => p.mz), Has.No.Member(interfererMz));
+            Assert.That(envelope.MonoisotopicMass, Is.EqualTo(1600.0).Within(0.01));
+        }
+
+        /// <summary>
+        /// With only one peak in the window the choice is unambiguous, so nothing about the single-candidate
+        /// case may change - including when the sole in-window peak fails the intensity ratio and the walk
+        /// must still stop there.
+        /// </summary>
+        [Test]
+        public void ASolePeakFailingTheIntensityRatioStillEndsTheWalk()
+        {
+            var parameters = new ClassicDeconvolutionParameters(1, 6, TolerancePpm, IntensityRatioLimit);
+            var built = Build(1600.0, realPeakPpmError: 0, interfererPpmError: 0, interfererFoldIntensity: 0);
+
+            // replace the second-most-intense isotope with a peak 20x too intense; no alternative exists
+            var mz = built.Spectrum.XArray.ToArray();
+            var intensities = built.Spectrum.YArray.ToArray();
+            int targetIndex = Array.FindIndex(mz, x => Math.Abs(x - built.TargetMz) < 1e-6);
+            Assert.That(targetIndex, Is.GreaterThanOrEqualTo(0));
+            intensities[targetIndex] = built.ExpectedIntensity * 20;
+
+            var envelopes = Deconvoluter
+                .Deconvolute(new MzSpectrum(mz, intensities, false), parameters, WholeSpectrum)
+                .ToList();
+
+            Assert.That(envelopes.Any(e => Math.Abs(e.MonoisotopicMass - 1600.0) < 0.01
+                                           && e.Peaks.Count == 6), Is.False,
+                "the full ladder must not be recovered when the only in-tolerance peak has the wrong intensity");
+        }
+    }
+}


### PR DESCRIPTION
🤖 Draft. This addresses the isotope-matching half of #245. See **Scope** for what is deliberately left unchanged.

`FindIsotopicEnvelope` looked up the single nearest peak to each sought isotope and ended the isotope walk if that peak failed the tolerance, intensity-ratio or already-claimed checks. A nearer peak that failed those checks masked a usable isotope sitting behind it, and because the walk `break`s on the first miss it truncated the entire envelope rather than swapping one peak.

The window is now scanned for the nearest peak that passes all the existing checks — but only when the nearest peak itself is unusable. No predicate changed.

### Accuracy

Verified on a constructed spectrum (z=2, 20 ppm, exact averagine envelope; real isotope +12 ppm with the predicted intensity, interferer −4 ppm at 20× the predicted intensity):

| | monoisotopic mass | peaks |
|---|---|---|
| truth | 1600.0000 | 6 |
| before | 1601.0017 | 4 |
| after | 1600.0000 | 6 |

On real data there is no ground truth, so the table below reports deltas only. **These are not validated as improvements** — envelope count moves in opposite directions on the two files.

| file | tolerance | envelopes | matched isotope peaks |
|---|---|---|---|
| TDYeastFractionMS1 (455 MS1) | 4 ppm | 228,583 → 228,583 | 617,823 → 617,823 |
| TDYeastFractionMS1 | 20 ppm | 325,487 → 325,535 | 960,326 → 963,270 (+0.31%) |
| FXN11…scans716_718 | 4 ppm | 355 → 355 | 1,294 → 1,297 |
| FXN11…scans716_718 | 20 ppm | 487 → 474 (−2.7%) | 1,791 → 1,812 (+1.2%) |

**At 4 ppm this is a measured no-op on real data** — byte-identical output. The behaviour only diverges at wide tolerance, because the condition itself is tolerance-dependent (fraction of isotope lookups with >1 peak in tolerance):

| tolerance | TDYeastFractionMS1 | FXN11…716_718 |
|---|---|---|
| 4 ppm | 0.002% (148 / 8.08M) | 0.034% (11 / 32,195) |
| 10 ppm | 0.140% (20,469 / 14.6M) | 1.57% (631 / 40,214) |
| 20 ppm | 5.53% (1.31M / 23.7M) | 6.68% (3,365 / 50,405) |
| 50 ppm | — | 19.8% (17,999 / 90,827) |

### Why not select by closest intensity match

The issue proposes taking the peak whose intensity best matches the prediction. That rule and a combined mass+intensity rule were both implemented and measured against this one. TDYeast, 20 ppm; "surrendered" is the extra mass error accepted by overruling the nearest peak, "poor trades" are overrules giving up >5 ppm for <2× intensity gain:

| rule | envelopes | peaks | overrules | median ppm surrendered | poor trades |
|---|---|---|---|---|---|
| previous behaviour | 325,487 | 960,326 | — | — | — |
| closest intensity match | 325,453 | 962,570 | 648,430 | 8.18 | 409,534 (63%) |
| **nearest passing peak (this PR)** | **325,535** | **963,270** | 0 | — | — |
| combined mass+intensity | 325,561 | 963,290 | 159,060 | 2.77 | 24,814 (16%) |

The intensity-ratio check already screens out implausible abundances, so among peaks that survive it, mass error carries more information. The combined rule scores marginally better than this one but introduces a weighting with no validation behind it.

Note the 0 in this PR's row is definitional, not a result: this rule never overrules the nearest passing peak, so the metric cannot fire. Its own error mode is the mirror image — declining a ≥2× better intensity match that sits farther out:

| tolerance | ≥2× better match declined | median extra ppm to reach it |
|---|---|---|
| 4 ppm | 0 | — |
| 10 ppm | 288 of 20,469 ambiguous (1.4%) | 1.35 |
| 20 ppm | 51,462 of 1.31M ambiguous (3.9%) | 7.97 |

### Speed

455 top-down yeast MS1 scans, minimum of 4–6 rounds with the variants interleaved inside one process (cross-process comparison on this machine was dominated by noise; spreads ran up to 2× the minimum):

| | 4 ppm | 20 ppm |
|---|---|---|
| **this PR** | **+1.0%** | **+2.4%** |
| helper called on every lookup | +5.4% | +5.6% |
| helper with an early-return fast path | +4.7% | +5.8% |

The last two explain the structure: the cost was calling an 8-argument out-of-line helper 8–24M times, not the window arithmetic. Keeping the nearest-peak test inline and calling the helper only on the rare miss recovers most of it. Part of the remaining 2.4% at 20 ppm is real extra work, since 5.5% of lookups take the slow path there.

### Scope — what this does not do

- **Does not implement the criterion in the issue body** (closest intensity match); measured above.
- **Does not fix the same pattern in `FindChargeStateOfMass`**, so the issue *title* is only partly addressed. Measured at 0–35 ambiguous lookups out of up to 5M, and no averagine intensity prediction exists for an adjacent charge state's abundance.
- **Does not change the `break`.** One unmatched isotope still ends the walk; this only reduces how often a spurious miss triggers it.
- The `[Obsolete]` copy in `MzSpectrum.Deconvolute` is unchanged.

### Testing and what could not be run

4 new cases in `TestDeconvolutionPeakChoiceWithinTolerance`; 3 fail against unfixed code, the 4th pins that the single-candidate path is unchanged. No existing test was modified.

`Test` is `net10.0-windows` and cannot run on macOS, so only the deconvolution test files were executed here, via a throwaway `net10.0` harness. The full suite has not been run — CI covers it. Benchmarks are one machine, two files.

mzLib ships to MetaMorpheus by NuGet; downstream search output has not been measured.
