### PR TITLE
Find PRIDE projects by keyword (search/projects)

### DIFF
--- a/mzLib/Test/DatabaseTests/PrideProjectSearchTests.cs
+++ b/mzLib/Test/DatabaseTests/PrideProjectSearchTests.cs
@@ -44,25 +44,46 @@ public class PrideProjectSearchTests
 
     /// <summary>
     /// One PRIDE search hit in the real v3 wire shape, captured live from
-    /// <c>search/projects?keyword=liver</c> on 2026-08-21 (PXD068742) and trimmed to two entries per
-    /// collection. Every collection is an array of plain STRINGS — no CvParam, no contact objects, no
-    /// structured references — which is the whole reason this endpoint needs its own DTO. Note also
-    /// the bare calendar dates, the "organismsPart" spelling (the metadata endpoint says
-    /// "organismParts"), the dynamic "highlights" map carrying &lt;em&gt; markup, and the
-    /// pre-mangled reference string.
+    /// <c>search/projects?keyword=hepatocyte</c> on 2026-08-21 (PXD068742).
     /// </summary>
+    /// <remarks>
+    /// TRIMMED, NOT EDITED: collections are cut to their first two entries and free text is truncated
+    /// with an ellipsis. No field was added, removed, renamed or given a different value. That
+    /// distinction matters — an earlier revision of this fixture carried an <c>sdrf</c> member and
+    /// invented <c>yearlyDownloads</c> counts, neither of which the server sends for this project, so
+    /// two tests pinned numbers PRIDE does not serve. Re-capture rather than hand-edit.
+    /// <para>
+    /// Note what the shape shows: every collection is an array of plain STRINGS — no CvParam, no
+    /// contact objects, no structured references — which is the whole reason this endpoint needs its
+    /// own DTO. Also the bare calendar dates, the "organismsPart" spelling (the metadata endpoint says
+    /// "organismParts"), the dynamic "highlights" map carrying &lt;em&gt; markup, and the pre-mangled
+    /// reference string with its literal "null" segments.
+    /// </para>
+    /// <para>
+    /// This project reports NO <c>sdrf</c> member at all, and its <c>doi</c>, <c>projectTags</c> and
+    /// <c>diseases</c> are empty. Those are exercised against
+    /// <see cref="PopulatedOptionalsHitJson"/> instead — asserting them empty here would pass whether
+    /// the property bound correctly or bound nothing at all.
+    /// </para>
+    /// </remarks>
     private const string SearchHitJson =
         """
         {
           "accession": "PXD068742",
-          "title": "Culturing of primary mouse hepatocytes",
-          "projectDescription": "Primary hepatocytes are a commonly used in vitro model.",
-          "dataProcessingProtocol": "The FragPipe-generated master spectral library was used.",
-          "sampleProcessingProtocol": "Samples were homogenized in 4% SDS buffer.",
+          "title": "Culturing of primary mouse hepatocytes is associated with major change...",
+          "projectDescription": "Primary hepatocytes are a commonly used in vitro model for studying li...",
+          "dataProcessingProtocol": "The FragPipe-generated master spectral library was used in concert wit...",
+          "sampleProcessingProtocol": "Samples were homogenized in 4% SDS buffer (0.1 M TrisHCl and 4% SDS),...",
           "projectTags": [],
-          "keywords": ["Cell culture", "Hepatocytes"],
+          "keywords": [
+            "Cell culture",
+            "Hepatocytes"
+          ],
           "doi": "",
-          "otherOmicsLinks": ["geo:GSE280301", "geo:GSE173406"],
+          "otherOmicsLinks": [
+            "geo:GSE280301",
+            "geo:GSE173406"
+          ],
           "submissionType": "PARTIAL",
           "publicationDate": "2025-09-25",
           "updatedDate": "2025-09-23",
@@ -73,23 +94,143 @@ public class PrideProjectSearchTests
           "hubCount": 47,
           "organicCount": 12,
           "percentile": 5,
-          "yearlyDownloads": [{ "year": "2025", "count": 91 }, { "year": "2026", "count": 20 }],
-          "submitters": ["Ben Stocks"],
-          "labPIs": ["Jonas T. Treebak"],
-          "affiliations": ["Novo Nordisk Foundation Center for Basic Metabolic Research"],
-          "instruments": ["timsTOF Pro 2"],
-          "softwares": ["FragPipe", "DIA-NN"],
-          "quantificationMethods": ["diaPASEF"],
-          "sampleAttributes": ["hepatocyte", "liver"],
-          "organisms": ["Mus musculus (mouse)"],
-          "organismsPart": ["Hepatocyte", "Liver"],
+          "yearlyDownloads": [
+            {
+              "year": "2025",
+              "count": 33
+            },
+            {
+              "year": "2026",
+              "count": 78
+            }
+          ],
+          "submitters": [
+            "Ben Stocks"
+          ],
+          "labPIs": [
+            "Jonas T. Treebak"
+          ],
+          "affiliations": [
+            "Novo Nordisk Foundation Center for Basic Metabolic Research"
+          ],
+          "instruments": [
+            "timsTOF Pro 2"
+          ],
+          "softwares": [
+            "FragPipe",
+            "DIA-NN"
+          ],
+          "quantificationMethods": [
+            "diaPASEF"
+          ],
+          "sampleAttributes": [
+            "hepatocyte",
+            "liver"
+          ],
+          "organisms": [
+            "Mus musculus (mouse)"
+          ],
+          "organismsPart": [
+            "Hepatocyte",
+            "Liver"
+          ],
           "diseases": [],
-          "references": ["null--pubMed:0--doi: 10.1097/HC9.0000000000000795"],
-          "experimentTypes": ["Data-independent acquisition"],
-          "projectFileNames": ["cs_quant.pg_matrix.tsv", "report.stats.tsv"],
-          "sdrf": "",
+          "references": [
+            "null--pubMed:0--doi: 10.1097/HC9.0000000000000795"
+          ],
+          "experimentTypes": [
+            "Data-independent acquisition"
+          ],
+          "projectFileNames": [
+            "cs_quant.pg_matrix.tsv",
+            "20210930_PRI_TIMS4_PRIEvo1_P094_R0275_44min_S12_S2-D12_1_2797.d.rar"
+          ],
           "highlights": {
-            "projectDescription": ["Primary <em>hepatocytes</em> are a commonly used in vitro model."]
+            "projectDescription": [
+              "Cultures contained ~10% non-<em>hepatocytes</em>, including stellate- and dedifferentiat..."
+            ]
+          }
+        }
+        """;
+
+    /// <summary>
+    /// A second live hit (PXD080181, same capture date) carrying optional members the primary fixture
+    /// leaves empty: a populated <c>sdrf</c>, <c>projectTags</c> and <c>diseases</c>. Trimmed on the
+    /// same terms — entries dropped and prose truncated, nothing invented.
+    /// </summary>
+    /// <remarks>
+    /// It exists so those members are pinned by an assertion that can actually FAIL. Note <c>sdrf</c>
+    /// is not a file or a filename: it is a flattened bag of the SDRF's term values, which is why the
+    /// DTO documents it that way.
+    /// </remarks>
+    private const string PopulatedOptionalsHitJson =
+        """
+        {
+          "accession": "PXD080181",
+          "title": "Platycodi Radix Extract Prevents Hepatic Steatosis by Enhancing Bile A...",
+          "projectDescription": "This project investigated the molecular mechanism by which *Platycodi...",
+          "dataProcessingProtocol": "The original MASCOT 2.4 result files were no longer available, so the...",
+          "sampleProcessingProtocol": "Five-week-old wild-type male C57BL/6J mice (Orient Bio, Seongnam, Kore...",
+          "projectTags": [
+            "Liver (b/d-hpp)",
+            "Human proteome project"
+          ],
+          "keywords": [
+            "Obesity",
+            "Nafld"
+          ],
+          "doi": "",
+          "submissionType": "PARTIAL",
+          "publicationDate": "2026-07-04",
+          "updatedDate": "2026-06-25",
+          "submissionDate": "2026-06-25",
+          "downloadCount": 0,
+          "avgDownloadsPerFile": 0.0,
+          "percentile": 0,
+          "submitters": [
+            "Wooyoung Kim"
+          ],
+          "labPIs": [
+            "Edmond Changkyun Park"
+          ],
+          "affiliations": [
+            "Korean Basic Science Instittue"
+          ],
+          "instruments": [
+            "LTQ Orbitrap Velos"
+          ],
+          "softwares": [],
+          "quantificationMethods": [],
+          "sampleAttributes": [
+            "liver",
+            "Mus musculus (Mouse)"
+          ],
+          "organisms": [
+            "Mus musculus",
+            "Mus musculus (mouse)"
+          ],
+          "organismsPart": [
+            "Liver"
+          ],
+          "diseases": [
+            "Normal",
+            "Non-alcoholic fatty liver disease"
+          ],
+          "references": [
+            "Kim W, Baek WH, Yun SH, Lee H, Kim MJ, Lee SY, Kim GH, Kim SI, Jeong H..."
+          ],
+          "experimentTypes": [
+            "Data-dependent acquisition"
+          ],
+          "sdrf": "Nt=label free sample;ac=ms:1002038 Nt=trypsin;ac=ms:1001251 Mus muscul...",
+          "projectFileNames": [
+            "150609_YSH_LIVER_HFD_10_06.raw",
+            "150811_YSH_LIVER_NCD_10_07.raw"
+          ],
+          "highlights": {
+            "sdrf": [
+              "...ac=ms:1001742 Non-alcoholic fatty liver <em>disease</em>"
+            ]
           }
         }
         """;
@@ -114,13 +255,15 @@ public class PrideProjectSearchTests
         Assert.Multiple(() =>
         {
             Assert.That(hit.Accession, Is.EqualTo("PXD068742"));
-            Assert.That(hit.Title, Is.EqualTo("Culturing of primary mouse hepatocytes"));
+            Assert.That(hit.Title, Does.StartWith("Culturing of primary mouse hepatocytes"));
             Assert.That(hit.ProjectDescription, Does.StartWith("Primary hepatocytes"));
             Assert.That(hit.DataProcessingProtocol, Does.Contain("FragPipe"));
             Assert.That(hit.SampleProcessingProtocol, Does.Contain("SDS buffer"));
             Assert.That(hit.SubmissionType, Is.EqualTo("PARTIAL"));
-            Assert.That(hit.Doi, Is.Empty);
-            Assert.That(hit.Sdrf, Is.Empty);
+            // Doi, Sdrf, ProjectTags and Diseases are deliberately NOT asserted here. They are empty
+            // (Sdrf absent outright) for this project, so "Is.Empty" would hold whether the property
+            // bound correctly or bound nothing at all — the exact silent-bind failure OrganismParts
+            // has its own test for. They are pinned against PopulatedOptionalsHitJson instead.
 
             // Bare calendar dates: no time component, and no offset attached from the local machine.
             Assert.That(hit.SubmissionDate, Is.EqualTo(new DateTime(2025, 9, 23)));
@@ -135,16 +278,14 @@ public class PrideProjectSearchTests
             Assert.That(hit.Softwares, Is.EqualTo(new[] { "FragPipe", "DIA-NN" }));
             Assert.That(hit.QuantificationMethods, Is.EqualTo(new[] { "diaPASEF" }));
             Assert.That(hit.Organisms, Is.EqualTo(new[] { "Mus musculus (mouse)" }));
-            Assert.That(hit.Diseases, Is.Empty);
             Assert.That(hit.ExperimentTypes, Is.EqualTo(new[] { "Data-independent acquisition" }));
             Assert.That(hit.SampleAttributes, Is.EqualTo(new[] { "hepatocyte", "liver" }));
             Assert.That(hit.Keywords, Is.EqualTo(new[] { "Cell culture", "Hepatocytes" }));
-            Assert.That(hit.ProjectTags, Is.Empty);
             Assert.That(hit.Submitters, Is.EqualTo(new[] { "Ben Stocks" }));
             Assert.That(hit.LabPIs, Is.EqualTo(new[] { "Jonas T. Treebak" }));
             Assert.That(hit.Affiliations, Is.EqualTo(new[] { "Novo Nordisk Foundation Center for Basic Metabolic Research" }));
             Assert.That(hit.References, Is.EqualTo(new[] { "null--pubMed:0--doi: 10.1097/HC9.0000000000000795" }));
-            Assert.That(hit.ProjectFileNames, Is.EqualTo(new[] { "cs_quant.pg_matrix.tsv", "report.stats.tsv" }));
+            Assert.That(hit.ProjectFileNames, Is.EqualTo(new[] { "cs_quant.pg_matrix.tsv", "20210930_PRI_TIMS4_PRIEvo1_P094_R0275_44min_S12_S2-D12_1_2797.d.rar" }));
             Assert.That(hit.OtherOmicsLinks, Is.EqualTo(new[] { "geo:GSE280301", "geo:GSE173406" }));
 
             Assert.That(hit.DownloadCount, Is.EqualTo(111));
@@ -155,11 +296,117 @@ public class PrideProjectSearchTests
             Assert.That(hit.OrganicCount, Is.EqualTo(12));
 
             Assert.That(hit.YearlyDownloads.Select(y => y.Year), Is.EqualTo(new[] { "2025", "2026" }));
-            Assert.That(hit.YearlyDownloads.Select(y => y.Count), Is.EqualTo(new long[] { 91, 20 }));
+            Assert.That(hit.YearlyDownloads.Select(y => y.Count), Is.EqualTo(new long[] { 33, 78 }));
 
-            Assert.That(hit.Highlights.Keys, Is.EqualTo(new[] { "projectDescription" }));
+            // Membership, not order: PRIDE serialises `highlights` from an unordered map, so its key
+            // order varies between identical requests (observed live 2026-08-21). Safe against this
+            // single-key stub, but an order-sensitive assertion here would invite a flaky live one.
+            Assert.That(hit.Highlights.Keys, Is.EquivalentTo(new[] { "projectDescription" }));
             Assert.That(hit.Highlights["projectDescription"].Single(), Does.Contain("<em>hepatocytes</em>"));
         });
+    }
+
+    /// <summary>
+    /// The optional members the primary fixture leaves empty, asserted against a hit that actually
+    /// carries them. Without this they would be pinned only by "Is.Empty" assertions that pass
+    /// whether the property binds or not — the same silent-bind failure OrganismParts guards against.
+    /// </summary>
+    [Test]
+    public async Task SearchProjectsAsync_OptionalMembers_BindWhenTheServerSendsThem()
+    {
+        var handler = new StubHandler(_ => JsonResponse(Array(PopulatedOptionalsHitJson)));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        PrideProjectSearchResult hit = (await client.SearchProjectsAsync("liver")).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hit.Accession, Is.EqualTo("PXD080181"));
+            Assert.That(hit.ProjectTags, Is.EqualTo(new[] { "Liver (b/d-hpp)", "Human proteome project" }));
+            Assert.That(hit.Diseases, Is.EqualTo(new[] { "Normal", "Non-alcoholic fatty liver disease" }));
+            // Not a filename and not a URL — a flattened bag of the SDRF's term values.
+            Assert.That(hit.Sdrf, Does.StartWith("Nt=label free sample;ac=ms:1002038"));
+        });
+    }
+
+    /// <summary>
+    /// Doi gets its own minimal probe because neither live fixture carries one — only 77 of 421
+    /// sampled hits had a DOI, and both captured projects fall in the majority that do not.
+    /// </summary>
+    /// <remarks>
+    /// This JSON is SYNTHETIC and says so, unlike the two captured fixtures above. It asserts one
+    /// thing only: that the property binds the wire name. That is worth pinning because `doi` is one
+    /// of ten members that bind through Newtonsoft's case-insensitive fallback rather than an exact
+    /// match, so nothing but a test would notice if that fallback ever went away.
+    /// </remarks>
+    [Test]
+    public async Task SearchProjectsAsync_Doi_BindsFromTheWire()
+    {
+        const string hitWithDoi = """{ "accession": "PXD000001", "doi": "10.6019/PXD000001" }""";
+        var handler = new StubHandler(_ => JsonResponse(Array(hitWithDoi)));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        PrideProjectSearchResult hit = (await client.SearchProjectsAsync("liver")).Single();
+
+        Assert.That(hit.Doi, Is.EqualTo("10.6019/PXD000001"));
+    }
+
+    // ---- mid-fetch drift ----------------------------------------------------
+
+    /// <summary>
+    /// PRIDE pages a LIVE index, so a result set can change between two requests of one fetch. When a
+    /// project is published mid-fetch every later record shifts down a position, and a record that was
+    /// on page 1 is served again on page 2 — verified live on 2026-08-21, where a project leaving the
+    /// "liver" set slid the whole window by one.
+    /// </summary>
+    /// <remarks>
+    /// The shared pager cannot defend this: it refuses to treat any FIELD as a record's identity,
+    /// because the file manifest it was written for has no unique key. A search hit does — accession
+    /// is exactly that — so the reasoning does not carry over, and search dedups on it. The mirror
+    /// case (a record SKIPPED because the window slid the other way) is not fixable without a stable
+    /// cursor the API does not offer, and is documented on the method rather than claimed away.
+    /// </remarks>
+    [Test]
+    public async Task SearchProjectsAsync_ResultSetGrowsMidFetch_DoesNotReturnADuplicateProject()
+    {
+        var handler = new StubHandler(request =>
+        {
+            string uri = request.RequestUri.ToString();
+            // page 0 of the set as it was; page 1 after a new project pushed everything down one, so
+            // PXD000002 is served a second time.
+            if (uri.Contains("page=0")) return JsonResponse(Array(HitJson("PXD000001"), HitJson("PXD000002")), totalRecords: 4);
+            if (uri.Contains("page=1")) return JsonResponse(Array(HitJson("PXD000002"), HitJson("PXD000003")), totalRecords: 4);
+            return JsonResponse("[ ]", totalRecords: 4);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        List<PrideProjectSearchResult> hits = await client.SearchProjectsAsync("liver", pageSize: 2);
+
+        Assert.That(hits.Select(h => h.Accession),
+            Is.EqualTo(new[] { "PXD000001", "PXD000002", "PXD000003" }),
+            "a project served on two pages must be returned once");
+    }
+
+    /// <summary>
+    /// The dedup must not mistake DISTINCT projects for repeats — it keys on accession precisely
+    /// because that is a real identity, so nothing else about a hit may affect whether it survives.
+    /// </summary>
+    [Test]
+    public async Task SearchProjectsAsync_DistinctProjects_AreAllKept()
+    {
+        var handler = new StubHandler(request =>
+        {
+            string uri = request.RequestUri.ToString();
+            if (uri.Contains("page=0")) return JsonResponse(Array(HitJson("PXD000001"), HitJson("PXD000002")), totalRecords: 4);
+            if (uri.Contains("page=1")) return JsonResponse(Array(HitJson("PXD000003"), HitJson("PXD000004")), totalRecords: 4);
+            return JsonResponse("[ ]", totalRecords: 4);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        List<PrideProjectSearchResult> hits = await client.SearchProjectsAsync("liver", pageSize: 2);
+
+        Assert.That(hits.Select(h => h.Accession),
+            Is.EqualTo(new[] { "PXD000001", "PXD000002", "PXD000003", "PXD000004" }));
     }
 
     /// <summary>
@@ -308,19 +555,58 @@ public class PrideProjectSearchTests
     [Test]
     public async Task SearchProjectsAsync_KeywordWithQuerySyntax_IsEscaped()
     {
-        var handler = new StubHandler(_ => JsonResponse("[]", totalRecords: 0));
+        var handler = new StubHandler(_ => JsonResponse("[ ]", totalRecords: 0));
         using var client = new PrideArchiveClient(new HttpClient(handler));
 
-        await client.SearchProjectsAsync("a&pageSize=1");
+        await client.SearchProjectsAsync("a&pageSize=1#b");
 
         string uri = handler.RequestedUris.Single();
         Assert.Multiple(() =>
         {
-            Assert.That(uri, Does.Contain("keyword=a%26pageSize%3D1"));
+            Assert.That(uri, Does.Contain("keyword=a%26pageSize%3D1%23b"));
             // The injected pageSize must not have displaced the real one.
             Assert.That(uri, Does.Contain("pageSize=100"));
             Assert.That(uri.Split("pageSize=").Length - 1, Is.EqualTo(1), "the keyword must not add a second pageSize parameter");
+            // '#' is the dangerous one, and the reason this test carries it: unescaped it is a FRAGMENT
+            // delimiter, so HttpClient sends nothing after it -- truncating the keyword AND deleting
+            // pageSize and page from the request, which then silently fall back to server defaults.
+            // Verified live 2026-08-21: the response grew from 12 KB to ~1 MB. Losing `page` would
+            // defeat paging itself, which is the failure GetAllPagesAsync exists to prevent.
+            Assert.That(uri, Does.Contain("page=0"), "the keyword must not be able to strip the paging parameters");
         });
+    }
+
+    /// <summary>
+    /// An over-long keyword is refused here rather than sent, because PRIDE answers it with HTTP 500
+    /// (observed at 2000 characters on 2026-08-21) rather than a 400 or a 414.
+    /// </summary>
+    /// <remarks>
+    /// A 500 is the one status that cannot be told apart from an outage: ExternalServiceTestHelper
+    /// reads it as "PRIDE is down" and SKIPS, and a caller reading the exception message sees the same
+    /// thing. So without this guard a caller's own bug would masquerade as an EBI outage -- and a live
+    /// test covering it would go green by skipping. Failing fast at the call site is the same posture
+    /// the method already takes for a blank keyword and a non-positive page size.
+    /// </remarks>
+    [Test]
+    public void SearchProjectsAsync_KeywordLongerThanTheCap_ThrowsWithoutSendingAnything()
+    {
+        var handler = new StubHandler(_ => JsonResponse("[ ]", totalRecords: 0));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        Assert.ThrowsAsync<ArgumentException>(
+            () => client.SearchProjectsAsync(new string('a', PrideArchiveClient.MaxKeywordLength + 1)));
+        Assert.That(handler.RequestedUris, Is.Empty, "the request must not reach PRIDE at all");
+    }
+
+    [Test]
+    public async Task SearchProjectsAsync_KeywordExactlyAtTheCap_IsSent()
+    {
+        var handler = new StubHandler(_ => JsonResponse("[ ]", totalRecords: 0));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        await client.SearchProjectsAsync(new string('a', PrideArchiveClient.MaxKeywordLength));
+
+        Assert.That(handler.RequestedUris.Count, Is.EqualTo(1), "the cap is inclusive");
     }
 
     // ---- argument and transport contracts -----------------------------------

--- a/mzLib/Test/DatabaseTests/PrideProjectSearchTests.cs
+++ b/mzLib/Test/DatabaseTests/PrideProjectSearchTests.cs
@@ -1,0 +1,462 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MzLibUtil;
+using UsefulProteomicsDatabases;
+
+namespace Test.DatabaseTests;
+
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class PrideProjectSearchTests
+{
+    // ---- test doubles -------------------------------------------------------
+
+    /// <summary>An HttpMessageHandler that returns a caller-supplied response and records request URIs.</summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+        public List<string> RequestedUris { get; } = new();
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestedUris.Add(request.RequestUri.ToString());
+            return Task.FromResult(_responder(request));
+        }
+    }
+
+    private static HttpResponseMessage JsonResponse(string body, HttpStatusCode status = HttpStatusCode.OK, long? totalRecords = null)
+    {
+        var response = new HttpResponseMessage(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+        if (totalRecords.HasValue)
+            response.Headers.TryAddWithoutValidation("total_records", totalRecords.Value.ToString());
+        return response;
+    }
+
+    /// <summary>
+    /// One PRIDE search hit in the real v3 wire shape, captured live from
+    /// <c>search/projects?keyword=liver</c> on 2026-08-21 (PXD068742) and trimmed to two entries per
+    /// collection. Every collection is an array of plain STRINGS — no CvParam, no contact objects, no
+    /// structured references — which is the whole reason this endpoint needs its own DTO. Note also
+    /// the bare calendar dates, the "organismsPart" spelling (the metadata endpoint says
+    /// "organismParts"), the dynamic "highlights" map carrying &lt;em&gt; markup, and the
+    /// pre-mangled reference string.
+    /// </summary>
+    private const string SearchHitJson =
+        """
+        {
+          "accession": "PXD068742",
+          "title": "Culturing of primary mouse hepatocytes",
+          "projectDescription": "Primary hepatocytes are a commonly used in vitro model.",
+          "dataProcessingProtocol": "The FragPipe-generated master spectral library was used.",
+          "sampleProcessingProtocol": "Samples were homogenized in 4% SDS buffer.",
+          "projectTags": [],
+          "keywords": ["Cell culture", "Hepatocytes"],
+          "doi": "",
+          "otherOmicsLinks": ["geo:GSE280301", "geo:GSE173406"],
+          "submissionType": "PARTIAL",
+          "publicationDate": "2025-09-25",
+          "updatedDate": "2025-09-23",
+          "submissionDate": "2025-09-23",
+          "downloadCount": 111,
+          "avgDownloadsPerFile": 3.9642856,
+          "botCount": 52,
+          "hubCount": 47,
+          "organicCount": 12,
+          "percentile": 5,
+          "yearlyDownloads": [{ "year": "2025", "count": 91 }, { "year": "2026", "count": 20 }],
+          "submitters": ["Ben Stocks"],
+          "labPIs": ["Jonas T. Treebak"],
+          "affiliations": ["Novo Nordisk Foundation Center for Basic Metabolic Research"],
+          "instruments": ["timsTOF Pro 2"],
+          "softwares": ["FragPipe", "DIA-NN"],
+          "quantificationMethods": ["diaPASEF"],
+          "sampleAttributes": ["hepatocyte", "liver"],
+          "organisms": ["Mus musculus (mouse)"],
+          "organismsPart": ["Hepatocyte", "Liver"],
+          "diseases": [],
+          "references": ["null--pubMed:0--doi: 10.1097/HC9.0000000000000795"],
+          "experimentTypes": ["Data-independent acquisition"],
+          "projectFileNames": ["cs_quant.pg_matrix.tsv", "report.stats.tsv"],
+          "sdrf": "",
+          "highlights": {
+            "projectDescription": ["Primary <em>hepatocytes</em> are a commonly used in vitro model."]
+          }
+        }
+        """;
+
+    /// <summary>A minimal hit carrying only the accession — enough to identify it while paging.</summary>
+    private static string HitJson(string accession) => $$"""{ "accession": "{{accession}}" }""";
+
+    private static string Array(params string[] objects) => "[" + string.Join(",", objects) + "]";
+
+    // ---- deserialization ----------------------------------------------------
+
+    [Test]
+    public async Task SearchProjectsAsync_RealWireShape_PopulatesEveryField()
+    {
+        var handler = new StubHandler(_ => JsonResponse(Array(SearchHitJson)));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        List<PrideProjectSearchResult> hits = await client.SearchProjectsAsync("liver");
+
+        Assert.That(hits.Count, Is.EqualTo(1));
+        PrideProjectSearchResult hit = hits[0];
+        Assert.Multiple(() =>
+        {
+            Assert.That(hit.Accession, Is.EqualTo("PXD068742"));
+            Assert.That(hit.Title, Is.EqualTo("Culturing of primary mouse hepatocytes"));
+            Assert.That(hit.ProjectDescription, Does.StartWith("Primary hepatocytes"));
+            Assert.That(hit.DataProcessingProtocol, Does.Contain("FragPipe"));
+            Assert.That(hit.SampleProcessingProtocol, Does.Contain("SDS buffer"));
+            Assert.That(hit.SubmissionType, Is.EqualTo("PARTIAL"));
+            Assert.That(hit.Doi, Is.Empty);
+            Assert.That(hit.Sdrf, Is.Empty);
+
+            // Bare calendar dates: no time component, and no offset attached from the local machine.
+            Assert.That(hit.SubmissionDate, Is.EqualTo(new DateTime(2025, 9, 23)));
+            Assert.That(hit.PublicationDate, Is.EqualTo(new DateTime(2025, 9, 25)));
+            Assert.That(hit.UpdatedDate, Is.EqualTo(new DateTime(2025, 9, 23)));
+            Assert.That(hit.SubmissionDate.TimeOfDay, Is.EqualTo(TimeSpan.Zero));
+
+            // Every controlled-vocabulary collection arrives FLATTENED to display strings. This is the
+            // assertion that would fail first if PRIDE ever served CvParam objects here, which is the
+            // drift that would invalidate the whole DTO.
+            Assert.That(hit.Instruments, Is.EqualTo(new[] { "timsTOF Pro 2" }));
+            Assert.That(hit.Softwares, Is.EqualTo(new[] { "FragPipe", "DIA-NN" }));
+            Assert.That(hit.QuantificationMethods, Is.EqualTo(new[] { "diaPASEF" }));
+            Assert.That(hit.Organisms, Is.EqualTo(new[] { "Mus musculus (mouse)" }));
+            Assert.That(hit.Diseases, Is.Empty);
+            Assert.That(hit.ExperimentTypes, Is.EqualTo(new[] { "Data-independent acquisition" }));
+            Assert.That(hit.SampleAttributes, Is.EqualTo(new[] { "hepatocyte", "liver" }));
+            Assert.That(hit.Keywords, Is.EqualTo(new[] { "Cell culture", "Hepatocytes" }));
+            Assert.That(hit.ProjectTags, Is.Empty);
+            Assert.That(hit.Submitters, Is.EqualTo(new[] { "Ben Stocks" }));
+            Assert.That(hit.LabPIs, Is.EqualTo(new[] { "Jonas T. Treebak" }));
+            Assert.That(hit.Affiliations, Is.EqualTo(new[] { "Novo Nordisk Foundation Center for Basic Metabolic Research" }));
+            Assert.That(hit.References, Is.EqualTo(new[] { "null--pubMed:0--doi: 10.1097/HC9.0000000000000795" }));
+            Assert.That(hit.ProjectFileNames, Is.EqualTo(new[] { "cs_quant.pg_matrix.tsv", "report.stats.tsv" }));
+            Assert.That(hit.OtherOmicsLinks, Is.EqualTo(new[] { "geo:GSE280301", "geo:GSE173406" }));
+
+            Assert.That(hit.DownloadCount, Is.EqualTo(111));
+            Assert.That(hit.AvgDownloadsPerFile, Is.EqualTo(3.9642856).Within(1e-7));
+            Assert.That(hit.Percentile, Is.EqualTo(5));
+            Assert.That(hit.BotCount, Is.EqualTo(52));
+            Assert.That(hit.HubCount, Is.EqualTo(47));
+            Assert.That(hit.OrganicCount, Is.EqualTo(12));
+
+            Assert.That(hit.YearlyDownloads.Select(y => y.Year), Is.EqualTo(new[] { "2025", "2026" }));
+            Assert.That(hit.YearlyDownloads.Select(y => y.Count), Is.EqualTo(new long[] { 91, 20 }));
+
+            Assert.That(hit.Highlights.Keys, Is.EqualTo(new[] { "projectDescription" }));
+            Assert.That(hit.Highlights["projectDescription"].Single(), Does.Contain("<em>hepatocytes</em>"));
+        });
+    }
+
+    /// <summary>
+    /// The one member that cannot bind by convention. PRIDE spells the field "organismsPart" here and
+    /// "organismParts" on projects/{accession}; the DTO keeps the metadata spelling so the two agree,
+    /// which only works because of the explicit JsonProperty. Without it the property binds nothing
+    /// and silently returns an empty list — a wrong answer, not an error — so it gets its own test.
+    /// </summary>
+    [Test]
+    public async Task SearchProjectsAsync_OrganismsPartWireName_BindsToOrganismParts()
+    {
+        var handler = new StubHandler(_ => JsonResponse(Array(SearchHitJson)));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        List<PrideProjectSearchResult> hits = await client.SearchProjectsAsync("liver");
+
+        Assert.That(hits[0].OrganismParts, Is.EqualTo(new[] { "Hepatocyte", "Liver" }));
+    }
+
+    /// <summary>
+    /// Members PRIDE omits arrive as empty collections and zeros, never null — the guarantee the DTO's
+    /// remarks make. Several search fields are genuinely sparse (yearlyDownloads was absent from 61 of
+    /// 100 hits in the capture sample), so a caller dereferencing one is the ordinary case.
+    /// </summary>
+    [Test]
+    public async Task SearchProjectsAsync_OmittedMembers_AreEmptyNotNull()
+    {
+        var handler = new StubHandler(_ => JsonResponse(Array(HitJson("PXD000001"))));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        PrideProjectSearchResult hit = (await client.SearchProjectsAsync("liver")).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hit.Accession, Is.EqualTo("PXD000001"));
+            Assert.That(hit.Title, Is.Empty);
+            Assert.That(hit.Keywords, Is.Empty);
+            Assert.That(hit.Instruments, Is.Empty);
+            Assert.That(hit.OrganismParts, Is.Empty);
+            Assert.That(hit.YearlyDownloads, Is.Empty);
+            Assert.That(hit.OtherOmicsLinks, Is.Empty);
+            Assert.That(hit.Highlights, Is.Empty);
+            Assert.That(hit.BotCount, Is.Zero);
+            Assert.That(hit.AvgDownloadsPerFile, Is.Zero);
+            Assert.That(hit.SubmissionDate, Is.EqualTo(default(DateTime)));
+        });
+    }
+
+    // ---- paging -------------------------------------------------------------
+
+    [Test]
+    public async Task SearchProjectsAsync_PagesUntilTotalRecords_ConcatenatesAllHits()
+    {
+        const long total = 3;
+        var handler = new StubHandler(request =>
+        {
+            string uri = request.RequestUri.ToString();
+            if (uri.Contains("page=0")) return JsonResponse(Array(HitJson("PXD000001"), HitJson("PXD000002")), totalRecords: total);
+            if (uri.Contains("page=1")) return JsonResponse(Array(HitJson("PXD000003")), totalRecords: total);
+            return JsonResponse("[]", totalRecords: total);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        List<PrideProjectSearchResult> hits = await client.SearchProjectsAsync("liver", pageSize: 2);
+
+        Assert.That(hits.Select(h => h.Accession), Is.EqualTo(new[] { "PXD000001", "PXD000002", "PXD000003" }));
+        // Stopped at total_records on a visibly short final page: no tail probe, no wasted request.
+        Assert.That(handler.RequestedUris.Count, Is.EqualTo(2));
+    }
+
+    /// <summary>
+    /// Search inherits the shared pager, so it inherits the understated-total_records defence too:
+    /// a fetch ending on a page that could be full is probed once rather than trusted. Pinned here
+    /// because the fix was made for the manifest and nothing else would notice if search ever stopped
+    /// consuming it.
+    /// </summary>
+    [Test]
+    public async Task SearchProjectsAsync_UnderstatedTotalRecords_StillReturnsEveryHit()
+    {
+        const long understated = 2;
+        var handler = new StubHandler(request =>
+        {
+            string uri = request.RequestUri.ToString();
+            if (uri.Contains("page=0")) return JsonResponse(Array(HitJson("PXD000001"), HitJson("PXD000002")), totalRecords: understated);
+            if (uri.Contains("page=1")) return JsonResponse(Array(HitJson("PXD000003")), totalRecords: understated);
+            return JsonResponse("[]", totalRecords: understated);
+        });
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        List<PrideProjectSearchResult> hits = await client.SearchProjectsAsync("liver", pageSize: 2);
+
+        Assert.That(hits.Select(h => h.Accession), Is.EqualTo(new[] { "PXD000001", "PXD000002", "PXD000003" }));
+    }
+
+    // ---- absence is not an error --------------------------------------------
+
+    /// <summary>
+    /// Zero hits is normal absence, not a failure: PRIDE answers 200 with an empty array and
+    /// total_records 0. This is why there is no TrySearchProjectsAsync — the Try/throwing pair on
+    /// GetProjectAsync exists for a 404 that this endpoint never returns.
+    /// </summary>
+    [Test]
+    public async Task SearchProjectsAsync_NoMatches_ReturnsEmptyListNotNull()
+    {
+        var handler = new StubHandler(_ => JsonResponse("[]", totalRecords: 0));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        List<PrideProjectSearchResult> hits = await client.SearchProjectsAsync("no-project-matches-this-keyword");
+
+        Assert.That(hits, Is.Not.Null);
+        Assert.That(hits, Is.Empty);
+        Assert.That(handler.RequestedUris.Count, Is.EqualTo(1));
+    }
+
+    // ---- request construction -----------------------------------------------
+
+    [Test]
+    public async Task SearchProjectsAsync_SendsKeywordAndPageSizeAndPage()
+    {
+        var handler = new StubHandler(_ => JsonResponse("[]", totalRecords: 0));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        await client.SearchProjectsAsync("liver disease", pageSize: 25);
+
+        string uri = handler.RequestedUris.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(uri, Does.StartWith("https://www.ebi.ac.uk/pride/ws/archive/v3/search/projects?"));
+            // The space IS escaped to %20 on the wire; Uri.ToString() decodes it back for display, so
+            // the decoded form is what this assertion can see. Asserting "%20" here would be asserting
+            // a property of Uri.ToString() rather than of the request — the characters that actually
+            // restructure a query are covered in the escaping test below, where %26/%3D do survive.
+            Assert.That(uri, Does.Contain("keyword=liver disease"));
+            Assert.That(uri, Does.Contain("pageSize=25"));
+            Assert.That(uri, Does.Contain("page=0"));
+        });
+    }
+
+    /// <summary>
+    /// A keyword is free text, so the characters that matter are the ones that would restructure the
+    /// query string. An unescaped "&amp;" splits the keyword into a second parameter and an unescaped
+    /// "=" splits it into a name/value pair — either way PRIDE answers 200 with results for a
+    /// DIFFERENT query, so the caller gets wrong data rather than an error. Uri.ToString() preserves
+    /// %26 and %3D (unlike %20 and %2F, which it decodes), so both are assertable directly.
+    /// </summary>
+    [Test]
+    public async Task SearchProjectsAsync_KeywordWithQuerySyntax_IsEscaped()
+    {
+        var handler = new StubHandler(_ => JsonResponse("[]", totalRecords: 0));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        await client.SearchProjectsAsync("a&pageSize=1");
+
+        string uri = handler.RequestedUris.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(uri, Does.Contain("keyword=a%26pageSize%3D1"));
+            // The injected pageSize must not have displaced the real one.
+            Assert.That(uri, Does.Contain("pageSize=100"));
+            Assert.That(uri.Split("pageSize=").Length - 1, Is.EqualTo(1), "the keyword must not add a second pageSize parameter");
+        });
+    }
+
+    // ---- argument and transport contracts -----------------------------------
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void SearchProjectsAsync_BlankKeyword_Throws(string keyword)
+    {
+        using var client = new PrideArchiveClient(new HttpClient(new StubHandler(_ => JsonResponse("[]"))));
+
+        // Not a degenerate search: PRIDE reads an absent keyword as "browse the whole archive", which
+        // is a different capability with a different cost, so it must be asked for deliberately.
+        Assert.ThrowsAsync<ArgumentException>(() => client.SearchProjectsAsync(keyword));
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void SearchProjectsAsync_NonPositivePageSize_Throws(int pageSize)
+    {
+        using var client = new PrideArchiveClient(new HttpClient(new StubHandler(_ => JsonResponse("[]"))));
+
+        Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => client.SearchProjectsAsync("liver", pageSize));
+    }
+
+    /// <summary>
+    /// A non-success status is a transport failure and stays an HttpRequestException — the type
+    /// ExternalServiceTestHelper converts to a SKIPPED live test. Contract breaks throw MzLibException
+    /// instead, precisely so an outage and a broken promise are never confused.
+    /// </summary>
+    [Test]
+    public void SearchProjectsAsync_NonSuccessStatus_ThrowsHttpRequestException()
+    {
+        var handler = new StubHandler(_ => JsonResponse("", HttpStatusCode.InternalServerError));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        Assert.ThrowsAsync<HttpRequestException>(() => client.SearchProjectsAsync("liver"));
+    }
+
+    [Test]
+    public void SearchProjectsAsync_ServerRepeatsAPageWhileTotalSaysMoreRemains_ThrowsMzLibException()
+    {
+        // A server that ignores `page` while total_records promises more is a broken contract, not an
+        // outage, so it must not surface as the exception type that means "PRIDE is down".
+        var handler = new StubHandler(_ => JsonResponse(Array(HitJson("PXD000001")), totalRecords: 500));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+
+        Assert.ThrowsAsync<MzLibException>(() => client.SearchProjectsAsync("liver", pageSize: 1));
+    }
+
+    [Test]
+    public void SearchProjectsAsync_Cancelled_Throws()
+    {
+        var handler = new StubHandler(_ => JsonResponse(Array(HitJson("PXD000001")), totalRecords: 1));
+        using var client = new PrideArchiveClient(new HttpClient(handler));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.ThrowsAsync<OperationCanceledException>(() => client.SearchProjectsAsync("liver", 100, cts.Token));
+    }
+}
+
+/// <summary>
+/// Live canary against the real PRIDE Archive search endpoint. Carries [Category("ExternalService")]
+/// so CI runs it in the dedicated, non-blocking external-service job rather than the required
+/// unit-test run; [Category("Pride")] allows selecting it on its own. Routed through
+/// <see cref="ExternalServiceTestHelper.RunAsync"/> so a PRIDE outage SKIPS the test while a genuine
+/// contract break still FAILS.
+/// </summary>
+/// <remarks>
+/// The drift worth catching here is the flattening. The offline fixture is a frozen copy of the wire
+/// format and so cannot notice if PRIDE ever starts serving structured CvParam objects from this
+/// endpoint — which would make every collection on the DTO deserialize to nothing. Only a live call
+/// can, so that is what the assertions below are aimed at.
+/// </remarks>
+[TestFixture]
+[Category("ExternalService")]
+[Category("Pride")]
+[ExcludeFromCodeCoverage]
+public class PrideProjectSearchLiveTests
+{
+    /// <summary>
+    /// The keyword is deliberately a NARROW one. SearchProjectsAsync fetches every page, so a broad
+    /// term ("liver" was 2 197 hits when this was written) would page through the whole result set on
+    /// every CI run — hammering EBI to prove something a small result set proves just as well.
+    /// "MetaMorpheus" was 93 hits, so this is a single request, and it is a term the lab's own output
+    /// keeps alive.
+    /// </summary>
+    [Test]
+    public Task SearchProjectsAsync_LiveKeyword_ReturnsPopulatedHits() =>
+        ExternalServiceTestHelper.RunAsync("PRIDE", async () =>
+        {
+            using var client = new PrideArchiveClient();
+            List<PrideProjectSearchResult> hits = await client.SearchProjectsAsync("MetaMorpheus");
+
+            Assert.That(hits, Is.Not.Empty);
+            Assert.Multiple(() =>
+            {
+                // Constraint form, not Assert.That(bool): a collapsed LINQ predicate reports only
+                // "Expected: True, But was: False", which cannot be triaged from a CI log.
+                Assert.That(hits, Is.All.Matches<PrideProjectSearchResult>(h => !string.IsNullOrEmpty(h.Accession)));
+                Assert.That(hits, Is.All.Matches<PrideProjectSearchResult>(h => !string.IsNullOrEmpty(h.Title)));
+                Assert.That(hits, Is.All.Matches<PrideProjectSearchResult>(h => h.SubmissionDate != default));
+
+                // The flattening itself: if PRIDE ever returns objects here these come back empty.
+                Assert.That(hits.Any(h => h.Organisms.Count > 0), Is.True, "no hit carried an organism");
+                Assert.That(hits.Any(h => h.Instruments.Count > 0), Is.True, "no hit carried an instrument");
+            });
+        });
+
+    [Test]
+    public Task SearchProjectsAsync_LiveNoMatches_ReturnsEmpty() =>
+        ExternalServiceTestHelper.RunAsync("PRIDE", async () =>
+        {
+            using var client = new PrideArchiveClient();
+            List<PrideProjectSearchResult> hits =
+                await client.SearchProjectsAsync("zzzzqqqqxxxx-no-such-dataset-zzzzqqqqxxxx");
+
+            // Absence, not an error — the fact that removes the need for a Try variant.
+            Assert.That(hits, Is.Not.Null);
+            Assert.That(hits, Is.Empty);
+        });
+
+    /// <summary>
+    /// Pins the multi-page path against the real server — the only place the server-side pageSize cap
+    /// and PRIDE's real total_records are in play. Same narrow keyword as above (93 hits when written)
+    /// at a small page size, so this costs about five requests rather than paging a broad result set.
+    /// </summary>
+    [Test]
+    public Task SearchProjectsAsync_LiveMultiPage_ReturnsMoreThanOnePageOfHits() =>
+        ExternalServiceTestHelper.RunAsync("PRIDE", async () =>
+        {
+            using var client = new PrideArchiveClient();
+            List<PrideProjectSearchResult> hits = await client.SearchProjectsAsync("MetaMorpheus", pageSize: 20);
+
+            Assert.That(hits.Count, Is.GreaterThan(20), "search stopped at the first page instead of paging");
+            Assert.That(hits.Select(h => h.Accession).Distinct().Count(), Is.EqualTo(hits.Count), "the pager returned a duplicate hit");
+        });
+}

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
@@ -827,6 +827,13 @@ namespace UsefulProteomicsDatabases
                 // be confused with a different record that way. Two byte-equal records in one manifest
                 // are indistinguishable from each other anyway, so dropping one of a straddling pair
                 // costs nothing a caller could act on.
+                //
+                // Stated plainly, because it is the one asymmetry this dedup introduces: a genuinely
+                // REPEATED record survives or not depending on where the page boundary happens to fall.
+                // Two byte-equal records inside one page are both kept; the same pair split across the
+                // probe boundary loses one. Nothing here can tell that pair from a re-served record,
+                // and the boundary is the server's to choose, so the count of an exactly-duplicated
+                // record is not something a caller should read anything into.
                 if (verifyingTail)
                 {
                     if (!pageAdvanced)

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
@@ -419,6 +419,83 @@ namespace UsefulProteomicsDatabases
         }
 
         /// <summary>
+        /// Finds PRIDE Archive projects matching a free-text keyword (v3 <c>search/projects</c>) — the
+        /// discovery entry point for a caller who has a subject rather than an accession.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Hits come back as <see cref="PrideProjectSearchResult"/>, NOT <see cref="PrideProject"/>.
+        /// PRIDE serves search from a separate flattened projection in which controlled-vocabulary
+        /// terms are reduced to display strings and contacts to names — see the remarks on
+        /// <see cref="PrideProjectSearchResult"/>. Follow a hit's
+        /// <see cref="PrideProjectSearchResult.Accession"/> to <see cref="GetProjectAsync"/> when the
+        /// full metadata object is wanted.
+        /// </para>
+        /// <para>
+        /// Only <paramref name="keyword"/> is exposed. PRIDE also accepts <c>filter</c>,
+        /// <c>sortFields</c> and <c>sortDirection</c>, but validates NONE of them: a misspelled field
+        /// or an invalid direction returns 200 with unfiltered, unsorted results (verified live
+        /// 2026-07-23), so a caller typo would silently produce wrong data instead of an error. Those
+        /// parameters are deferred until they can be validated in C# — an enum for the direction, a
+        /// restricted set for the sort fields — so a mistake fails here rather than at PRIDE.
+        /// </para>
+        /// <para>
+        /// A keyword is required. PRIDE treats an absent one as "browse the whole archive" (40 000+
+        /// projects at the time of writing), which is a different capability with a different cost,
+        /// not a degenerate search — so asking for it has to be deliberate rather than the result of
+        /// passing through an empty string.
+        /// </para>
+        /// <para>
+        /// EVERY matching project is returned, which for a search means the cost is set by the
+        /// KEYWORD rather than by anything the caller can cap. That differs in kind from
+        /// <see cref="GetProjectFilesAsync"/>, whose result is bounded by one project: a broad term
+        /// ("liver" matched 2 197 projects on 2026-08-21) pages until it has them all, so a caller
+        /// wanting a quick look should search narrowly rather than reach for
+        /// <paramref name="pageSize"/>, which changes only how many requests that takes. Narrowing
+        /// beyond a keyword needs <c>filter</c>, which is deferred for the reason above.
+        /// </para>
+        /// </remarks>
+        /// <param name="keyword">
+        /// The free-text query. Escaped before it is sent, so it may contain any character —
+        /// <c>&amp;</c> and <c>=</c> included, which would otherwise split it into further query
+        /// parameters.
+        /// </param>
+        /// <param name="pageSize">
+        /// Hits requested per page (default 100). PRIDE caps this server-side and then pages by the
+        /// capped size, exactly as it does for the file manifest; see
+        /// <see cref="GetProjectFilesAsync"/> for what that means for termination. Every page is
+        /// fetched regardless — this is a throughput knob, not a limit on how many hits are returned.
+        /// </param>
+        /// <param name="cancellationToken">Cancels the (possibly multi-page) search.</param>
+        /// <returns>
+        /// Every matching project, across all pages. Empty when nothing matches — PRIDE reports no
+        /// hits as an empty result rather than an error, so there is no <c>Try</c> variant of this
+        /// method as there is for <see cref="GetProjectAsync"/>. Never null.
+        /// </returns>
+        /// <exception cref="ArgumentException">The keyword is null, empty, or whitespace.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The page size is not positive.</exception>
+        /// <exception cref="HttpRequestException">The API returned a non-success status code.</exception>
+        /// <exception cref="MzLibException">
+        /// PRIDE answered successfully but served a page identical to its predecessor while
+        /// <c>total_records</c> reported more remained — a broken contract rather than an outage.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">The operation was cancelled via <paramref name="cancellationToken"/>.</exception>
+        public async Task<List<PrideProjectSearchResult>> SearchProjectsAsync(string keyword, int pageSize = 100,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(keyword))
+                throw new ArgumentException("A search keyword is required.", nameof(keyword));
+            if (pageSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(pageSize), "Page size must be positive.");
+
+            return await GetAllPagesAsync<PrideProjectSearchResult>(
+                page => $"search/projects?keyword={Uri.EscapeDataString(keyword)}&pageSize={pageSize}&page={page}",
+                pageSize,
+                $"keyword '{keyword}'",
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Downloads a single PRIDE file's bytes to <paramref name="destinationDirectory"/>, saved under the
         /// file's own <see cref="PrideArchiveFile.FileName"/>. The download runs over HTTPS through this
         /// client's reused <see cref="HttpClient"/>: PRIDE exposes files as FTP/Aspera locations, but its FTP

--- a/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideArchiveClient.cs
@@ -60,6 +60,17 @@ namespace UsefulProteomicsDatabases
         /// </summary>
         public int MaxPages { get; init; } = 10000;
 
+        /// <summary>
+        /// The longest keyword <see cref="SearchProjectsAsync"/> will send. PRIDE answers a very long
+        /// keyword with HTTP 500 rather than a 400 or a 414 (observed at 2000 characters on
+        /// 2026-08-21; 500 characters still answered 200), and a 500 is the one signature that cannot
+        /// be told apart from an outage — <c>ExternalServiceTestHelper</c> reads it as "the service is
+        /// down" and SKIPS. Refusing the request here turns a caller's bug into an
+        /// <see cref="ArgumentException"/> at the call site instead. The exact server threshold is not
+        /// published; this sits well inside the range observed to work.
+        /// </summary>
+        public const int MaxKeywordLength = 1000;
+
         /// <summary>Creates a client with its own <see cref="HttpClient"/> pointed at the PRIDE Archive API.</summary>
         public PrideArchiveClient()
             : this(new HttpClient { BaseAddress = new Uri(DefaultBaseAddress), Timeout = TimeSpan.FromSeconds(100) }, ownsHttpClient: true)
@@ -448,11 +459,22 @@ namespace UsefulProteomicsDatabases
         /// <para>
         /// EVERY matching project is returned, which for a search means the cost is set by the
         /// KEYWORD rather than by anything the caller can cap. That differs in kind from
-        /// <see cref="GetProjectFilesAsync"/>, whose result is bounded by one project: a broad term
-        /// ("liver" matched 2 197 projects on 2026-08-21) pages until it has them all, so a caller
-        /// wanting a quick look should search narrowly rather than reach for
-        /// <paramref name="pageSize"/>, which changes only how many requests that takes. Narrowing
-        /// beyond a keyword needs <c>filter</c>, which is deferred for the reason above.
+        /// <see cref="GetProjectFilesAsync"/>, whose result is bounded by one project. Search hits are
+        /// also fat — roughly 10-14 KB each, since each carries the full protocols, every file name and
+        /// the match highlights — so a request count badly understates the load. Measured live
+        /// 2026-08-21: "liver" was 2 197 projects over 22 requests and about 30 MB; "proteomics" was
+        /// 37 356 projects over 374 requests and roughly 355 MB, most of the archive. PRIDE offers no
+        /// compression even when asked, so none of that can be traded away. Search narrowly;
+        /// <paramref name="pageSize"/> changes only how many requests it takes, never how much comes
+        /// back. Narrowing beyond a keyword needs <c>filter</c>, which is deferred for the reason above.
+        /// </para>
+        /// <para>
+        /// The keyword is free text with AND-of-prefix-token semantics, and PRIDE supports no query
+        /// operators: quotes are discarded (there is no phrase search), <c>*</c> is dropped, and
+        /// <c>AND</c>/<c>OR</c> match as ordinary literal terms — "liver OR kidney" returned 2 hits
+        /// where "liver" alone returned 2 197. Diacritics are not folded either: "Nájera" found nothing
+        /// while "Najera" found a project. None of this can be escaped around, so a caller who passes
+        /// query syntax silently gets a different result set (all verified live 2026-08-21).
         /// </para>
         /// </remarks>
         /// <param name="keyword">
@@ -461,18 +483,35 @@ namespace UsefulProteomicsDatabases
         /// parameters.
         /// </param>
         /// <param name="pageSize">
-        /// Hits requested per page (default 100). PRIDE caps this server-side and then pages by the
-        /// capped size, exactly as it does for the file manifest; see
+        /// Hits requested per page (default 100). PRIDE caps this server-side at 100 and then pages by
+        /// the capped size, exactly as it does for the file manifest; see
         /// <see cref="GetProjectFilesAsync"/> for what that means for termination. Every page is
-        /// fetched regardless — this is a throughput knob, not a limit on how many hits are returned.
+        /// fetched regardless, so this is never a limit on how many hits are returned.
+        /// <para>
+        /// Above the cap it is not a throughput knob either — it is a no-op. A request for 500 comes
+        /// back byte-identical to a request for 100 (verified live 2026-08-21), so the fetch costs the
+        /// same requests and buys nothing. Below the cap it only costs MORE requests, and a small value
+        /// also guarantees the tail probe fires, since every page is then trivially "full". The default
+        /// is the value to leave it at.
+        /// </para>
         /// </param>
         /// <param name="cancellationToken">Cancels the (possibly multi-page) search.</param>
         /// <returns>
-        /// Every matching project, across all pages. Empty when nothing matches — PRIDE reports no
-        /// hits as an empty result rather than an error, so there is no <c>Try</c> variant of this
-        /// method as there is for <see cref="GetProjectAsync"/>. Never null.
+        /// Every matching project, across all pages, with no accession repeated. Empty when nothing
+        /// matches — PRIDE reports no hits as an empty result rather than an error, so there is no
+        /// <c>Try</c> variant of this method as there is for <see cref="GetProjectAsync"/>. Never null.
+        /// <para>
+        /// One caveat, stated because it cannot be fixed here: PRIDE pages a LIVE index and offers no
+        /// stable cursor, so a result set that changes DURING a multi-page fetch shifts its own paging.
+        /// A project published mid-fetch is served on two pages — that is deduplicated, so it comes
+        /// back once — but a project REMOVED mid-fetch slides the window the other way and can fall
+        /// between two pages, and then no page carries it. A search whose results fit on one page
+        /// cannot be affected. Verified live 2026-08-21.
+        /// </para>
         /// </returns>
-        /// <exception cref="ArgumentException">The keyword is null, empty, or whitespace.</exception>
+        /// <exception cref="ArgumentException">
+        /// The keyword is null, empty, whitespace, or longer than <see cref="MaxKeywordLength"/>.
+        /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">The page size is not positive.</exception>
         /// <exception cref="HttpRequestException">The API returned a non-success status code.</exception>
         /// <exception cref="MzLibException">
@@ -485,14 +524,38 @@ namespace UsefulProteomicsDatabases
         {
             if (string.IsNullOrWhiteSpace(keyword))
                 throw new ArgumentException("A search keyword is required.", nameof(keyword));
+            if (keyword.Length > MaxKeywordLength)
+                throw new ArgumentException(
+                    $"A search keyword may be at most {MaxKeywordLength} characters, but this one is {keyword.Length}. " +
+                    "PRIDE answers a very long keyword with HTTP 500, which is indistinguishable from the service " +
+                    "being down.", nameof(keyword));
             if (pageSize <= 0)
                 throw new ArgumentOutOfRangeException(nameof(pageSize), "Page size must be positive.");
 
-            return await GetAllPagesAsync<PrideProjectSearchResult>(
+            List<PrideProjectSearchResult> hits = await GetAllPagesAsync<PrideProjectSearchResult>(
                 page => $"search/projects?keyword={Uri.EscapeDataString(keyword)}&pageSize={pageSize}&page={page}",
                 pageSize,
                 $"keyword '{keyword}'",
                 cancellationToken).ConfigureAwait(false);
+
+            // PRIDE pages a LIVE index with no stable cursor, so the result set can change underneath a
+            // multi-page fetch. Verified live 2026-08-21: a project left the "liver" set mid-session and
+            // every record after it shifted up one position, which moves a record from page 1 into
+            // page 0's range after page 0 was already read. Publication does the same in reverse, and
+            // then a record is served on two consecutive pages.
+            //
+            // The shared pager cannot fix this, and deliberately does not try: it refuses to treat any
+            // FIELD as a record's identity because the file manifest it was written for has no unique
+            // key, so dropping "repeats" there would drop real files. That reasoning does not carry
+            // over. A search hit HAS a real identity — its accession is the very thing a caller would
+            // use to fetch the project — so two hits sharing one are the same project, not two projects
+            // that happen to look alike. Deduping here is therefore sound where it would not be there.
+            //
+            // Only the duplicate half is fixable. A record can equally be skipped, when the window
+            // slides the other way, and nothing short of a cursor the API does not offer would catch
+            // that. It is stated in the returns docs rather than papered over.
+            var seenAccessions = new HashSet<string>(StringComparer.Ordinal);
+            return hits.Where(hit => seenAccessions.Add(hit.Accession)).ToList();
         }
 
         /// <summary>
@@ -761,8 +824,13 @@ namespace UsefulProteomicsDatabases
                 int servedCount = pageItems.Count(x => x is not null);
 
                 // An empty page ends the fetch. This is also the backstop for a total_records that
-                // overstates what the server will actually serve: paging past the end returns a
-                // zero-byte body (verified live 2026-07-23), which deserializes to an empty list. An
+                // overstates what the server will actually serve. Paging past the end returns an EMPTY
+                // JSON ARRAY -- "[]" from the file manifest, "[ ]" from search -- with the total_records
+                // header still present (re-verified live 2026-08-21; an earlier note here claimed a
+                // zero-byte body with no header, which was wrong for both endpoints. A zero-byte form
+                // does exist, but only far past the end, beyond roughly offset 40 000, which no current
+                // result set is large enough to reach). Every form deserializes to an empty list, the
+                // zero-byte one via the null-coalesce above. An
                 // overstatement is therefore accepted as the server's own correction rather than
                 // reported as a shortfall -- there is no way to distinguish it from a result set whose
                 // size changed mid-fetch, and throwing would fail a caller who asked for
@@ -812,6 +880,18 @@ namespace UsefulProteomicsDatabases
                 // what is new is that the total check no longer rescues it. Nothing short of a record
                 // key -- which this loop has established the DTO does not have -- would tell those pages
                 // apart, and MaxPages remains settable by a caller who meets such a server.
+                //
+                // Correction, from live evidence on 2026-08-21. A body-varying server is NOT
+                // hypothetical, and the paragraph above understated what it costs. On search/projects
+                // PRIDE serialises the dynamic `highlights` map from an unordered hash map, so two
+                // identical requests routinely differ in bytes while carrying the very same records --
+                // which silently disables the identical-page guard below for that endpoint. And the
+                // outcome it degrades to is NOT the MaxPages throw: a page-ignoring server whose bytes
+                // vary gets its records appended a second time, items.Count reaches total, and the
+                // fetch ENDS EARLY holding duplicates that look like a complete answer. SearchProjectsAsync
+                // therefore deduplicates its own results on accession, which it can do because a search
+                // hit carries the record key this loop does not have. The file manifest has no such key
+                // and stays exposed to this -- the honest state of it, rather than a claim otherwise.
                 //
                 // (2) It could bring records this fetch ALREADY HOLDS. A result set that grows between
                 // two requests shifts its own paging: page 0 of a 2-record set is [a, b], and page 1 of

--- a/mzLib/UsefulProteomicsDatabases/PrideProjectSearchResult.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideProjectSearchResult.cs
@@ -29,15 +29,30 @@ namespace UsefulProteomicsDatabases
     /// </para>
     /// <para>
     /// Fields PRIDE omits for a given project arrive as empty collections, empty strings or zero,
-    /// never null. Several are genuinely sparse — <see cref="YearlyDownloads"/>,
-    /// <see cref="BotCount"/>, <see cref="HubCount"/>, <see cref="OrganicCount"/> and
-    /// <see cref="OtherOmicsLinks"/> were absent from most hits in a 100-hit sample captured
-    /// 2026-08-21 — so treat a zero or an empty list as "not reported" rather than as a measurement.
+    /// never null. Several are genuinely sparse: across 1 600 hits sampled from 16 different queries
+    /// on 2026-08-21, <see cref="ProjectTags"/> was populated on 2.6%, <see cref="Sdrf"/> on 2.4%,
+    /// <see cref="OtherOmicsLinks"/> on 18%, and <see cref="YearlyDownloads"/> with the
+    /// <see cref="BotCount"/>/<see cref="HubCount"/>/<see cref="OrganicCount"/> trio on under half.
+    /// Treat a zero or an empty list as "not reported", never as a measured zero. How sparse a given
+    /// field looks tracks the RESULT SET rather than the archive, so it varies by query.
+    /// </para>
+    /// <para>
+    /// One caveat the never-null guarantee does NOT cover: it applies to the fields, not to the
+    /// elements inside them. PRIDE ships empty and whitespace-only strings inside
+    /// <see cref="Keywords"/> on roughly 9% of hits, so filter before displaying or joining them.
     /// </para>
     /// </remarks>
     public class PrideProjectSearchResult
     {
-        /// <summary>The ProteomeXchange accession (e.g. "PXD012345"). The key to the full metadata object.</summary>
+        /// <summary>
+        /// The project accession (e.g. "PXD012345") — the key to the full metadata object via
+        /// <see cref="PrideArchiveClient.GetProjectAsync"/>.
+        /// </summary>
+        /// <remarks>
+        /// Usually a ProteomeXchange "PXD" accession, but not always: search also returns legacy
+        /// PRIDE-era "PRD" accessions and affinity "PAD" ones. Both resolve on the metadata endpoint,
+        /// so treat this as an opaque key rather than assuming a prefix.
+        /// </remarks>
         public string Accession { get; set; } = string.Empty;
 
         /// <summary>The project title.</summary>
@@ -55,10 +70,25 @@ namespace UsefulProteomicsDatabases
         /// <summary>The dataset DOI, or empty if PRIDE has not minted one.</summary>
         public string Doi { get; set; } = string.Empty;
 
-        /// <summary>Whether the submission is "COMPLETE", "PARTIAL" or "AFFINITY".</summary>
+        /// <summary>
+        /// How the project was submitted: "COMPLETE", "PARTIAL", "AFFINITY", or "PRIDE" for legacy
+        /// pre-ProteomeXchange submissions. Not treated as a closed set — it is a plain string
+        /// because PRIDE has added values before.
+        /// </summary>
         public string SubmissionType { get; set; } = string.Empty;
 
-        /// <summary>The project's SDRF sample-metadata file, or empty if it has none.</summary>
+        /// <summary>
+        /// The project's SDRF sample metadata, flattened by PRIDE's search index into a single
+        /// space-joined bag of the term VALUES — e.g. "Nt=label free sample;ac=ms:1002038
+        /// Nt=trypsin;ac=ms:1001251 Mus musculus Liver Male 18 weeks". Empty when the project has no
+        /// SDRF, which is the common case.
+        /// </summary>
+        /// <remarks>
+        /// Not a file, a filename or a URL: nothing can be fetched with it, and the row/column
+        /// structure of the real SDRF is gone. It is searchable text, useful for reading and matching
+        /// rather than for parsing. Rare in practice — non-empty on roughly 2% of hits sampled
+        /// 2026-08-21.
+        /// </remarks>
         public string Sdrf { get; set; } = string.Empty;
 
         /// <summary>The date the project was submitted to PRIDE.</summary>

--- a/mzLib/UsefulProteomicsDatabases/PrideProjectSearchResult.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideProjectSearchResult.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace UsefulProteomicsDatabases
+{
+    /// <summary>
+    /// One hit from a PRIDE Archive project search (v3 <c>search/projects</c>). A plain data object
+    /// populated by JSON deserialization.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is deliberately NOT a <see cref="PrideProject"/>, and the two are not interchangeable.
+    /// PRIDE serves search hits from a separate Elasticsearch projection (the API spec names it
+    /// <c>ElasticPrideProject</c>) in which every controlled-vocabulary field has been FLATTENED TO A
+    /// PLAIN STRING: the same project returns <c>instruments: [{ "accession": "MS:1001911", "name":
+    /// "Q Exactive" }]</c> from <c>projects/{accession}</c> and <c>instruments: ["Q Exactive"]</c>
+    /// here. Contacts collapse from ten-field objects to a display name, and references to a single
+    /// pre-mangled citation string. Deserializing this payload into <see cref="PrideProject"/> would
+    /// throw rather than silently degrade.
+    /// </para>
+    /// <para>
+    /// So the collections below are <see cref="string"/>, not <see cref="MzLibUtil.CvParam"/>, and
+    /// that is a property of the wire rather than a simplification chosen here. The accessions simply
+    /// are not sent, and manufacturing one by looking a display name up in a vocabulary would put an
+    /// identifier in a caller's hands that PRIDE never asserted. A caller who needs the controlled
+    /// vocabulary should follow the hit's <see cref="Accession"/> to
+    /// <see cref="PrideArchiveClient.GetProjectAsync"/>, which returns the full metadata object.
+    /// </para>
+    /// <para>
+    /// Fields PRIDE omits for a given project arrive as empty collections, empty strings or zero,
+    /// never null. Several are genuinely sparse — <see cref="YearlyDownloads"/>,
+    /// <see cref="BotCount"/>, <see cref="HubCount"/>, <see cref="OrganicCount"/> and
+    /// <see cref="OtherOmicsLinks"/> were absent from most hits in a 100-hit sample captured
+    /// 2026-08-21 — so treat a zero or an empty list as "not reported" rather than as a measurement.
+    /// </para>
+    /// </remarks>
+    public class PrideProjectSearchResult
+    {
+        /// <summary>The ProteomeXchange accession (e.g. "PXD012345"). The key to the full metadata object.</summary>
+        public string Accession { get; set; } = string.Empty;
+
+        /// <summary>The project title.</summary>
+        public string Title { get; set; } = string.Empty;
+
+        /// <summary>The submitter's free-text description of the project.</summary>
+        public string ProjectDescription { get; set; } = string.Empty;
+
+        /// <summary>The submitter's description of how the sample was prepared.</summary>
+        public string SampleProcessingProtocol { get; set; } = string.Empty;
+
+        /// <summary>The submitter's description of how the data were searched and processed.</summary>
+        public string DataProcessingProtocol { get; set; } = string.Empty;
+
+        /// <summary>The dataset DOI, or empty if PRIDE has not minted one.</summary>
+        public string Doi { get; set; } = string.Empty;
+
+        /// <summary>Whether the submission is "COMPLETE", "PARTIAL" or "AFFINITY".</summary>
+        public string SubmissionType { get; set; } = string.Empty;
+
+        /// <summary>The project's SDRF sample-metadata file, or empty if it has none.</summary>
+        public string Sdrf { get; set; } = string.Empty;
+
+        /// <summary>The date the project was submitted to PRIDE.</summary>
+        /// <remarks>
+        /// Typed as <see cref="DateTime"/>, not <see cref="DateTimeOffset"/> as on
+        /// <see cref="PrideArchiveFile"/>: this endpoint sends a bare calendar date ("2026-08-15")
+        /// with no time and no UTC offset, and parsing that into a <see cref="DateTimeOffset"/> would
+        /// silently attach whatever offset the executing machine happens to be in. The split between
+        /// the two types is per-endpoint and deliberate — it follows what each one actually sends.
+        /// </remarks>
+        public DateTime SubmissionDate { get; set; }
+
+        /// <summary>The date the project became publicly visible. See <see cref="SubmissionDate"/> for why this is a <see cref="DateTime"/>.</summary>
+        public DateTime PublicationDate { get; set; }
+
+        /// <summary>
+        /// The date the project was last modified. Has no counterpart on <see cref="PrideProject"/> —
+        /// the search projection carries it and the metadata endpoint does not.
+        /// </summary>
+        public DateTime UpdatedDate { get; set; }
+
+        /// <summary>PRIDE's coarse classification tags (e.g. "Human proteome project").</summary>
+        public List<string> ProjectTags { get; set; } = new();
+
+        /// <summary>The submitter's free-text keywords.</summary>
+        public List<string> Keywords { get; set; } = new();
+
+        /// <summary>The submitters' display names. Flattened from the ten-field contact objects the metadata endpoint returns.</summary>
+        public List<string> Submitters { get; set; } = new();
+
+        /// <summary>The principal investigators' display names. Flattened as <see cref="Submitters"/> is.</summary>
+        public List<string> LabPIs { get; set; } = new();
+
+        /// <summary>The submitting laboratories' affiliations. Has no counterpart on <see cref="PrideProject"/>.</summary>
+        public List<string> Affiliations { get; set; } = new();
+
+        /// <summary>The instruments used, by display name (e.g. "Orbitrap Exploris 480").</summary>
+        public List<string> Instruments { get; set; } = new();
+
+        /// <summary>The software used, by display name.</summary>
+        public List<string> Softwares { get; set; } = new();
+
+        /// <summary>The quantification methods used, by display name.</summary>
+        public List<string> QuantificationMethods { get; set; } = new();
+
+        /// <summary>
+        /// The sample characteristics, by display value (e.g. "liver"). Flattened: the metadata
+        /// endpoint returns these as key/value pairs of controlled-vocabulary terms, so which
+        /// characteristic each value describes is not recoverable from a search hit.
+        /// </summary>
+        public List<string> SampleAttributes { get; set; } = new();
+
+        /// <summary>The organisms studied, by display name (e.g. "Mus musculus (mouse)").</summary>
+        public List<string> Organisms { get; set; } = new();
+
+        /// <summary>The tissues or organism parts sampled.</summary>
+        /// <remarks>
+        /// PRIDE spells this "organismsPart" on the search endpoint and "organismParts" on
+        /// <c>projects/{accession}</c>. The property keeps the metadata spelling so the two DTOs agree
+        /// on the name of the same concept; the attribute carries the search endpoint's own. This is
+        /// the one place a PRIDE DTO needs an explicit JSON name — every other member here binds by
+        /// convention.
+        /// </remarks>
+        [JsonProperty("organismsPart")]
+        public List<string> OrganismParts { get; set; } = new();
+
+        /// <summary>The diseases studied, by display name.</summary>
+        public List<string> Diseases { get; set; } = new();
+
+        /// <summary>
+        /// The associated publications, each as a single pre-formatted citation string. Flattened: the
+        /// metadata endpoint returns structured <see cref="PrideReference"/> objects, so a PubMed ID or
+        /// DOI cannot be read out of a search hit without parsing the string PRIDE assembled.
+        /// </summary>
+        public List<string> References { get; set; } = new();
+
+        /// <summary>The experiment types, by display name (e.g. "Data-independent acquisition").</summary>
+        public List<string> ExperimentTypes { get; set; } = new();
+
+        /// <summary>
+        /// The names of the project's files. A search-only convenience: it is not the manifest, and
+        /// carries no sizes, categories or download locations. Use
+        /// <see cref="PrideArchiveClient.GetProjectFilesAsync"/> — or
+        /// <see cref="PrideArchiveClient.GetProjectFilesFromFtpAsync"/> for the complete list — to act
+        /// on the files themselves.
+        /// </summary>
+        public List<string> ProjectFileNames { get; set; } = new();
+
+        /// <summary>Links to related datasets in other omics repositories (e.g. "pride.project:PXD062751").</summary>
+        public List<string> OtherOmicsLinks { get; set; } = new();
+
+        /// <summary>
+        /// The snippets that matched the query, keyed by the field each match was found in, with the
+        /// matched terms wrapped in <c>&lt;em&gt;</c> markup.
+        /// </summary>
+        /// <remarks>
+        /// A dynamic map, not a fixed shape: the keys are whichever fields the query happened to hit,
+        /// so they vary per hit and per query. This is the one thing a search returns that
+        /// <see cref="PrideArchiveClient.GetProjectAsync"/> cannot — it says WHY a project matched.
+        /// The markup is PRIDE's; strip it if the value is going anywhere other than a highlighted view.
+        /// </remarks>
+        public Dictionary<string, List<string>> Highlights { get; set; } = new();
+
+        /// <summary>Downloads recorded for the project, broken out by calendar year.</summary>
+        public List<PrideYearlyDownloadCount> YearlyDownloads { get; set; } = new();
+
+        /// <summary>Total downloads recorded for the project.</summary>
+        public long DownloadCount { get; set; }
+
+        /// <summary>Mean downloads per file in the project.</summary>
+        public double AvgDownloadsPerFile { get; set; }
+
+        /// <summary>The project's download-popularity percentile within PRIDE.</summary>
+        public int Percentile { get; set; }
+
+        /// <summary>Downloads attributed to automated crawlers.</summary>
+        public long BotCount { get; set; }
+
+        /// <summary>Downloads attributed to institutional or aggregating hubs.</summary>
+        public long HubCount { get; set; }
+
+        /// <summary>Downloads attributed to ordinary human traffic.</summary>
+        public long OrganicCount { get; set; }
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/PrideYearlyDownloadCount.cs
+++ b/mzLib/UsefulProteomicsDatabases/PrideYearlyDownloadCount.cs
@@ -1,0 +1,20 @@
+namespace UsefulProteomicsDatabases
+{
+    /// <summary>
+    /// How many times a project was downloaded in one calendar year, as reported by the PRIDE Archive
+    /// search endpoint (v3 <c>search/projects</c>) in <see cref="PrideProjectSearchResult.YearlyDownloads"/>.
+    /// </summary>
+    /// <remarks>
+    /// The year arrives as a string ("2026") rather than a number, and is kept as one: it is a label on
+    /// a bucket, not a quantity to compute with, and parsing it here would invent a failure mode for a
+    /// value no caller needs to do arithmetic on.
+    /// </remarks>
+    public class PrideYearlyDownloadCount
+    {
+        /// <summary>The calendar year the count covers, e.g. "2026".</summary>
+        public string Year { get; set; } = string.Empty;
+
+        /// <summary>Downloads recorded for the project in <see cref="Year"/>.</summary>
+        public long Count { get; set; }
+    }
+}


### PR DESCRIPTION
Adds `SearchProjectsAsync(keyword, pageSize)` over PRIDE v3 `search/projects` — the discovery entry point for a caller who has a subject rather than an accession. It is the last Tier 1/2 item on the PRIDE roadmap, and it consumes the shared `GetAllPagesAsync<T>` that #1173 extracted, so it carries no second copy of the paging loop.

Stacked on nothing — #1173 is merged, this branches off current `master`.

## What it adds

- `SearchProjectsAsync(string keyword, int pageSize = 100, CancellationToken)` on `PrideArchiveClient`.
- `PrideProjectSearchResult` — its own DTO, plus a small `PrideYearlyDownloadCount`.
- 22 offline tests over two fixtures captured live, and 3 live canaries under `[Category("ExternalService")]`.

## Hits are NOT `PrideProject`, and the types are not interchangeable

PRIDE serves search from a separate Elasticsearch projection (the spec names it `ElasticPrideProject`) in which every controlled-vocabulary field is **flattened to a plain string**. The same project returns `instruments` as `CvParam` objects from `projects/{accession}` and as `["Q Exactive"]` here; contacts collapse from ten-field objects to a display name; references become one pre-mangled citation string. Deserializing this payload into `PrideProject` would throw, not silently degrade.

So the collections are `string`, not `CvParam` — a property of the wire, not a simplification chosen here. Resolving those display names against a vocabulary was considered and rejected: NCBITaxon, UBERON and MONDO are deliberately absent from the embedded vocabularies, so `organisms`, `organismParts` and `diseases` could never resolve, and a resolved accession would be one PRIDE never asserted.

**Dates are `DateTime`, not `DateTimeOffset`** as on `PrideArchiveFile`: this endpoint sends bare calendar dates, and parsing those into a `DateTimeOffset` would silently attach the executing machine's offset. The split is per-endpoint and follows what each one actually sends.

**`OrganismParts` carries the one explicit `[JsonProperty]` in any PRIDE DTO.** PRIDE spells the field `organismsPart` here and `organismParts` on `projects/{accession}`. The property keeps the metadata spelling so the two DTOs agree on the name of one concept, rather than exporting the server's typo into mzLib's public API permanently. It has its own test, because without the attribute the property binds nothing and returns an empty list — a wrong answer rather than an error.

## Scope: `keyword` + `pageSize` only

PRIDE also accepts `filter`, `sortFields` and `sortDirection` but validates **none** of them — a misspelled field or an invalid direction returns `200` with unfiltered, unsorted results. A caller typo would silently produce wrong data. Those wait until they can be validated in C# (an enum for direction, a restricted set for sort fields) so a mistake fails at the call site instead.

A keyword is **required**: PRIDE reads an absent one as "browse the whole archive" (40,834 projects), which is a different capability with a different cost, not a degenerate search. There is **no `Try` variant** — search never 404s, and zero hits is an empty array with `total_records: 0`, which is absence rather than an error.

---

# The five-agent live stress test

Before opening this, I ran five independent investigations against the live endpoint, each on a different angle, each with a hard request budget and pacing so we did not hammer EBI. Together they read roughly **2,000 records across 16 different queries**. Two of them were aimed squarely at the weakest points in my own work: the DTO was built from a *single* 100-hit sample of one keyword, and a frozen fixture is exactly the thing that cannot notice drift.

| angle | what it did | budget |
|---|---|---|
| Broad-term paging | `pageSize` cap, `total_records` stability, page overlap, past-the-end shape, real fetch cost | ≤40 requests |
| Escaping | `&` `=` `+` `%` `#` `/`, unicode and Greek letters, long keywords, quoted phrases and boolean syntax | ≤40 |
| Edge counts | zero-hit, single-hit, exact page boundaries where the tail probe fires, ordering stability | ≤40 |
| Field sparsity | ~12 diverse keywords — chiefly *wire fields the DTO drops* and DTO properties never seen live | ≤30 |
| Fixture drift | re-fetch the captured hit, walk all 35 properties, hunt a second silent-bind trap | ≤25 |

## What held up

The DTO survived contact with the archive. **35 wire keys map 1:1 onto 35 DTO properties** — nothing dropped in either direction, and no property that binds nothing. Every field was monomorphic across ~2,000 records; **zero JSON nulls**; 843 dates spanning 2004–2026 were all bare `yyyy-MM-dd`, confirming the `DateTime` choice; and there were zero non-string elements in 16 collection fields, so the flattening premise holds. Six spec fields I had omitted never appeared in 1,600 hits, including under targeted `sortFields=score` and `filter=` probes — the omission was right.

On paging: the `pageSize` cap is still 100 and still pages by the capped size; `total_records` was exact on every result set measured (1, 6, 30, 181, 2,197, 23,252); the exact-boundary probe fires and the page past the end is always empty; and the server never clamps an out-of-range page to the last valid one — which is the one behavior that would have made the probe append a page of duplicates.

## What did not — including two defects of mine

**The fixture was not the verbatim capture its docstring claimed.** It carried an `sdrf` member the captured project does not send at all, and `yearlyDownloads` counts of `91/20` where the server sends `33/78`. Two tests were pinning numbers PRIDE does not serve. Re-captured verbatim; the docstring now states exactly what trimming did — entries dropped and prose truncated, nothing added or altered.

**Four assertions proved nothing.** `Doi`, `Sdrf`, `ProjectTags` and `Diseases` are all empty on that project, and the test asserted `Is.Empty` on each — which passes whether the property binds correctly *or* binds nothing at all. Deleting the `Doi` property left the suite green. That is precisely the silent-bind failure `OrganismParts` has its own test for. A second live hit now carries `sdrf`, `projectTags` and `diseases`, and a clearly-labelled synthetic probe covers `doi`, which neither captured project has.

**Mid-fetch drift can lose or duplicate a project.** PRIDE pages a live index with no stable cursor. Observed directly: a project left the `liver` result set mid-session and every record after it shifted up one position, moving a record from page 1 into page 0's range *after* page 0 had been read. Publication does the same in reverse and a record is then served on two pages.

The shared pager cannot fix this and deliberately does not try — it refuses to treat any **field** as a record's identity, because the file manifest it was written for has no unique key, so dropping "repeats" there would drop real files. That reasoning does not carry over: a search hit's accession *is* its identity, the very thing a caller uses to fetch the project. So search deduplicates on it. Only the duplicate half is fixable; the skip half needs a cursor the API does not offer, and is stated in the `<returns>` docs rather than papered over.

**`highlights` key order is non-deterministic.** PRIDE serializes that map from an unordered hash map, so identical requests differ in bytes while carrying the same records — which silently disables the pager's raw-body identical-page guard on this endpoint. Worse, the comment claiming such a server "falls through to the `MaxPages` backstop" is wrong: traced live, a page-ignoring server whose bytes vary gets its records appended a second time, `items.Count` reaches `total`, and the fetch **ends early holding duplicates that look like a complete answer**. The comment now says what actually happens; the accession dedup covers search, and the manifest's remaining exposure is stated rather than claimed away.

**A very long keyword returns HTTP 500**, not 400 or 414. That is the one status indistinguishable from an outage — `ExternalServiceTestHelper` reads it as "PRIDE is down" and *skips* — so a caller's bug would masquerade as an EBI outage, and a live test covering it would go green by skipping. Guarded by `MaxKeywordLength`, matching the fail-fast posture already taken for a blank keyword and a non-positive page size.

## Claims retracted rather than reworded

- **Past-the-end returns `[ ]` (search) or `[]` (manifest) *with* the `total_records` header** — not the zero-byte, header-less body that both the pager comment and the grounding doc asserted as "verified live 2026-07-23". That was wrong for *both* consumers, and a reviewer checking it would have found it false. The loop always terminated correctly; only the claim was wrong. A zero-byte form does exist, but only beyond roughly offset 40,000, which no current result set is large enough to reach.
- **`pageSize` above 100 is a no-op**, not the "throughput knob" I called it. A request for 500 comes back byte-identical to a request for 100.
- **`submissionType` has a fourth value**, `"PRIDE"` (legacy pre-ProteomeXchange submissions).
- **Accessions are not all ProteomeXchange** — legacy `PRD…` and affinity `PAD…` also appear, and both resolve on `projects/{accession}`.
- **`Sdrf` is not a file or a filename** — it is a flattened bag of the SDRF's term values, non-empty on about 2% of hits.
- The grounding doc's **six unmodeled spec fields are eleven**, and its stated reason was wrong for three of them.

## Documented rather than defended

Cost is now measured rather than gestured at. Hits are fat — roughly 10–14 KB each, since each carries the full protocols, every file name and the match highlights — so a request count badly understates the load: `liver` is 2,197 projects over 22 requests and ~30 MB; `proteomics` is 37,356 projects over 374 requests and roughly **355 MB**, most of the archive. The server offers no compression even when asked, so none of that can be traded away.

**PRIDE supports no query operators.** Quotes are discarded (there is no phrase search), `*` is dropped, and `AND`/`OR` match as ordinary literal terms — `liver OR kidney` returned **2** hits where `liver` alone returned **2,197**. Diacritics are not folded either: `Nájera` found nothing while `Najera` found a project. None of this can be escaped around, so a caller passing query syntax silently gets a different result set. It is documented on the method.

Empty and whitespace-only strings appear inside `keywords` on about 9% of hits — the never-null guarantee covers fields, not the elements inside them.

## Two things reviewers should weigh

1. **The tail probe has never bought a record back on search.** `total_records` was exact on every result set measured, and no live understatement could be constructed. Its value here rests on inheritance from the shared pager, where #1102 proved the bug on the file manifest — not on observed search misbehavior. Stating that plainly rather than letting the PR imply live evidence it does not have.
2. **There is no retry.** About 6% of requests stalled ~93 s against the client's 100 s timeout, so one stall over the limit discards an entire multi-page fetch with no partial result. I documented it rather than adding a retry policy, which felt like a separate architectural change rather than something to smuggle in here. Happy to do it if you would rather it were handled now.

Also deliberate: `filter` stays unexposed even though it is the only way to narrow below a keyword. If the cost above argues for anything, I think it argues for a *validated* `filter` in v2, not a result cap — a cap silently returns part of an answer, which is the failure mode this client has spent #1102 and #1173 eliminating.

## Testing

22 offline tests over two live-captured fixtures, plus 3 live canaries. The canaries search a narrow keyword deliberately (`MetaMorpheus`, 93 hits) — an early draft used `liver` and paged its whole 2,197-project result set, about 110 requests to EBI per run.

The load-bearing tests were each verified red by breaking only the source under test: the `[JsonProperty]` binding, the keyword escaping, the accession dedup, and the length guard.

- PRIDE offline: **172** · full offline suite: **5584 passed / 0 failed** · live PRIDE canaries: **pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
