### PR TITLE
ci(release): exclude live external-service tests from the release run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,24 @@ jobs:
           cd mzLib
           dotnet build --no-restore --configuration Release /p:Platform="Any CPU" /p:Version=${version}
       - name: Test
+        # Excludes the live external-service tests (Koina, PRIDE, UniProt), the same way the required job
+        # in dotnet.yml does. They were running here: this step had neither a filter nor a runsettings, so
+        # a tag push tested the package against third-party availability, inside a 30-minute job cap. A
+        # failure there leaves the tag public and the package unpublished, and recovery is deleting a
+        # public tag. Those services are already covered on master by the separate non-blocking
+        # external-service job, so running them again at pack time buys nothing.
+        #
+        # Uses the runsettings rather than a testcase filter to match the required job, so there is one
+        # exclusion to maintain rather than two spellings of it. Measured on this suite the two select
+        # the same 5609 tests, so this is about keeping them in one place, not about a difference.
+        #
+        # Do NOT add a testcase filter to this line. A filter overrides the Where clause outright rather
+        # than combining with it, so the exclusion would be silently discarded and the live tests would
+        # come back. Express any further narrowing as another clause in the runsettings.
         run: |
           $version= &git describe --tags
           cd mzLib
-          dotnet test --configuration Release /p:Platform="Any CPU" /p:Version=${version} --no-build
+          dotnet test --configuration Release /p:Platform="Any CPU" /p:Version=${version} --no-build --settings ./Test/required.runsettings
       - name: Pack and Push NuGet Package
         run: |
           $version= &git describe --tags


### PR DESCRIPTION
The release job runs `dotnet test` with neither a filter nor a runsettings, so a tag push tests the package against the live availability of Koina, PRIDE and UniProt — 26 fixtures, 198 test cases — inside a 30-minute job cap.

That was survivable while those services failed fast. #1189 changed the failure mode: a stalled transfer now waits out a two-minute connect deadline plus a two-minute inactivity deadline instead of erroring immediately, and #1173 and #1187 added further live PRIDE fixtures. The consequence of a timeout here is worse than in CI — the tag is already public, nothing was pushed to NuGet, and recovery is deleting a public tag and re-tagging.

Master already exercises these services in the separate, deliberately non-blocking `external-service-tests` job, so running them again at pack time buys nothing and couples publishing to a third party's uptime.

### Why the runsettings rather than a filter

To match the required job, so there is one exclusion to maintain rather than two spellings of it. **Not** because the two behave differently — I checked, and on this suite they do not:

```
--list-tests --filter "Category!=ExternalService"        → 5609 tests
--list-tests --settings ./Test/required.runsettings      → 5609 tests
diff of the two selected sets                            → empty
```

That is worth stating plainly because `Test/required.runsettings` currently explains itself in terms of the two selectors disagreeing, and I could not reproduce a disagreement — including against a fixture-level category, which was my best guess at the mechanism. Whatever caused live UniProt tests to run in the required job on 2026-08-21, it does not reproduce as a filter-versus-Where difference today. The deadline work in #1189 stands on its own; only that particular explanation looks unsupported. Happy to open a separate issue to correct the comment rather than touch it here.

### One thing that is real, and is why this line is fragile

Passing a testcase filter **alongside** a runsettings overrides the `Where` clause outright rather than combining with it:

| Command | Live fixture selected |
|---|---|
| `--settings required.runsettings` (alone) | 0 tests |
| `--settings required.runsettings --filter "FullyQualifiedName~PrideProjectSearchLiveTests"` | 3 tests |

The settings file is simply ignored when a filter is present. This step has no filter, which is what makes the exclusion apply — so it must not grow one. That is recorded in the step comment.

No change to what is packed or pushed; only which tests gate it.
