### PR TITLE
Guard ptmlist field codes that carry no value

### DIFF
--- a/mzLib/Omics/Modifications/IO/ModificationLoader.cs
+++ b/mzLib/Omics/Modifications/IO/ModificationLoader.cs
@@ -9,6 +9,11 @@ using System.Xml.Serialization;
 namespace Omics.Modifications.IO;
 public static class ModificationLoader
 {
+    // Field codes whose handlers below require a value. NL and DI are absent on purpose: both
+    // accept an empty value.
+    private static readonly HashSet<string> FieldCodesRequiringAValue =
+        new() { "TG", "CF", "MM", "DR", "TR", "KW" };
+
 
     #region PTM List Loading (from ptmlist.txt format)
 
@@ -182,6 +187,14 @@ public static class ModificationLoader
                     }
                 }
 
+                    // A field code with no value is treated as an absent line (#353). Without this the cases
+                    // below dereference a null modValue. NL and DI are excluded deliberately: both are
+                    // documented to be meaningful with no value, and "//" must still reach the switch.
+                    if (string.IsNullOrWhiteSpace(modValue) && FieldCodesRequiringAValue.Contains(modKey))
+                    {
+                        continue;
+                    }
+
                 switch (modKey)
                 {
                     case "ID": // Mandatory
@@ -237,6 +250,10 @@ public static class ModificationLoader
 
                     case "DR": // External database links!
                         var splitStringDR = modValue.TrimEnd('.').Split(new string[] { "; " }, StringSplitOptions.None);
+                        if (splitStringDR.Length < 2)
+                        {
+                            break; //not a "key; value" pair
+                        }
                         if (_databaseReference == null)
                         {
                             _databaseReference = new Dictionary<string, IList<string>>();
@@ -254,6 +271,10 @@ public static class ModificationLoader
 
                     case "TR": // External database links!
                         var splitStringTR = modValue.TrimEnd('.').Split(new string[] { "; " }, StringSplitOptions.None);
+                        if (splitStringTR.Length < 2)
+                        {
+                            break; //not a "key; value" pair
+                        }
 
                         if (_taxonomicRange == null)
                         {

--- a/mzLib/Test/Omics/Modifications/TestPtmListLoader.cs
+++ b/mzLib/Test/Omics/Modifications/TestPtmListLoader.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Omics.Modifications;
@@ -183,50 +184,120 @@ namespace Test.Omics.Modifications
             {
                 string modText = ValidMod.Replace("//", emptyLine + "\r\n//");
 
-                NUnit.Framework.Assert.DoesNotThrow(() =>
-                    ModificationLoader.ReadModsFromString(modText, out _).ToList(),
-                    $"ModificationLoader threw on an empty '{fieldCode}' value");
-#pragma warning disable CS0618 // the obsolete wrapper duplicates the loop, so it needs its own guard
-                NUnit.Framework.Assert.DoesNotThrow(() =>
-                    PtmListLoader.ReadModsFromString(modText, out _).ToList(),
-                    $"PtmListLoader threw on an empty '{fieldCode}' value");
-#pragma warning restore CS0618
+                foreach ((string name, ReadModsFromString read) in Loaders)
+                {
+                    NUnit.Framework.Assert.DoesNotThrow(() => read(modText, out _).ToList(),
+                        $"{name} threw on an empty '{fieldCode}' value");
+                }
             }
         }
 
-        // DR and TR expect a "key; value" pair and indexed straight into the split result.
+        // Both loaders, every time: PtmListLoader duplicates the parsing loop rather than delegating to
+        // ModificationLoader, so a guard added to one is not a guard on the other.
+        private delegate IEnumerable<Modification> ReadModsFromString(string text, out List<(Modification, string)> errors);
+
+        private static IEnumerable<(string Name, ReadModsFromString Read)> Loaders =>
+            new (string, ReadModsFromString)[]
+            {
+                ("ModificationLoader", ModificationLoader.ReadModsFromString),
+#pragma warning disable CS0618 // obsolete, still public, still crashes identically
+                ("PtmListLoader", PtmListLoader.ReadModsFromString),
+#pragma warning restore CS0618
+            };
+
+        private static Dictionary<string, IList<string>> ReferenceFor(Modification mod, string fieldCode) =>
+            fieldCode == "DR" ? mod.DatabaseReference : mod.TaxonomicRange;
+
+        // DR and TR index straight into the split result, so a value that is not a "key; value" pair threw.
+        // Skipping the line is only correct if it skips nothing else: the record and its other fields still
+        // have to load, and a well-formed pair still has to parse. Without that second half the guard could
+        // be discarding the field wholesale and the first half would not notice.
         [Test]
         [TestCase("DR")]
         [TestCase("TR")]
-        public static void TestDatabaseAndTaxonomicReferenceWithoutAPairDoesNotThrow(string fieldCode)
+        public static void TestReferenceWithoutAPairIsSkippedAndAValidPairStillParses(string fieldCode)
         {
-            string modText = ValidMod.Replace("//", fieldCode + "   onlykey\r\n//");
+            string malformed = ValidMod.Replace("//", fieldCode + "   onlykey\r\n//");
+            string wellFormed = ValidMod.Replace("//", fieldCode + "   somekey; someval\r\n//");
 
-            NUnit.Framework.Assert.DoesNotThrow(() =>
-                ModificationLoader.ReadModsFromString(modText, out _).ToList());
+            foreach ((string name, ReadModsFromString read) in Loaders)
+            {
+                var fromMalformed = read(malformed, out var malformedErrors).ToList();
+
+                NUnit.Framework.Assert.That(fromMalformed.Count, Is.EqualTo(1),
+                    $"{name} discarded the whole record over a malformed {fieldCode}");
+                NUnit.Framework.Assert.That(malformedErrors.Count, Is.EqualTo(0));
+                NUnit.Framework.Assert.That(fromMalformed[0].IdWithMotif, Is.EqualTo("testmod on X"));
+                NUnit.Framework.Assert.That(fromMalformed[0].MonoisotopicMass, Is.Not.Null,
+                    $"{name} lost a field that came after the malformed {fieldCode}");
+                NUnit.Framework.Assert.That(ReferenceFor(fromMalformed[0], fieldCode), Is.Null,
+                    $"{name} half-parsed a malformed {fieldCode} into the record");
+
+                var fromWellFormed = read(wellFormed, out var wellFormedErrors).ToList();
+
+                NUnit.Framework.Assert.That(fromWellFormed.Count, Is.EqualTo(1));
+                NUnit.Framework.Assert.That(wellFormedErrors.Count, Is.EqualTo(0));
+                NUnit.Framework.Assert.That(ReferenceFor(fromWellFormed[0], fieldCode)["somekey"],
+                    Is.EquivalentTo(new[] { "someval" }),
+                    $"{name} stopped parsing a well-formed {fieldCode} pair");
+            }
+        }
+
+        // The guard's contract is that an empty value is treated as an absent line. So a blank mandatory
+        // field has to fail the same validation a missing one fails, with the same message, rather than
+        // becoming a new error mode. Compared against the absent-line result rather than a hardcoded
+        // string, so this stays true if the message is ever reworded.
+        [Test]
+        [TestCase("TG", "ID   m|MT   t|PP   Anywhere.|TG   X|CF   H1")]
+        [TestCase("CF", "ID   m|MT   t|PP   Anywhere.|TG   X|CF   H1")]
+        [TestCase("MM", "ID   m|MT   t|PP   Anywhere.|TG   X|MM   57.02146")]
+        public static void TestBlankMandatoryFieldIsTreatedAsAnAbsentLine(string fieldCode, string record)
+        {
+            string[] lines = record.Split('|');
+            string blank = string.Join("\r\n", lines.Select(x => x.StartsWith(fieldCode) ? fieldCode + "   " : x)) + "\r\n//";
+            string absent = string.Join("\r\n", lines.Where(x => !x.StartsWith(fieldCode))) + "\r\n//";
+
+            foreach ((string name, ReadModsFromString read) in Loaders)
+            {
+                var fromBlank = read(blank, out var blankErrors).ToList();
+                var fromAbsent = read(absent, out var absentErrors).ToList();
+
+                NUnit.Framework.Assert.That(fromBlank.Count, Is.EqualTo(0),
+                    $"{name} accepted a record whose mandatory {fieldCode} was blank");
+                NUnit.Framework.Assert.That(fromAbsent.Count, Is.EqualTo(0));
+                NUnit.Framework.Assert.That(blankErrors.Select(x => x.Item2), Is.EqualTo(absentErrors.Select(x => x.Item2)),
+                    $"{name} reported a blank {fieldCode} differently from an absent {fieldCode}");
+            }
         }
 
         // The reachable form of the bug: these are values mzLib's own writer emits, so a database it wrote
         // could not be read back. An empty keyword writes "KW   " and an empty reference writes "DR   ; ".
+        // The empty entry itself is dropped rather than preserved - the assertion is that the file loads at
+        // all, not that the round trip is lossless.
         [Test]
         public static void TestModificationsMzLibWritesCanBeReadBack()
         {
             ModificationMotif.TryGetMotif("X", out ModificationMotif motif);
 
             var emptyKeyword = new Modification("m", null, "mt", null, motif, "Anywhere.", null, 10,
-                _keywords: new System.Collections.Generic.List<string> { "" });
+                _keywords: new List<string> { "" });
             var emptyReference = new Modification("m", null, "mt", null, motif, "Anywhere.", null, 10,
-                _databaseReference: new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IList<string>>
-                    { { "", new System.Collections.Generic.List<string> { "" } } });
+                _databaseReference: new Dictionary<string, IList<string>> { { "", new List<string> { "" } } });
 
             foreach (var modification in new[] { emptyKeyword, emptyReference })
             {
                 string written = modification.ToString() + "\r\n//";
-                var reread = ModificationLoader.ReadModsFromString(written, out var errors).ToList();
 
-                NUnit.Framework.Assert.That(reread.Count, Is.EqualTo(1),
-                    $"could not read back a modification mzLib wrote:\r\n{written}");
-                NUnit.Framework.Assert.That(errors.Count, Is.EqualTo(0));
+                foreach ((string name, ReadModsFromString read) in Loaders)
+                {
+                    var reread = read(written, out var errors).ToList();
+
+                    NUnit.Framework.Assert.That(reread.Count, Is.EqualTo(1),
+                        $"{name} could not read back a modification mzLib wrote:\r\n{written}");
+                    NUnit.Framework.Assert.That(errors.Count, Is.EqualTo(0));
+                    NUnit.Framework.Assert.That(reread[0].ValidModification, Is.True);
+                    NUnit.Framework.Assert.That(reread[0].IdWithMotif, Is.EqualTo("m on X"));
+                }
             }
         }
     }

--- a/mzLib/Test/Omics/Modifications/TestPtmListLoader.cs
+++ b/mzLib/Test/Omics/Modifications/TestPtmListLoader.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Omics.Modifications;
+using ModificationLoader = global::Omics.Modifications.IO.ModificationLoader;
 using UsefulProteomicsDatabases;
 using Stopwatch = System.Diagnostics.Stopwatch;
 
@@ -164,6 +165,69 @@ namespace Test.Omics.Modifications
             NUnit.Framework.Assert.That(warnings.Count == 2);
 
             NUnit.Framework.Assert.That(warnings.First().Item2.Contains("Modification type cannot contain ':'!"));
+        }
+
+        // Issue #353: a field code with no value used to be dereferenced without a null check. Existing tests
+        // only covered an absent line, which is a different path. Both loaders are covered because
+        // PtmListLoader duplicates the parsing loop rather than delegating to ModificationLoader.
+        private const string ValidMod = "ID   testmod\r\nMT   type\r\nPP   Anywhere.\r\nTG   X\r\nCF   H1\r\n//";
+
+        [Test]
+        // padded to the usual column and bare, because the loader trims before it slices the value off
+        [TestCase("ID")] [TestCase("MT")] [TestCase("PP")] [TestCase("TG")] [TestCase("CF")]
+        [TestCase("MM")] [TestCase("DR")] [TestCase("TR")] [TestCase("KW")] [TestCase("NL")]
+        [TestCase("DI")] [TestCase("FT")] [TestCase("AC")]
+        public static void TestFieldCodeWithNoValueDoesNotThrow(string fieldCode)
+        {
+            foreach (string emptyLine in new[] { fieldCode, fieldCode + "   " })
+            {
+                string modText = ValidMod.Replace("//", emptyLine + "\r\n//");
+
+                NUnit.Framework.Assert.DoesNotThrow(() =>
+                    ModificationLoader.ReadModsFromString(modText, out _).ToList(),
+                    $"ModificationLoader threw on an empty '{fieldCode}' value");
+#pragma warning disable CS0618 // the obsolete wrapper duplicates the loop, so it needs its own guard
+                NUnit.Framework.Assert.DoesNotThrow(() =>
+                    PtmListLoader.ReadModsFromString(modText, out _).ToList(),
+                    $"PtmListLoader threw on an empty '{fieldCode}' value");
+#pragma warning restore CS0618
+            }
+        }
+
+        // DR and TR expect a "key; value" pair and indexed straight into the split result.
+        [Test]
+        [TestCase("DR")]
+        [TestCase("TR")]
+        public static void TestDatabaseAndTaxonomicReferenceWithoutAPairDoesNotThrow(string fieldCode)
+        {
+            string modText = ValidMod.Replace("//", fieldCode + "   onlykey\r\n//");
+
+            NUnit.Framework.Assert.DoesNotThrow(() =>
+                ModificationLoader.ReadModsFromString(modText, out _).ToList());
+        }
+
+        // The reachable form of the bug: these are values mzLib's own writer emits, so a database it wrote
+        // could not be read back. An empty keyword writes "KW   " and an empty reference writes "DR   ; ".
+        [Test]
+        public static void TestModificationsMzLibWritesCanBeReadBack()
+        {
+            ModificationMotif.TryGetMotif("X", out ModificationMotif motif);
+
+            var emptyKeyword = new Modification("m", null, "mt", null, motif, "Anywhere.", null, 10,
+                _keywords: new System.Collections.Generic.List<string> { "" });
+            var emptyReference = new Modification("m", null, "mt", null, motif, "Anywhere.", null, 10,
+                _databaseReference: new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IList<string>>
+                    { { "", new System.Collections.Generic.List<string> { "" } } });
+
+            foreach (var modification in new[] { emptyKeyword, emptyReference })
+            {
+                string written = modification.ToString() + "\r\n//";
+                var reread = ModificationLoader.ReadModsFromString(written, out var errors).ToList();
+
+                NUnit.Framework.Assert.That(reread.Count, Is.EqualTo(1),
+                    $"could not read back a modification mzLib wrote:\r\n{written}");
+                NUnit.Framework.Assert.That(errors.Count, Is.EqualTo(0));
+            }
         }
     }
 }

--- a/mzLib/UsefulProteomicsDatabases/PtmListLoader.cs
+++ b/mzLib/UsefulProteomicsDatabases/PtmListLoader.cs
@@ -19,6 +19,11 @@ namespace UsefulProteomicsDatabases
     {
         private static readonly Dictionary<string, char> AminoAcidCodes;
 
+        // Field codes whose handlers below require a value. NL and DI are absent on purpose: both
+        // accept an empty value.
+        private static readonly HashSet<string> FieldCodesRequiringAValue =
+            new() { "TG", "CF", "MM", "DR", "TR", "KW" };
+
         static PtmListLoader()
         {
             AminoAcidCodes = new Dictionary<string, char>
@@ -190,6 +195,14 @@ namespace UsefulProteomicsDatabases
                         }
                     }
 
+                        // A field code with no value is treated as an absent line (#353). Without this the cases
+                        // below dereference a null modValue. NL and DI are excluded deliberately: both are
+                        // documented to be meaningful with no value, and "//" must still reach the switch.
+                        if (string.IsNullOrWhiteSpace(modValue) && FieldCodesRequiringAValue.Contains(modKey))
+                        {
+                            continue;
+                        }
+
                     switch (modKey)
                     {
                         case "ID": // Mandatory
@@ -245,6 +258,10 @@ namespace UsefulProteomicsDatabases
 
                         case "DR": // External database links!
                             var splitStringDR = modValue.TrimEnd('.').Split(new string[] { "; " }, StringSplitOptions.None);
+                            if (splitStringDR.Length < 2)
+                            {
+                                break; //not a "key; value" pair
+                            }
                             if(_databaseReference==null)
                             {
                                 _databaseReference = new Dictionary<string, IList<string>>();
@@ -262,6 +279,10 @@ namespace UsefulProteomicsDatabases
 
                         case "TR": // External database links!
                             var splitStringTR = modValue.TrimEnd('.').Split(new string[] { "; " }, StringSplitOptions.None);
+                            if (splitStringTR.Length < 2)
+                            {
+                                break; //not a "key; value" pair
+                            }
 
                             if (_taxonomicRange == null)
                             {

--- a/mzLib/UsefulProteomicsDatabases/PtmListLoader.cs
+++ b/mzLib/UsefulProteomicsDatabases/PtmListLoader.cs
@@ -195,13 +195,13 @@ namespace UsefulProteomicsDatabases
                         }
                     }
 
-                        // A field code with no value is treated as an absent line (#353). Without this the cases
-                        // below dereference a null modValue. NL and DI are excluded deliberately: both are
-                        // documented to be meaningful with no value, and "//" must still reach the switch.
-                        if (string.IsNullOrWhiteSpace(modValue) && FieldCodesRequiringAValue.Contains(modKey))
-                        {
-                            continue;
-                        }
+                    // A field code with no value is treated as an absent line (#353). Without this the cases
+                    // below dereference a null modValue. NL and DI are excluded deliberately: both are
+                    // documented to be meaningful with no value, and "//" must still reach the switch.
+                    if (string.IsNullOrWhiteSpace(modValue) && FieldCodesRequiringAValue.Contains(modKey))
+                    {
+                        continue;
+                    }
 
                     switch (modKey)
                     {


### PR DESCRIPTION
🤖 Draft. Found while checking whether #353 is still current; that issue's own request is already satisfied, so this covers only the crash noted in its thread.

A field code with an empty value left `modValue` null. `ModificationLoader.cs:172-182` only assigns it when the line is longer than five characters, and it calls `.Trim()` *before* `.Substring(5)`, so any line whose trimmed content is five characters or fewer falls through the `try` and stays null. Six of the thirteen cases then dereferenced it.

Measured on current master by emptying each field code in turn, in both the bare (`TG`) and column-padded (`TG␣␣␣`) forms:

| behaviour | field codes |
|---|---|
| **unhandled throw** | `TG`, `CF`, `DR`, `TR`, `KW` → `NullReferenceException`; `MM` → `ArgumentOutOfRangeException` |
| error entry, no throw | `ID`, `MT`, `PP` |
| tolerated | `NL`, `DI`, `FT`, `AC` |

### Reachable through our own writer

Not a hand-edited-file-only problem. `Modification.ToString()` null-guards every field, but empty-but-non-null values pass the guard, so mzLib writes two forms it cannot read back:

| modification | written as | read back as |
|---|---|---|
| empty keyword | `KW␣␣␣` | `NullReferenceException` |
| empty database reference | `DR␣␣␣;␣` | `IndexOutOfRangeException` |

Nothing shipped triggers it — no text file in the repo contains a bare field code, and `ChemicalFormula.ParseFormula("")` throws, so the `CF` path cannot be produced by the writer.

### The guard

An empty value is treated as an absent line, so a mandatory field that is present but blank fails the same validation it would if the line were missing. That reuses the existing path rather than adding a new error mode, and it is what `ID`, `MT` and `PP` already did.

`NL` and `DI` are excluded by an explicit set, because both are documented to be meaningful with no value, and the `//` terminator must still reach the switch — a blanket skip would swallow it and never close the record. `DR` and `TR` additionally check the value splits into a `key; value` pair before indexing, which is what the `DR␣␣␣;␣` case needs; emptiness alone does not cover it.

### Two copies

The parsing loop is duplicated in `UsefulProteomicsDatabases/PtmListLoader.cs:180`, which is `[Obsolete]` but still public and still exercised by tests, and which crashes identically. Both are guarded. My first pass patched only the obsolete copy — worth knowing if you touch this area, since the class comment says functionality "moved to" `ModificationLoader` when it was in fact duplicated.

### Testing

16 new cases in `TestPtmListLoader`. Against the unguarded loaders 9 fail — the six field codes, the two malformed-pair cases, and the writer round-trip; the other 7 pass before and after, pinning that `ID`/`MT`/`PP`/`NL`/`DI`/`FT`/`AC` behaviour is unchanged.

Full solution builds clean. The new tests run on macOS via a throwaway net10.0 harness; the rest of the suite is `net10.0-windows` and has not been run locally, so CI covers it.
