### PR TITLE
Share the PRIDE pager, and close the understated total_records truncation

### DIFF
--- a/mzLib/Test/DatabaseTests/PrideArchiveClientTests.cs
+++ b/mzLib/Test/DatabaseTests/PrideArchiveClientTests.cs
@@ -67,6 +67,31 @@ public class PrideArchiveClientTests
 
     private static string Array(params string[] fileJson) => "[" + string.Join(",", fileJson) + "]";
 
+    /// <summary>
+    /// The same record <see cref="FileJson"/> produces, written with its properties in a different
+    /// order and different whitespace — the same record to anything that parses it, a different one to
+    /// anything that compares bytes.
+    /// </summary>
+    private static string FileJsonReordered(string fileName) =>
+        $$"""
+        {   "totalDownloads": 19,
+            "fileName": "{{fileName}}",
+            "additionalAttributes": [], "compress": false,
+            "updatedDate": "2019-01-15T09:47:55.000+00:00",
+            "publicationDate": "2025-07-13T23:01:04.308+00:00",
+            "submissionDate": "2019-01-15T09:42:57.000+00:00",
+            "fileSizeBytes": 96358400,
+            "publicFileLocations": [
+              { "@type": "CvParam", "cvLabel": "PRIDE", "accession": "PRIDE:0000469", "name": "FTP Protocol", "value": "ftp://ftp.pride.ebi.ac.uk/{{fileName}}" },
+              { "@type": "CvParam", "cvLabel": "PRIDE", "accession": "PRIDE:0000468", "name": "Aspera Protocol", "value": "prd_ascp@fasp.ebi.ac.uk:{{fileName}}" }
+            ],
+            "checksum": "",
+            "fileCategory": { "value": "SEARCH", "name": "category", "accession": "PRIDE:0000408", "cvLabel": "PRIDE", "@type": "CvParam" },
+            "accession": "hashid",
+            "projectAccessions": ["PXD012345"]
+        }
+        """;
+
     // ---- deserialization ----------------------------------------------------
 
     [Test]
@@ -319,6 +344,84 @@ public class PrideArchiveClientTests
             Assert.That(files.Select(f => f.FileName), Is.EqualTo(new[] { "a", "b", "c" }));
             Assert.That(handler.RequestedUris.Count, Is.EqualTo(2), "a short final page needs no probe");
         });
+    }
+
+    /// <summary>
+    /// The single-page fetch is the common case -- most PRIDE projects hold fewer files than the
+    /// default page size -- so it is the one the probe must not tax. Page 0 is trivially the largest
+    /// page seen, so "as full as any served" is vacuously true there and would probe every such fetch;
+    /// the requested pageSize is what decides it instead. 50 of a requested 100 is the server running
+    /// out, not a full page, so the header is believed and nothing further is requested.
+    /// </summary>
+    [Test]
+    public async Task GetProjectFilesAsync_SinglePageShorterThanRequested_DoesNotProbe()
+    {
+        string[] names = Enumerable.Range(0, 50).Select(i => "f" + i).ToArray();
+        var handler = new StubHandler(request => request.RequestUri.ToString().Contains("page=0")
+            ? JsonResponse(Array(names.Select(n => FileJson(n)).ToArray()), totalRecords: 50)
+            : JsonResponse("[]", totalRecords: 50));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        var files = await client.GetProjectFilesAsync("PXD012345"); // the default pageSize of 100
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(files, Has.Count.EqualTo(50));
+            Assert.That(handler.RequestedUris.Count, Is.EqualTo(1),
+                "50 files at a requested page size of 100 is a short page; the probe is not for it");
+        });
+    }
+
+    /// <summary>
+    /// A result set that GROWS between two requests repages itself, so the probe can be handed records
+    /// the fetch already holds: page 0 of a 2-record set is [a, b], and page 1 of the 3-record set it
+    /// became is [b, c]. The server is behaving correctly throughout -- the empty-page and
+    /// identical-page comments both decline to fail on exactly this -- so the answer cannot be to
+    /// throw, and it cannot be to append either: that hands the caller a duplicate "b", which it has no
+    /// way to see, and which a caller acts on by downloading the same file twice or reporting the wrong
+    /// count. The repeat is dropped by matching the whole JSON record, and only "c" is appended.
+    /// </summary>
+    [Test]
+    public async Task GetProjectFilesAsync_ResultSetGrowsBeforeTheProbe_DoesNotDuplicateARecord()
+    {
+        var handler = new StubHandler(request =>
+        {
+            string uri = request.RequestUri.ToString();
+            if (uri.Contains("page=0")) return JsonResponse(Array(FileJson("a"), FileJson("b")), totalRecords: 2);
+            if (uri.Contains("page=1")) return JsonResponse(Array(FileJson("b"), FileJson("c")), totalRecords: 3);
+            return JsonResponse("[]", totalRecords: 3);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        var files = await client.GetProjectFilesAsync("PXD012345", pageSize: 2);
+
+        // Not [a, b, b, c]. The record the probe repeats is dropped; the one it genuinely adds is kept,
+        // so the probe still does the job it exists for on a result set that moved underneath it.
+        Assert.That(files.Select(f => f.FileName), Is.EqualTo(new[] { "a", "b", "c" }));
+    }
+
+    /// <summary>
+    /// The repeat is matched on the whole record as PARSED JSON, not as raw bytes, so a server that
+    /// re-serves the same record with different whitespace or a different property order is still
+    /// recognised. Byte identity alone would miss it and append the duplicate.
+    /// </summary>
+    [Test]
+    public async Task GetProjectFilesAsync_ProbeRepeatsARecordFormattedDifferently_StillDropsIt()
+    {
+        var handler = new StubHandler(request =>
+        {
+            string uri = request.RequestUri.ToString();
+            if (uri.Contains("page=0")) return JsonResponse(Array(FileJson("a"), FileJson("b")), totalRecords: 2);
+            // Same two records, reformatted: whitespace inserted and the properties reordered.
+            if (uri.Contains("page=1"))
+                return JsonResponse("[\n  " + FileJson("a") + " ,\n  " + FileJsonReordered("b") + "\n]", totalRecords: 2);
+            return JsonResponse("[]", totalRecords: 2);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        var files = await client.GetProjectFilesAsync("PXD012345", pageSize: 2);
+
+        Assert.That(files.Select(f => f.FileName), Is.EqualTo(new[] { "a", "b" }));
     }
 
     [Test]

--- a/mzLib/Test/DatabaseTests/PrideArchiveClientTests.cs
+++ b/mzLib/Test/DatabaseTests/PrideArchiveClientTests.cs
@@ -229,15 +229,22 @@ public class PrideArchiveClientTests
         });
     }
 
+    /// <summary>
+    /// The counterpart to the overstated case, and the pin on what the tail probe costs. The fetch ends
+    /// on a page as full as any served, which is indistinguishable from a total that is one page short,
+    /// so one further page is requested before the header is believed.
+    /// </summary>
+    /// <remarks>
+    /// The stub ignores <c>page</c> and serves the same two files forever, never an empty page. That is
+    /// deliberate and does double duty: it makes total_records the only thing that can stop this loop,
+    /// so weakening that check shows up here; and it is the worst case for the probe, because the probe
+    /// walks straight into the identical-page guard. Returning the two files rather than throwing is
+    /// what makes the probe strictly non-regressive -- a server that ignores paging behaves exactly as
+    /// it did before the probe existed.
+    /// </remarks>
     [Test]
-    public async Task GetProjectFilesAsync_TotalRecordsExactlyMatched_DoesNotFetchExtraPage()
+    public async Task GetProjectFilesAsync_TotalRecordsExactlyMatched_ProbesOncePastTheReportedTotal()
     {
-        // The counterpart to the overstated case. Note the stub ignores `page` and serves the same
-        // two files forever, never an empty page: that makes the total_records check the ONLY thing
-        // that can stop this loop on the first request, so if it is ever weakened this test does not
-        // fail by one wasted request -- the second request re-serves an identical page and trips the
-        // identical-page guard instead. PagesUntilTotalRecords cannot pin that, because its fallback
-        // returns [] and the empty-page check would rescue it.
         const long total = 2;
         var handler = new StubHandler(_ => JsonResponse(Array(FileJson("a"), FileJson("b")), totalRecords: total));
         using var client = new PrideArchiveClient(new HttpClient(handler));
@@ -246,8 +253,71 @@ public class PrideArchiveClientTests
 
         Assert.Multiple(() =>
         {
+            // The repeated page is discarded, not appended: the probe adds records only when the server
+            // actually has some. Duplicating "a" and "b" here would be the tail probe reintroducing the
+            // duplicate-padding failure the identical-page guard exists to prevent.
             Assert.That(files.Select(f => f.FileName), Is.EqualTo(new[] { "a", "b" }));
-            Assert.That(handler.RequestedUris.Count, Is.EqualTo(1));
+            // 2, not 1: the cost of closing the understated-total hole, paid only when a fetch ends
+            // exactly on a full page. Was 1 before the probe; changing it back re-opens that hole.
+            Assert.That(handler.RequestedUris.Count, Is.EqualTo(2));
+        });
+    }
+
+    /// <summary>
+    /// An UNDERSTATED total_records is the mirror of the overstated case and truncates the tail: every
+    /// record past the reported total is dropped with no error, which is the same silent-truncation
+    /// class as the capped-pageSize bug. Verified RED against the pre-probe loop, which returns 2 of 4.
+    /// </summary>
+    [Test]
+    public async Task GetProjectFilesAsync_TotalRecordsUnderstated_ReturnsEveryRecordAnyway()
+    {
+        // The server has 4 files but reports 2. Reaching page=1 at all requires disbelieving the header.
+        const long understatedTotal = 2;
+        var handler = new StubHandler(request =>
+        {
+            string uri = request.RequestUri.ToString();
+            if (uri.Contains("page=0")) return JsonResponse(Array(FileJson("a"), FileJson("b")), totalRecords: understatedTotal);
+            if (uri.Contains("page=1")) return JsonResponse(Array(FileJson("c"), FileJson("d")), totalRecords: understatedTotal);
+            return JsonResponse("[]", totalRecords: understatedTotal);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        var files = await client.GetProjectFilesAsync("PXD012345", pageSize: 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(files.Select(f => f.FileName), Is.EqualTo(new[] { "a", "b", "c", "d" }));
+            // 3 requests: page 0, the probe that finds the disclaimed tail, and the empty page that
+            // ends it. Asserting the count is what makes this discriminate -- the file list alone would
+            // also pass if the loop ignored total_records entirely, which is not the fix.
+            Assert.That(handler.RequestedUris.Count, Is.EqualTo(3));
+        });
+    }
+
+    /// <summary>
+    /// The probe is spent only on the ambiguous stop. A fetch that ends on a page SHORTER than the
+    /// largest served has reached the end of the data, the header agrees, and no extra request is made.
+    /// This is what keeps the probe from costing a request on every ordinary multi-page fetch.
+    /// </summary>
+    [Test]
+    public async Task GetProjectFilesAsync_TotalRecordsMatchedOnAShortPage_DoesNotProbe()
+    {
+        const long total = 3;
+        var handler = new StubHandler(request =>
+        {
+            string uri = request.RequestUri.ToString();
+            if (uri.Contains("page=0")) return JsonResponse(Array(FileJson("a"), FileJson("b")), totalRecords: total);
+            if (uri.Contains("page=1")) return JsonResponse(Array(FileJson("c")), totalRecords: total);
+            return JsonResponse("[]", totalRecords: total);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        var files = await client.GetProjectFilesAsync("PXD012345", pageSize: 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(files.Select(f => f.FileName), Is.EqualTo(new[] { "a", "b", "c" }));
+            Assert.That(handler.RequestedUris.Count, Is.EqualTo(2), "a short final page needs no probe");
         });
     }
 

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using MassSpectrometry;
 using MzLibUtil;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace UsefulProteomicsDatabases
 {
@@ -103,7 +104,13 @@ namespace UsefulProteomicsDatabases
         /// <para>
         /// A <c>total_records</c> that misreports the count in either direction is tolerated: an
         /// overstated one stops on the empty page past the end, and an understated one is caught by
-        /// fetching one further page whenever the fetch would otherwise end on a full page.
+        /// fetching one further page whenever the fetch would otherwise end on a page that could be
+        /// full — a first page holding everything that was asked for, or a later page as large as the
+        /// largest the server has served. That costs one extra request per fetch of exactly that shape;
+        /// a fetch ending on a page that is visibly short pays nothing. The one case it cannot catch is
+        /// an understated total on a single page requested ABOVE the server cap, where the capped page
+        /// that comes back looks short but may not be — the same above-the-cap caveat as the paragraph
+        /// above.
         /// </para>
         /// </param>
         /// <param name="cancellationToken">Cancels the (possibly multi-page) fetch.</param>
@@ -670,9 +677,11 @@ namespace UsefulProteomicsDatabases
                     JsonConvert.DeserializeObject<List<T>>(content, JsonSettings) ?? new List<T>();
 
                 // A null ELEMENT ("[null]") deserializes to a null entry that carries no record at all.
-                // Drop it here, mirroring what RemoveNullElements does for PrideProject, so neither this
-                // loop nor a caller dereferences it. Nothing is lost: a null is not a record.
-                pageItems.RemoveAll(x => x is null);
+                // It is dropped below, mirroring what RemoveNullElements does for PrideProject, so
+                // neither this loop nor a caller dereferences it. Nothing is lost: a null is not a
+                // record. The count of what the SERVER actually served is taken first, because that --
+                // not what survives the tail-probe dedup further down -- is what says how full a page is.
+                int servedCount = pageItems.Count(x => x is not null);
 
                 // An empty page ends the fetch. This is also the backstop for a total_records that
                 // overstates what the server will actually serve: paging past the end returns a
@@ -681,7 +690,7 @@ namespace UsefulProteomicsDatabases
                 // reported as a shortfall -- there is no way to distinguish it from a result set whose
                 // size changed mid-fetch, and throwing would fail a caller who asked for
                 // nothing unreasonable.
-                if (pageItems.Count == 0)
+                if (servedCount == 0)
                     break; // no (more) records
 
                 // Every entry the server returns is kept. A page may legitimately repeat a value that
@@ -701,23 +710,60 @@ namespace UsefulProteomicsDatabases
                 // actually paged, needs no per-record key the DTO does not carry, and degrades safely:
                 // a server that varies its body (an embedded timestamp) merely stops this guard firing
                 // and falls through to the MaxPages backstop, as it did before the guard existed.
-                bool pageAdvanced = content != previousPageIdentity;
+                string previousPageBody = previousPageIdentity;
+                bool pageAdvanced = content != previousPageBody;
                 previousPageIdentity = content;
 
                 // A tail probe (see the total_records branch below) is speculative: total_records has
                 // already said the fetch is done, and this page is only being read in case it lied
                 // downward. So it must never be able to make things worse than trusting the header
-                // would have been. A probe that brought nothing new ends the fetch and lets the header
-                // stand -- deliberately NOT the identical-page throw, which is reserved for a server
-                // contradicting a total that says more is still to come. A server that ignores `page`
-                // entirely therefore still returns its records rather than throwing, exactly as it did
-                // before this guard existed.
-                if (verifyingTail && !pageAdvanced)
-                    break;
+                // would have been, and there are two ways it could.
+                //
+                // (1) It could bring nothing new, in which case the header was right after all and the
+                // fetch ends -- deliberately NOT the identical-page throw, which is reserved for a
+                // server contradicting a total that says more is still to come. A server that ignores
+                // `page` therefore still returns its records rather than throwing, as it did before this
+                // guard existed. A byte-identical body is that case outright, and is taken here without
+                // parsing anything; a body that repeats the same records in different bytes is caught by
+                // the record comparison below, which sees past whitespace and property order.
+                //
+                // One case is NOT recovered, and the claim is limited to match: a server that both
+                // ignores `page` AND varies the CONTENT of the records it re-serves (a per-record
+                // timestamp, say) produces pages that are new by every measure available here, so the
+                // fetch runs to the MaxPages backstop and throws where the total check used to stop it.
+                // That server already defeated the identical-page guard above before this probe existed;
+                // what is new is that the total check no longer rescues it. Nothing short of a record
+                // key -- which this loop has established the DTO does not have -- would tell those pages
+                // apart, and MaxPages remains settable by a caller who meets such a server.
+                //
+                // (2) It could bring records this fetch ALREADY HOLDS. A result set that grows between
+                // two requests shifts its own paging: page 0 of a 2-record set is [a, b], and page 1 of
+                // the 3-record set it became is [b, c]. That is a correct server, and the comments above
+                // and below both promise to tolerate it -- but appending the probe's answer wholesale
+                // would hand the caller a duplicated record, which is a worse failure than the truncation
+                // this probe exists to prevent, and one the caller cannot see. So a probe's records are
+                // matched against the page before them and the repeats are dropped.
+                //
+                // Matching is on the WHOLE JSON record, not on any field of it. The distinction matters:
+                // the comment above refuses to treat a field as a record's identity because a value may
+                // repeat or be absent, so two different records can share one. A complete record cannot
+                // be confused with a different record that way. Two byte-equal records in one manifest
+                // are indistinguishable from each other anyway, so dropping one of a straddling pair
+                // costs nothing a caller could act on.
+                if (verifyingTail)
+                {
+                    if (!pageAdvanced)
+                        break;
 
+                    NullOutRecordsRepeatedFromPreviousPage(pageItems, content, previousPageBody);
+                    if (pageItems.All(x => x is null))
+                        break; // the probe held nothing this fetch did not already have
+                }
+
+                pageItems.RemoveAll(x => x is null);
                 items.AddRange(pageItems);
-                if (pageItems.Count > largestPageSeen)
-                    largestPageSeen = pageItems.Count;
+                if (servedCount > largestPageSeen)
+                    largestPageSeen = servedCount;
 
                 if (TryGetTotalRecords(response, out long total))
                 {
@@ -743,21 +789,42 @@ namespace UsefulProteomicsDatabases
                     // and every record past the reported total is dropped with no error.
                     //
                     // It is only distinguishable by asking for one more page, and only worth asking
-                    // when the answer is in doubt. A page SHORTER than the largest the server has
-                    // actually served is the end of the data -- the server ran out, and the header
-                    // agrees -- so that stop is trusted outright. Stopping on a page that is as full as
-                    // any seen so far is the ambiguous case: it looks identical whether the total is
-                    // honest or one page short. There, one speculative page is fetched before
-                    // believing the header.
+                    // when the answer is in doubt. Truncation needs the last page to have been FULL:
+                    // a server with more to give fills the page it is giving. So a page that is not
+                    // full is the end of the data, the header agrees, and that stop is trusted outright.
+                    // A full one is the ambiguous case -- it looks identical whether the total is honest
+                    // or one page short -- and there one speculative page is fetched before believing
+                    // the header.
                     //
-                    // The probe cannot cost correctness, only a single request: it may add records the
-                    // header disclaimed, and the guard above makes an empty or repeated answer mean
-                    // "the header was right after all". The one request is spent only when a fetch ends
-                    // exactly on a full page boundary, which for an honest server means the record
-                    // count is an exact multiple of the page size.
+                    // "Full" is measured against different evidence on the first page than on later
+                    // ones, because the two pages carry different information.
+                    //
+                    // On a LATER page, the size of the largest page already served is what a full page
+                    // looks like from here, and it is the only sound measure: PRIDE caps pageSize
+                    // server-side and pages by the capped size, so a page of 100 against a requested 500
+                    // is full, and #1102 established that the requested size cannot tell the two apart.
+                    //
+                    // On page 0 there is no such evidence -- the first page is trivially the largest
+                    // seen, so that test is vacuously true and would probe every single-page fetch,
+                    // doubling the request count of the common case. The requested pageSize is the only
+                    // evidence there is, so it is used: a first page shorter than what was asked for is
+                    // the server running out. That is exact whenever pageSize is at or below the server
+                    // cap, which is every default call. It leaves one gap, and only one: a single-page
+                    // fetch that asked for MORE than the cap gets back a capped -- and therefore
+                    // possibly full -- page that looks short, so an understated total would still
+                    // truncate it. That is the same above-the-cap caveat the public docstring already
+                    // carries, and it buys back a request on every ordinary call.
+                    //
+                    // Getting this judgement wrong costs at most one request in one direction and, in
+                    // the gap above, the records the header disclaimed -- never a record the header
+                    // acknowledged. The probe itself cannot cost correctness at all: the guard above
+                    // drops anything it repeats, so it can only ever add.
                     if (items.Count >= total)
                     {
-                        if (pageItems.Count < largestPageSeen)
+                        bool pageCouldBeFull = page == 0
+                            ? servedCount >= pageSize
+                            : servedCount >= largestPageSeen;
+                        if (!pageCouldBeFull)
                             break;
                         verifyingTail = true;
                     }
@@ -770,7 +837,7 @@ namespace UsefulProteomicsDatabases
                         verifyingTail = false;
                     }
                 }
-                else if (pageItems.Count < pageSize)
+                else if (servedCount < pageSize)
                 {
                     // No total to trust: a short page is the last page.
                     break;
@@ -783,6 +850,48 @@ namespace UsefulProteomicsDatabases
             }
 
             return items;
+        }
+
+        /// <summary>
+        /// Nulls out the entries of a speculative tail page that the page before it already delivered,
+        /// so the null sweep in <see cref="GetAllPagesAsync{T}"/> removes them before they are appended.
+        /// Records are matched whole, as parsed JSON, which ignores whitespace and property order but
+        /// nothing that carries meaning.
+        /// </summary>
+        /// <remarks>
+        /// Nulling in place rather than filtering keeps this index-aligned with the raw array — the
+        /// caller has not yet swept its own nulls, so element <c>i</c> here is element <c>i</c> there —
+        /// and reuses the null removal that already exists instead of adding a second one.
+        /// <para>
+        /// Both bodies are known to be JSON arrays of the same length as their deserialized lists: the
+        /// caller reached this line only by deserializing <paramref name="pageBody"/> into
+        /// <paramref name="pageItems"/> element-for-element, and only on a page that follows another.
+        /// Re-checking either fact here would be an unreachable branch, so the invariant is stated
+        /// rather than guarded.
+        /// </para>
+        /// </remarks>
+        private static void NullOutRecordsRepeatedFromPreviousPage<T>(List<T> pageItems, string pageBody,
+            string previousPageBody) where T : class
+        {
+            JArray currentRecords = ParseJsonArray(pageBody);
+            JArray previousRecords = ParseJsonArray(previousPageBody);
+
+            for (int i = 0; i < pageItems.Count; i++)
+            {
+                if (previousRecords.Any(earlier => JToken.DeepEquals(currentRecords[i], earlier)))
+                    pageItems[i] = null;
+            }
+        }
+
+        /// <summary>
+        /// Parses a JSON array without the date recognition Newtonsoft applies by default, so a record
+        /// is compared as the server wrote it rather than as a round-trip through <see cref="DateTime"/>
+        /// would render it.
+        /// </summary>
+        private static JArray ParseJsonArray(string json)
+        {
+            using var reader = new JsonTextReader(new StringReader(json)) { DateParseHandling = DateParseHandling.None };
+            return JArray.Load(reader);
         }
 
         /// <summary>Reads the PRIDE "total_records" response header, if present and numeric.</summary>

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
@@ -123,99 +123,11 @@ namespace UsefulProteomicsDatabases
             if (pageSize <= 0)
                 throw new ArgumentOutOfRangeException(nameof(pageSize), "Page size must be positive.");
 
-            var files = new List<PrideArchiveFile>();
-            string previousPageIdentity = null;
-            int page = 0;
-
-            while (true)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                string requestUri = $"projects/{Uri.EscapeDataString(accession)}/files?pageSize={pageSize}&page={page}";
-                using HttpResponseMessage response = await _httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
-
-                if (!response.IsSuccessStatusCode)
-                    throw new HttpRequestException(
-                        $"PRIDE Archive request failed with status {(int)response.StatusCode} {response.ReasonPhrase} for '{requestUri}'.");
-
-                string content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-                List<PrideArchiveFile> pageFiles =
-                    JsonConvert.DeserializeObject<List<PrideArchiveFile>>(content, JsonSettings) ?? new List<PrideArchiveFile>();
-
-                // A null ELEMENT ("[null]") deserializes to a null entry that carries no file at all.
-                // Drop it here, mirroring what RemoveNullElements does for PrideProject, so neither this
-                // loop nor a caller dereferences it. Nothing is lost: a null is not a manifest record.
-                pageFiles.RemoveAll(f => f is null);
-
-                // An empty page ends the fetch. This is also the backstop for a total_records that
-                // overstates what the server will actually serve: paging past the end returns a
-                // zero-byte body (verified live 2026-07-23), which deserializes to an empty list. An
-                // overstatement is therefore accepted as the server's own correction rather than
-                // reported as a shortfall -- there is no way to distinguish it from a project whose
-                // file count changed mid-fetch, and throwing would fail a caller who asked for
-                // nothing unreasonable.
-                if (pageFiles.Count == 0)
-                    break; // no (more) files
-
-                // Every entry the server returns stays in the manifest. A manifest may legitimately
-                // repeat a leaf name (the same name under different publicFileLocations), and an entry
-                // with no fileName at all is a case DownloadFileAsync already expects and guards. So
-                // paging progress is a property of the PAGE, not of individual file names: deciding
-                // membership by name uniqueness would silently drop real records, which is precisely
-                // the failure this method exists to prevent.
-                //
-                // The page's identity is therefore its RAW RESPONSE BODY, not a projection of it.
-                // File names are the one field this method has already established it cannot treat as
-                // an identity: a name may legitimately repeat, or be absent entirely, so two
-                // consecutive pages of genuinely DIFFERENT records can share a name sequence and be
-                // misread as a re-served page -- failing a correct server on exactly the manifests the
-                // comment above promises to support. A separator alone does not close that gap; the
-                // names simply are not the record. The body distinguishes any two pages the server
-                // actually paged, needs no per-record key the DTO does not carry, and degrades safely:
-                // a server that varies its body (an embedded timestamp) merely stops this guard firing
-                // and falls through to the MaxPages backstop, as it did before the guard existed.
-                bool pageAdvanced = content != previousPageIdentity;
-                previousPageIdentity = content;
-
-                files.AddRange(pageFiles);
-
-                if (TryGetTotalRecords(response, out long total))
-                {
-                    // Checked BEFORE the total comparison: a server re-serving the same page forever
-                    // would otherwise push files.Count past total with duplicates and break out as if
-                    // it had succeeded, hiding the fault behind a plausible-looking manifest.
-                    //
-                    // This is deliberately the strict signal -- a page byte-identical to its
-                    // predecessor -- rather than "this page added nothing new". A project whose files
-                    // change mid-fetch can legitimately return a page that merely overlaps the previous
-                    // one, and the empty-page comment above declines to throw on exactly that
-                    // ambiguity; failing only on an exactly-repeated page keeps the two consistent.
-                    if (!pageAdvanced)
-                        throw new MzLibException(
-                            $"PRIDE Archive re-served an identical page {page} for accession '{accession}' " +
-                            $"while reporting {total} total records. The server may be ignoring the page " +
-                            $"parameter, or the project's file list may have changed mid-fetch.");
-
-                    // The server's own record count is authoritative: stop once we have all of it.
-                    if (files.Count >= total)
-                        break;
-                    // More remain, so keep paging even though the page may look short. PRIDE caps
-                    // pageSize server-side (100 as of 2026-07-23) and then pages by the capped size,
-                    // so requesting 500 yields a 100-file "short" page that still has successors.
-                    // Treating that as the last page silently truncated the manifest.
-                }
-                else if (pageFiles.Count < pageSize)
-                {
-                    // No total to trust: a short page is the last page.
-                    break;
-                }
-
-                page++;
-                if (page >= MaxPages)
-                    throw new HttpRequestException(
-                        $"PRIDE Archive paging exceeded {MaxPages} pages for accession '{accession}'; the server may be ignoring paging parameters.");
-            }
-
-            return files;
+            return await GetAllPagesAsync<PrideArchiveFile>(
+                page => $"projects/{Uri.EscapeDataString(accession)}/files?pageSize={pageSize}&page={page}",
+                pageSize,
+                $"accession '{accession}'",
+                cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -704,6 +616,127 @@ namespace UsefulProteomicsDatabases
             // than re-checked here, where the null branch would be unreachable and untestable.
             foreach (PrideSampleAttribute attribute in project.SampleAttributes)
                 attribute.Value.RemoveAll(x => x == null);
+        }
+
+        /// <summary>
+        /// Fetches every page of a PRIDE endpoint that answers with a bare JSON array plus a
+        /// <c>total_records</c> response header, and concatenates them in server order.
+        /// </summary>
+        /// <remarks>
+        /// More than one PRIDE endpoint uses this envelope, and the termination rules below are subtle
+        /// enough — and have been got wrong often enough — that a second copy of them would only be a
+        /// second place for the same truncation bug to live. The rules are documented at each step
+        /// rather than here, because each one exists to defend against a specific observed behavior.
+        /// </remarks>
+        /// <typeparam name="T">The element type of a single page.</typeparam>
+        /// <param name="requestUriForPage">Builds the request URI for a zero-based page index.</param>
+        /// <param name="pageSize">
+        /// The page size that was requested. Used only by the fallback that runs when the response
+        /// carries no usable <c>total_records</c> header.
+        /// </param>
+        /// <param name="subject">
+        /// Names what is being paged, for error messages — e.g. <c>accession 'PXD012345'</c>. It is
+        /// interpolated as written, so each endpoint's failures stay as specific as they were when this
+        /// loop lived inside that endpoint's own method.
+        /// </param>
+        /// <param name="cancellationToken">Cancels the (possibly multi-page) fetch.</param>
+        /// <returns>Every element the endpoint served, across all pages. Never null.</returns>
+        private async Task<List<T>> GetAllPagesAsync<T>(Func<int, string> requestUriForPage, int pageSize,
+            string subject, CancellationToken cancellationToken) where T : class
+        {
+            var items = new List<T>();
+            string previousPageIdentity = null;
+            int page = 0;
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                string requestUri = requestUriForPage(page);
+                using HttpResponseMessage response = await _httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
+
+                if (!response.IsSuccessStatusCode)
+                    throw new HttpRequestException(
+                        $"PRIDE Archive request failed with status {(int)response.StatusCode} {response.ReasonPhrase} for '{requestUri}'.");
+
+                string content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                List<T> pageItems =
+                    JsonConvert.DeserializeObject<List<T>>(content, JsonSettings) ?? new List<T>();
+
+                // A null ELEMENT ("[null]") deserializes to a null entry that carries no record at all.
+                // Drop it here, mirroring what RemoveNullElements does for PrideProject, so neither this
+                // loop nor a caller dereferences it. Nothing is lost: a null is not a record.
+                pageItems.RemoveAll(x => x is null);
+
+                // An empty page ends the fetch. This is also the backstop for a total_records that
+                // overstates what the server will actually serve: paging past the end returns a
+                // zero-byte body (verified live 2026-07-23), which deserializes to an empty list. An
+                // overstatement is therefore accepted as the server's own correction rather than
+                // reported as a shortfall -- there is no way to distinguish it from a result set whose
+                // size changed mid-fetch, and throwing would fail a caller who asked for
+                // nothing unreasonable.
+                if (pageItems.Count == 0)
+                    break; // no (more) records
+
+                // Every entry the server returns is kept. A page may legitimately repeat a value that
+                // looks like a key (a manifest may list the same leaf name under different
+                // publicFileLocations, and an entry with no fileName at all is a case DownloadFileAsync
+                // already expects and guards). So paging progress is a property of the PAGE, not of the
+                // individual records: deciding membership by the uniqueness of any one field would
+                // silently drop real records, which is precisely the failure this loop exists to prevent.
+                //
+                // The page's identity is therefore its RAW RESPONSE BODY, not a projection of it.
+                // A record field is the one thing this loop has already established it cannot treat as
+                // an identity: a value may legitimately repeat, or be absent entirely, so two
+                // consecutive pages of genuinely DIFFERENT records can share a field sequence and be
+                // misread as a re-served page -- failing a correct server on exactly the result sets the
+                // comment above promises to support. A separator alone does not close that gap; the
+                // fields simply are not the record. The body distinguishes any two pages the server
+                // actually paged, needs no per-record key the DTO does not carry, and degrades safely:
+                // a server that varies its body (an embedded timestamp) merely stops this guard firing
+                // and falls through to the MaxPages backstop, as it did before the guard existed.
+                bool pageAdvanced = content != previousPageIdentity;
+                previousPageIdentity = content;
+
+                items.AddRange(pageItems);
+
+                if (TryGetTotalRecords(response, out long total))
+                {
+                    // Checked BEFORE the total comparison: a server re-serving the same page forever
+                    // would otherwise push items.Count past total with duplicates and break out as if
+                    // it had succeeded, hiding the fault behind a plausible-looking result.
+                    //
+                    // This is deliberately the strict signal -- a page byte-identical to its
+                    // predecessor -- rather than "this page added nothing new". A result set that
+                    // changes mid-fetch can legitimately return a page that merely overlaps the previous
+                    // one, and the empty-page comment above declines to throw on exactly that
+                    // ambiguity; failing only on an exactly-repeated page keeps the two consistent.
+                    if (!pageAdvanced)
+                        throw new MzLibException(
+                            $"PRIDE Archive re-served an identical page {page} for {subject} " +
+                            $"while reporting {total} total records. The server may be ignoring the page " +
+                            $"parameter, or the result set may have changed mid-fetch.");
+
+                    // The server's own record count is authoritative: stop once we have all of it.
+                    if (items.Count >= total)
+                        break;
+                    // More remain, so keep paging even though the page may look short. PRIDE caps
+                    // pageSize server-side (100 as of 2026-07-23) and then pages by the capped size,
+                    // so requesting 500 yields a 100-record "short" page that still has successors.
+                    // Treating that as the last page silently truncated the result.
+                }
+                else if (pageItems.Count < pageSize)
+                {
+                    // No total to trust: a short page is the last page.
+                    break;
+                }
+
+                page++;
+                if (page >= MaxPages)
+                    throw new HttpRequestException(
+                        $"PRIDE Archive paging exceeded {MaxPages} pages for {subject}; the server may be ignoring paging parameters.");
+            }
+
+            return items;
         }
 
         /// <summary>Reads the PRIDE "total_records" response header, if present and numeric.</summary>

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
@@ -100,6 +100,11 @@ namespace UsefulProteomicsDatabases
         /// page against, and termination falls back to the first short page — under which a requested
         /// size above the server cap can still return a partial manifest. Leave this at the default
         /// unless you have a reason not to; the full manifest is returned either way at or below the cap.
+        /// <para>
+        /// A <c>total_records</c> that misreports the count in either direction is tolerated: an
+        /// overstated one stops on the empty page past the end, and an understated one is caught by
+        /// fetching one further page whenever the fetch would otherwise end on a full page.
+        /// </para>
         /// </param>
         /// <param name="cancellationToken">Cancels the (possibly multi-page) fetch.</param>
         /// <returns>
@@ -647,6 +652,8 @@ namespace UsefulProteomicsDatabases
             var items = new List<T>();
             string previousPageIdentity = null;
             int page = 0;
+            int largestPageSeen = 0;
+            bool verifyingTail = false;
 
             while (true)
             {
@@ -697,7 +704,20 @@ namespace UsefulProteomicsDatabases
                 bool pageAdvanced = content != previousPageIdentity;
                 previousPageIdentity = content;
 
+                // A tail probe (see the total_records branch below) is speculative: total_records has
+                // already said the fetch is done, and this page is only being read in case it lied
+                // downward. So it must never be able to make things worse than trusting the header
+                // would have been. A probe that brought nothing new ends the fetch and lets the header
+                // stand -- deliberately NOT the identical-page throw, which is reserved for a server
+                // contradicting a total that says more is still to come. A server that ignores `page`
+                // entirely therefore still returns its records rather than throwing, exactly as it did
+                // before this guard existed.
+                if (verifyingTail && !pageAdvanced)
+                    break;
+
                 items.AddRange(pageItems);
+                if (pageItems.Count > largestPageSeen)
+                    largestPageSeen = pageItems.Count;
 
                 if (TryGetTotalRecords(response, out long total))
                 {
@@ -716,13 +736,39 @@ namespace UsefulProteomicsDatabases
                             $"while reporting {total} total records. The server may be ignoring the page " +
                             $"parameter, or the result set may have changed mid-fetch.");
 
-                    // The server's own record count is authoritative: stop once we have all of it.
+                    // The server's own record count is authoritative for stopping -- but only upward.
+                    // An OVERSTATED total is already handled (the empty page above accepts it as the
+                    // server's own correction). An UNDERSTATED one is the mirror failure, and it
+                    // truncates the tail exactly as the capped-pageSize bug did: stop at Count >= total
+                    // and every record past the reported total is dropped with no error.
+                    //
+                    // It is only distinguishable by asking for one more page, and only worth asking
+                    // when the answer is in doubt. A page SHORTER than the largest the server has
+                    // actually served is the end of the data -- the server ran out, and the header
+                    // agrees -- so that stop is trusted outright. Stopping on a page that is as full as
+                    // any seen so far is the ambiguous case: it looks identical whether the total is
+                    // honest or one page short. There, one speculative page is fetched before
+                    // believing the header.
+                    //
+                    // The probe cannot cost correctness, only a single request: it may add records the
+                    // header disclaimed, and the guard above makes an empty or repeated answer mean
+                    // "the header was right after all". The one request is spent only when a fetch ends
+                    // exactly on a full page boundary, which for an honest server means the record
+                    // count is an exact multiple of the page size.
                     if (items.Count >= total)
-                        break;
-                    // More remain, so keep paging even though the page may look short. PRIDE caps
-                    // pageSize server-side (100 as of 2026-07-23) and then pages by the capped size,
-                    // so requesting 500 yields a 100-record "short" page that still has successors.
-                    // Treating that as the last page silently truncated the result.
+                    {
+                        if (pageItems.Count < largestPageSeen)
+                            break;
+                        verifyingTail = true;
+                    }
+                    else
+                    {
+                        // More remain, so keep paging even though the page may look short. PRIDE caps
+                        // pageSize server-side (100 as of 2026-07-23) and then pages by the capped size,
+                        // so requesting 500 yields a 100-record "short" page that still has successors.
+                        // Treating that as the last page silently truncated the result.
+                        verifyingTail = false;
+                    }
                 }
                 else if (pageItems.Count < pageSize)
                 {


### PR DESCRIPTION
## The nut

`GetProjectFilesAsync` trusted `total_records` in both directions. An **understated** one truncated the tail: the loop stopped at `files.Count >= total` and every file past the reported total was dropped, with no error. That is the mirror of the capped-`pageSize` bug #1102 fixed, and @Alexander-Sol named it on that PR as the one truncation path that was neither documented nor pinned.

This PR closes it — and first moves the paging loop somewhere it only has to be closed once.

## Three commits, in order

### 1. `refactor` — lift the pager into `GetAllPagesAsync<T>`

The loop was inline in `GetProjectFilesAsync`. PRIDE uses the same envelope (bare JSON array + `total_records` header) on more than one endpoint, and dataset search is about to need it, so it moves into a private generic helper rather than being copied.

Copying was the alternative, and this loop's history argues against it: #1102 needed two review rounds, and round one's own hardening *reintroduced* the silent manifest loss it was meant to prevent. A second copy is a second place for that to happen.

**Behavior-preserving.** Every termination rule keeps its order and its comment: empty-page stop, raw-body page identity, the identical-page `MzLibException` checked *before* the total comparison, `total_records` authoritative, short-page only as the no-header fallback, `MaxPages` backstop. **No test file is touched in this commit** — the existing 145 PRIDE offline tests and 8 live canaries pass unchanged, which is the proof. @acesnik verified this independently by running the same paging scenarios against base and the refactor separately; they agree on every one.

One deliberate text change: the identical-page message ended *"the project's file list may have changed mid-fetch"*, which would be wrong on a non-manifest endpoint; it now reads *"the result set"*. Everything else is verbatim — the accession still reaches the message, through a `subject` parameter, so each endpoint's failures stay as specific as they were.

### 2. `fix` — the tail probe

An understated total is only distinguishable by asking for one more page, so the loop asks — **but only when the answer is in doubt**. Truncation needs the last page to have been *full*: a server with more to give fills the page it is giving. So a page that is not full ends the fetch on the header's word, and a page that could be full buys one speculative request first.

### 3. `fix` — what the probe cost, and what it duplicated

Review (@acesnik) found three ways the commit above overstated itself. All three reproduce against a stub handler; all three are corrected here rather than reworded around.

**It fired on every single-page fetch.** `largestPageSeen` is updated before it is compared against, so "shorter than the largest page seen" is false on any page that *is* the largest — and page 0 always is. 50 files at the default `pageSize` of 100 cost two requests. Most PRIDE projects are single-page, so the stated cost was not merely wrong, it was backwards.

Fullness is now measured against different evidence on page 0 than afterwards, because the two pages carry different information:

```csharp
bool pageCouldBeFull = page == 0
    ? servedCount >= pageSize
    : servedCount >= largestPageSeen;
```

On a **later** page `largestPageSeen` is the only sound measure — PRIDE caps `pageSize` server-side, so a page of 100 against a requested 500 is full, and #1102 settled that the requested size cannot tell the two apart. On **page 0** there is no such evidence, so the requested `pageSize` decides: a first page shorter than what was asked for is the server running out. Exact whenever `pageSize` is at or below the cap, which is every default call. One gap remains, and only one — a single-page fetch requested *above* the cap comes back capped, so it looks short when it may be full. That is the same above-the-cap caveat the docstring already carries.

**It could duplicate a record.** A result set that grows between two requests repages itself: page 0 of a 2-record set is `[a, b]`, page 1 of the 3-record set it became is `[b, c]`. The server is correct throughout — the empty-page and identical-page comments both decline to fail on exactly this — but the probe appended anything not byte-identical, returning `[a, b, b, c]` where before the probe it returned `[a, b]`. A duplicate the caller cannot see is a worse failure than the truncation the probe exists to prevent, and unlike that truncation it lands on a *correct* server.

A probe's records are now matched against the page before them and the repeats dropped, on the **whole parsed JSON record** rather than any field of it. That distinction is the loop's own argument, not a loophole around it: a field is refused as identity because a value may repeat or be absent, so two *different* records can share one; a complete record cannot be confused with a different record that way. Two byte-equal records in one manifest are indistinguishable from each other anyway, so dropping one of a straddling pair costs nothing a caller could act on. Parsed rather than raw also means whitespace and property order no longer defeat it.

**"Never throw where it did not throw already" was too strong.** A server that ignores `page` and does not return byte-stable bodies never tripped the identical-page discard, so the fetch ran to the `MaxPages` backstop — 10,000 requests by default — where the total check used to stop it at page 0. The parsed record comparison recovers the whitespace and property-order cases. What is left is a server that ignores `page` **and** varies the *content* of the records it re-serves; nothing short of a record key the DTO does not carry would tell those pages apart. The claim is narrowed in the comment to say exactly that.

## What it costs now

| scenario | before this PR | after |
|---|---|---|
| 131 files, `pageSize` 100 | 2 requests, 131 files | unchanged |
| 50 files, `pageSize` 100 | 1 request | unchanged |
| record count an exact multiple of the page size | 1 request too few — silent truncation risk | +1 request |
| `total_records` understated (4 records reported as 2) | 2 of 4, no error | all 4 |
| manifest changes between requests | `[a, b]` | `[a, b, c]` |

The probe is spent only on a fetch that ends on a page that could be full. PXD012345 (131 files at the default page size) does not pay it; neither does any project holding fewer files than the page size.

## The test I flipped, and why it is not quiet

`GetProjectFilesAsync_TotalRecordsExactlyMatched_DoesNotFetchExtraPage` asserted exactly this behavior should not exist, and its own comment nominates it as the tripwire for weakening the `total_records` check. So it is flipped deliberately:

- renamed to `..._ProbesOncePastTheReportedTotal`, request count `1` → `2`;
- it **keeps** the ignores-`page` stub, because that is the probe's worst case — the probe walks straight into the identical-page guard, and returning the two files rather than throwing is precisely what makes the probe non-regressive;
- it now also asserts the repeated page is **discarded, not appended**.

Five tests added, each verified RED against the loop it pins:

- `..._TotalRecordsUnderstated_ReturnsEveryRecordAnyway` — 2 of 4 files in 1 request before. Asserts the request count too, so it discriminates: the file list alone would also pass if the loop ignored `total_records` entirely, which is not the fix.
- `..._TotalRecordsMatchedOnAShortPage_DoesNotProbe` — the ordinary multi-page fetch pays nothing.
- `..._SinglePageShorterThanRequested_DoesNotProbe` — 50 files at the default `pageSize` of 100, 1 request. This is the shape most callers hit, and nothing exercised it before, which is why the cost claim went unchallenged.
- `..._ResultSetGrowsBeforeTheProbe_DoesNotDuplicateARecord` — `[a, b, c]`, not `[a, b, b, c]`.
- `..._ProbeRepeatsARecordFormattedDifferently_StillDropsIt` — reordered properties and inserted whitespace are still recognised as a repeat.

## Rejected alternatives

- **A docstring caveat instead of a guard** (the lighter option @Alexander-Sol offered). Rejected because the loop now has exactly one home, which is the cheapest this fix will ever be, and because a documented silent truncation is still a silent truncation.
- **Always probing / paging until an empty page.** Correct, and it makes `total_records` unnecessary for termination — but it costs one extra request on *every* call, including the single-page common case, and changes the request count in most existing tests.
- **Learning the effective page size from page 0** for termination. Already rejected in #1102: it cannot distinguish a capped page from a genuinely short last page. Note `largestPageSeen` here decides only whether to *probe*, never when to terminate — a misjudgment costs a request, not a record.
- **Keying the dedup on a record field** (`fileName`, `accession`). Refused for the same reason the identical-page guard refuses it, and refused again here: a value may legitimately repeat or be absent, so it cannot carry a record's identity. The whole record can.
- **Guarding the dedup against an unparseable body or a mismatched length.** Both are unreachable through the public API — the caller reaches that line only by having deserialized the body element-for-element, on a page that follows another. Written as an invariant in the remarks rather than shipped as uncoverable branches, the same call made on the null-`Key` guard in #1102.

## Verification

- Full offline suite **5741 passed / 0 failed** (29 skipped)
- PRIDE offline **150**, live PRIDE **8/8** against the real service
- No public API change; no existing caller behaves differently

Stacked work: dataset search (`GET /search/projects`) consumes `GetAllPagesAsync<T>` and will name this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
