### PR TITLE
fix(nuget): declare the four dependencies missing from mzLib.nuspec

### DIFF
--- a/mzLib/mzLib.nuspec
+++ b/mzLib/mzLib.nuspec
@@ -30,6 +30,10 @@
     <dependency id="Microsoft.Extensions.ObjectPool" version="9.0.0" />
     <dependency id="TorchSharp" version="0.105.1" />
     <dependency id="libtorch-cpu" version="2.5.1" />
+    <dependency id="Nett" version="0.15.0" />
+    <dependency id="Newtonsoft.Json" version="13.0.4" />
+    <dependency id="TopDownProteomics" version="0.0.299" />
+    <dependency id="ZstdSharp.Port" version="0.8.7" />
   </group>
   <group targetFramework="net10.0-windows7.0">
     <!--net10.0 target with OxyPlot-->
@@ -50,6 +54,10 @@
     <dependency id="Microsoft.Extensions.ObjectPool" version="9.0.0" />
     <dependency id="TorchSharp" version="0.105.1" />
     <dependency id="libtorch-cpu" version="2.5.1" />
+    <dependency id="Nett" version="0.15.0" />
+    <dependency id="Newtonsoft.Json" version="13.0.4" />
+    <dependency id="TopDownProteomics" version="0.0.299" />
+    <dependency id="ZstdSharp.Port" version="0.8.7" />
   </group>
 </dependencies>
   </metadata>


### PR DESCRIPTION
Root-cause fix for the top-down ProForma crash. Pairs with MetaMorpheus#2740, which is the stopgap.

## The problem

`mzLib/mzLib.nuspec` maintains its `<dependencies>` groups **by hand**. Nothing generates them from the csprojs, so a `PackageReference` added to a shipping project never reaches consumers of the mzLib NuGet package unless someone remembers to edit the nuspec too. Four have drifted out:

| package | version | referenced by |
|---|---|---|
| `Nett` | 0.15.0 | SpectralAveraging |
| `Newtonsoft.Json` | 13.0.4 | PredictionClients, UsefulProteomicsDatabases |
| `TopDownProteomics` | 0.0.299 | Readers, UsefulProteomicsDatabases |
| `ZstdSharp.Port` | 0.8.7 | Readers |

## Why it matters

**`TopDownProteomics` is already breaking top-down Jenkins.** Because mzLib never declared it, NuGet had nothing to unify against, so MetaMorpheus's own stale direct reference (0.0.297) was free to win nearest-wins resolution. `Readers` is compiled against 0.0.299; .NET rolls assembly versions forward but never backward, so `ToProFormaString` threw:

```
System.IO.FileNotFoundException: Could not load file or assembly
'TopDownProteomics, Version=0.0.299.0, Culture=neutral, PublicKeyToken=null'
```

...for an assembly that was sitting in the output folder the entire time. That is why the error reads as a missing file rather than a version conflict.

**`ZstdSharp.Port` is the same bug one step earlier.** Nothing supplies it to MetaMorpheus at all — `ZstdSharp.dll` is absent from the output folder outright — so any zstd-compressed read fails identically. Not yet reported only because nobody has hit that path.

`Nett` and `Newtonsoft.Json` are currently masked by consumers that happen to reference compatible versions themselves. They are latent for any consumer that does not (FlashLFQ, ProteaseGuru, the language bindings).

## The change

Four `<dependency>` lines added to each of the two target-framework groups. Nothing else. Every declared version matches what the csprojs reference.

## Verification

- nuspec parses as well-formed XML; both groups intact (20 and 21 deps).
- Cross-checked every declared version against the csproj `PackageReference` set — all four additions match exactly.
- CI's `nuget pack` step exercises the packaging path.

## Follow-ups (deliberately not in this PR)

The same audit found **pre-existing version mismatches** where the nuspec declares an older version than mzLib builds against:

| package | nuspec says | csproj says |
|---|---|---|
| `Microsoft.ML` | 2.0.0 | **3.0.1** |
| `Microsoft.ML.FastTree` | 2.0.0 | **3.0.1** |
| `NetSerializer` | 4.1.1 | **4.1.2** |

These are the same drift class and the same latent failure mode. I left them out because correcting them changes what existing consumers resolve to (an ML.NET major bump is not a quiet change), so it deserves its own review rather than riding along with a crash fix.

Worth considering generating the dependency list from the csprojs at pack time, or adding a CI check that diffs the two — this will drift again otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)