### PR TITLE
Implement GetAllPeptideToProteinMap, so shared-peptide protein quant can run

### DIFF
--- a/mzLib/Quantification/QuantificationEngine.cs
+++ b/mzLib/Quantification/QuantificationEngine.cs
@@ -364,7 +364,7 @@ public class QuantificationEngine
 
         // 7) Roll up to proteins
         var proteinMap = Parameters.UseSharedPeptidesForProteinQuant
-            ? GetAllPeptideToProteinMap(peptideMatrixNorm)
+            ? GetAllPeptideToProteinMap(peptideMatrixNorm, BioPolymerGroups)
             : GetUniquePeptideToProteinMap(peptideMatrixNorm, BioPolymerGroups);
 
         var proteinMatrix = Parameters.PeptideToProteinRollUpStrategy
@@ -565,10 +565,52 @@ public class QuantificationEngine
         return proteinToPeptideMap;
     }
 
-    // TODO: Implement this method to that include all peptides (shared and unique) in the mapping
-    public Dictionary<IBioPolymerGroup, List<int>> GetAllPeptideToProteinMap(
-        QuantMatrix<IBioPolymerWithSetMods> peptideMatrix)
+    /// <summary>
+    /// Creates a mapping from each protein group to the list of row indices in the peptide matrix that correspond to
+    /// every peptide assigned to that group -- shared as well as unique.
+    /// </summary>
+    /// <remarks>A shared peptide belongs to more than one protein group, so its row index appears in more than one
+    /// list. That is the difference from <see cref="GetUniquePeptideToProteinMap"/>, where each index appears once:
+    /// a shared peptide's intensity contributes to every group it was assigned to. Indices are sorted, because
+    /// <see cref="IBioPolymerGroup.AllBioPolymersWithSetMods"/> is a HashSet and its enumeration order is not
+    /// guaranteed stable -- an unsorted list would make roll-up results depend on set ordering.</remarks>
+    /// <param name="peptideMatrix">A matrix containing peptides as row keys.</param>
+    /// <param name="bioPolymerGroups">The protein groups to map. Groups with no peptide in the matrix get an empty list.</param>
+    /// <returns>A dictionary that maps each protein group to the sorted row indices of all of its peptides.</returns>
+    public static Dictionary<IBioPolymerGroup, List<int>> GetAllPeptideToProteinMap(
+        QuantMatrix<IBioPolymerWithSetMods> peptideMatrix, List<IBioPolymerGroup> bioPolymerGroups)
     {
-        throw new NotImplementedException();
+        var proteinToPeptideMap = new Dictionary<IBioPolymerGroup, List<int>>();
+
+        // Initialize empty lists for each protein group
+        foreach (var protein in bioPolymerGroups)
+        {
+            proteinToPeptideMap[protein] = new List<int>();
+        }
+
+        // Index the matrix rows once, rather than scanning it per protein group
+        var rowIndexByPeptide = new Dictionary<IBioPolymerWithSetMods, int>();
+        for (int i = 0; i < peptideMatrix.RowKeys.Count; i++)
+        {
+            rowIndexByPeptide[peptideMatrix.RowKeys[i]] = i;
+        }
+
+        foreach (var proteinGroup in bioPolymerGroups)
+        {
+            var rowIndices = proteinToPeptideMap[proteinGroup];
+
+            foreach (var peptide in proteinGroup.AllBioPolymersWithSetMods)
+            {
+                // A peptide the caller did not pass to the engine has no row to contribute
+                if (rowIndexByPeptide.TryGetValue(peptide, out int rowIndex))
+                {
+                    rowIndices.Add(rowIndex);
+                }
+            }
+
+            rowIndices.Sort();
+        }
+
+        return proteinToPeptideMap;
     }
 }

--- a/mzLib/Test/Quantification/SharedPeptideProteinMapTests.cs
+++ b/mzLib/Test/Quantification/SharedPeptideProteinMapTests.cs
@@ -1,0 +1,239 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using MassSpectrometry;
+using NUnit.Framework;
+using Omics;
+using Omics.BioPolymerGroup;
+using Omics.Digestion;
+using Omics.Modifications;
+using Proteomics;
+using Proteomics.ProteolyticDigestion;
+using Quantification;
+using Omics.SpectralMatch;
+using Test.Omics;
+
+namespace Test.Quantification
+{
+    /// <summary>
+    /// Tests for QuantificationEngine.GetAllPeptideToProteinMap -- the shared-peptide half of
+    /// protein roll-up, which threw NotImplementedException until now, so
+    /// UseSharedPeptidesForProteinQuant = true could not run at all.
+    /// </summary>
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class SharedPeptideProteinMapTests
+    {
+        private class TestExperimentalDesign : IExperimentalDesign
+        {
+            public Dictionary<string, ISampleInfo[]> FileNameSampleInfoDictionary { get; }
+
+            public TestExperimentalDesign(Dictionary<string, ISampleInfo[]> dict)
+            {
+                FileNameSampleInfoDictionary = dict;
+            }
+        }
+
+        private static IBioPolymerWithSetMods Peptide(string sequence, string accession)
+        {
+            var protein = new Protein(sequence, accession);
+            var digestionParams = new DigestionParams(maxMissedCleavages: 0, minPeptideLength: 5);
+            return protein.Digest(digestionParams, new List<Modification>(), new List<Modification>()).First();
+        }
+
+        private static BioPolymerGroup Group(
+            string accession,
+            IEnumerable<IBioPolymerWithSetMods> all,
+            IEnumerable<IBioPolymerWithSetMods> unique)
+        {
+            return new BioPolymerGroup(
+                new HashSet<IBioPolymer> { new Protein("MPEPTIDEK", accession) },
+                new HashSet<IBioPolymerWithSetMods>(all),
+                new HashSet<IBioPolymerWithSetMods>(unique));
+        }
+
+        private static QuantMatrix<IBioPolymerWithSetMods> MatrixOf(params IBioPolymerWithSetMods[] peptides)
+        {
+            const string file = "file1.raw";
+            var columns = new List<ISampleInfo>
+            {
+                new IsobaricQuantSampleInfo(file, "Control", 0, 0, 0, 0, "126", 126.0, false)
+            };
+            var design = new TestExperimentalDesign(
+                new Dictionary<string, ISampleInfo[]> { [file] = columns.ToArray() });
+
+            return new QuantMatrix<IBioPolymerWithSetMods>(peptides.ToList(), columns, design);
+        }
+
+        [Test]
+        public void SharedPeptide_CountsTowardEveryGroupItBelongsTo()
+        {
+            var pepA = Peptide("PEPTIDEK", "P1");
+            var pepShared = Peptide("SEQUENCEK", "P2");
+            var pepC = Peptide("ANOTHERK", "P3");
+
+            // pepShared is in both groups; pepA is unique to g1 and pepC unique to g2.
+            var g1 = Group("G1", new[] { pepA, pepShared }, new[] { pepA });
+            var g2 = Group("G2", new[] { pepShared, pepC }, new[] { pepC });
+            var groups = new List<IBioPolymerGroup> { g1, g2 };
+
+            var matrix = MatrixOf(pepA, pepShared, pepC);
+
+            var map = QuantificationEngine.GetAllPeptideToProteinMap(matrix, groups);
+
+            Assert.Multiple(() =>
+            {
+                // Row 1 (the shared peptide) appears in both lists. That is the whole difference
+                // from the unique map, where each row index appears at most once.
+                Assert.That(map[g1], Is.EqualTo(new List<int> { 0, 1 }));
+                Assert.That(map[g2], Is.EqualTo(new List<int> { 1, 2 }));
+            });
+        }
+
+        [Test]
+        public void UniqueMap_ExcludesTheSharedPeptide()
+        {
+            var pepA = Peptide("PEPTIDEK", "P1");
+            var pepShared = Peptide("SEQUENCEK", "P2");
+            var pepC = Peptide("ANOTHERK", "P3");
+
+            var g1 = Group("G1", new[] { pepA, pepShared }, new[] { pepA });
+            var g2 = Group("G2", new[] { pepShared, pepC }, new[] { pepC });
+            var groups = new List<IBioPolymerGroup> { g1, g2 };
+
+            var matrix = MatrixOf(pepA, pepShared, pepC);
+
+            var unique = QuantificationEngine.GetUniquePeptideToProteinMap(matrix, groups);
+            var all = QuantificationEngine.GetAllPeptideToProteinMap(matrix, groups);
+
+            Assert.Multiple(() =>
+            {
+                // Contrast, on the same input: the shared row is absent from the unique map and
+                // present in both lists of the all map.
+                Assert.That(unique[g1], Is.EqualTo(new List<int> { 0 }));
+                Assert.That(unique[g2], Is.EqualTo(new List<int> { 2 }));
+                Assert.That(all[g1].Count + all[g2].Count, Is.EqualTo(4));
+                Assert.That(unique[g1].Count + unique[g2].Count, Is.EqualTo(2));
+            });
+        }
+
+        [Test]
+        public void EveryGroupGetsAnEntry_EvenWithNoPeptidesInTheMatrix()
+        {
+            var pepA = Peptide("PEPTIDEK", "P1");
+            var absent = Peptide("SEQUENCEK", "P2");
+
+            var g1 = Group("G1", new[] { pepA }, new[] { pepA });
+            var g2 = Group("G2", new[] { absent }, new[] { absent });
+            var groups = new List<IBioPolymerGroup> { g1, g2 };
+
+            // Only pepA is in the matrix -- g2's peptide was never passed to the engine.
+            var matrix = MatrixOf(pepA);
+
+            var map = QuantificationEngine.GetAllPeptideToProteinMap(matrix, groups);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(map.Keys, Has.Count.EqualTo(2));
+                Assert.That(map[g1], Is.EqualTo(new List<int> { 0 }));
+                // An empty list, not a missing key -- the roll-up strategy iterates the map.
+                Assert.That(map[g2], Is.Empty);
+            });
+        }
+
+        [Test]
+        public void RowIndicesAreSorted()
+        {
+            var pep1 = Peptide("PEPTIDEK", "P1");
+            var pep2 = Peptide("SEQUENCEK", "P2");
+            var pep3 = Peptide("ANOTHERK", "P3");
+            var pep4 = Peptide("MYFAVORITEK", "P4");
+
+            var group = Group("G1", new[] { pep4, pep1, pep3, pep2 }, new[] { pep1 });
+            var groups = new List<IBioPolymerGroup> { group };
+
+            var matrix = MatrixOf(pep1, pep2, pep3, pep4);
+
+            var map = QuantificationEngine.GetAllPeptideToProteinMap(matrix, groups);
+
+            // AllBioPolymersWithSetMods is a HashSet, whose enumeration order is not guaranteed
+            // stable. Sorting keeps roll-up from depending on it.
+            Assert.That(map[group], Is.EqualTo(new List<int> { 0, 1, 2, 3 }));
+        }
+
+        [Test]
+        public void Engine_RunsWithSharedPeptidesEnabled()
+        {
+            const string file = "file1.raw";
+            var columns = new ISampleInfo[]
+            {
+                new IsobaricQuantSampleInfo(file, "Control", 0, 0, 0, 0, "126", 126.0, false),
+                new IsobaricQuantSampleInfo(file, "Treatment", 0, 0, 0, 0, "127N", 127.1, false)
+            };
+            var design = new TestExperimentalDesign(
+                new Dictionary<string, ISampleInfo[]> { [file] = columns });
+
+            var pepA = Peptide("PEPTIDEK", "P1");
+            var pepShared = Peptide("SEQUENCEK", "P2");
+            var pepC = Peptide("ANOTHERK", "P3");
+            var peptides = new List<IBioPolymerWithSetMods> { pepA, pepShared, pepC };
+
+            var g1 = Group("G1", new[] { pepA, pepShared }, new[] { pepA });
+            var g2 = Group("G2", new[] { pepShared, pepC }, new[] { pepC });
+            var groups = new List<IBioPolymerGroup> { g1, g2 };
+
+            int scan = 1;
+            var matches = peptides
+                .Select(p => (ISpectralMatch)new MockSpectralMatch(
+                    file, p.FullSequence, p.BaseSequence, 100.0, scan++, new[] { p })
+                {
+                    Intensities = new[] { 1000.0, 2000.0 }
+                })
+                .ToList();
+
+            var parameters = QuantificationParameters.GetSimpleParameters();
+            parameters.UseSharedPeptidesForProteinQuant = true;
+
+            var engine = new QuantificationEngine(parameters, design, matches, peptides, groups);
+
+            // Before this change, Run() threw NotImplementedException here -- the flag was settable
+            // and unusable.
+            var result = engine.Run();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Success, Is.True, result.Summary);
+
+                // Both groups quantify. G1 gets pepA + pepShared, G2 gets pepShared + pepC, so with
+                // equal peptide intensities the shared peptide lands in both totals.
+                Assert.That(g1.IntensitiesBySample, Is.Not.Null.And.Not.Empty);
+                Assert.That(g2.IntensitiesBySample, Is.Not.Null.And.Not.Empty);
+                Assert.That(g1.IntensitiesBySample.Values.Sum(), Is.EqualTo(g2.IntensitiesBySample.Values.Sum()));
+            });
+        }
+
+        [Test]
+        public void NoGroups_GivesAnEmptyMap()
+        {
+            var matrix = MatrixOf(Peptide("PEPTIDEK", "P1"));
+
+            var map = QuantificationEngine.GetAllPeptideToProteinMap(matrix, new List<IBioPolymerGroup>());
+
+            Assert.That(map, Is.Empty);
+        }
+
+        [Test]
+        public void EmptyMatrix_GivesEveryGroupAnEmptyList()
+        {
+            var pepA = Peptide("PEPTIDEK", "P1");
+            var group = Group("G1", new[] { pepA }, new[] { pepA });
+
+            var matrix = MatrixOf();
+
+            var map = QuantificationEngine.GetAllPeptideToProteinMap(
+                matrix, new List<IBioPolymerGroup> { group });
+
+            Assert.That(map[group], Is.Empty);
+        }
+    }
+}

--- a/mzLib/Test/Quantification/SharedPeptideProteinMapTests.cs
+++ b/mzLib/Test/Quantification/SharedPeptideProteinMapTests.cs
@@ -52,6 +52,14 @@ namespace Test.Quantification
                 new HashSet<IBioPolymerWithSetMods>(unique));
         }
 
+        /// <summary>The group's delivered intensities, keyed by channel label rather than sample object.</summary>
+        private static Dictionary<string, double> ByChannel(IBioPolymerGroup group)
+        {
+            return group.IntensitiesBySample.ToDictionary(
+                kvp => ((IsobaricQuantSampleInfo)kvp.Key).ChannelLabel,
+                kvp => kvp.Value);
+        }
+
         private static QuantMatrix<IBioPolymerWithSetMods> MatrixOf(params IBioPolymerWithSetMods[] peptides)
         {
             const string file = "file1.raw";
@@ -161,8 +169,12 @@ namespace Test.Quantification
             Assert.That(map[group], Is.EqualTo(new List<int> { 0, 1, 2, 3 }));
         }
 
-        [Test]
-        public void Engine_RunsWithSharedPeptidesEnabled()
+        /// <summary>
+        /// Builds the same two-group scenario each time -- fresh groups, because the engine writes its
+        /// results onto them -- and returns each group's per-channel totals.
+        /// </summary>
+        private static (Dictionary<string, double> g1, Dictionary<string, double> g2, QuantificationResults result)
+            RunSharedPeptideScenario(bool useSharedPeptides)
         {
             const string file = "file1.raw";
             var columns = new ISampleInfo[]
@@ -182,33 +194,72 @@ namespace Test.Quantification
             var g2 = Group("G2", new[] { pepShared, pepC }, new[] { pepC });
             var groups = new List<IBioPolymerGroup> { g1, g2 };
 
+            // Distinct intensities per peptide, so the expected protein totals are only reachable if
+            // the shared peptide really is counted in both groups. With equal values the totals match
+            // even when the shared peptide is dropped from both.
+            var intensityByPeptide = new Dictionary<IBioPolymerWithSetMods, double[]>
+            {
+                [pepA] = new[] { 100.0, 200.0 },
+                [pepShared] = new[] { 30.0, 60.0 },
+                [pepC] = new[] { 7.0, 14.0 },
+            };
+
             int scan = 1;
             var matches = peptides
                 .Select(p => (ISpectralMatch)new MockSpectralMatch(
                     file, p.FullSequence, p.BaseSequence, 100.0, scan++, new[] { p })
                 {
-                    Intensities = new[] { 1000.0, 2000.0 }
+                    Intensities = intensityByPeptide[p]
                 })
                 .ToList();
 
             var parameters = QuantificationParameters.GetSimpleParameters();
-            parameters.UseSharedPeptidesForProteinQuant = true;
+            parameters.UseSharedPeptidesForProteinQuant = useSharedPeptides;
 
             var engine = new QuantificationEngine(parameters, design, matches, peptides, groups);
 
-            // Before this change, Run() threw NotImplementedException here -- the flag was settable
-            // and unusable.
+            // Before this change, Run() threw NotImplementedException here with the flag on -- it was
+            // settable and unusable.
             var result = engine.Run();
+
+            return (ByChannel(g1), ByChannel(g2), result);
+        }
+
+        [Test]
+        public void Engine_RunsWithSharedPeptidesEnabled()
+        {
+            var (g1ByChannel, g2ByChannel, result) = RunSharedPeptideScenario(useSharedPeptides: true);
 
             Assert.Multiple(() =>
             {
                 Assert.That(result.Success, Is.True, result.Summary);
 
-                // Both groups quantify. G1 gets pepA + pepShared, G2 gets pepShared + pepC, so with
-                // equal peptide intensities the shared peptide lands in both totals.
-                Assert.That(g1.IntensitiesBySample, Is.Not.Null.And.Not.Empty);
-                Assert.That(g2.IntensitiesBySample, Is.Not.Null.And.Not.Empty);
-                Assert.That(g1.IntensitiesBySample.Values.Sum(), Is.EqualTo(g2.IntensitiesBySample.Values.Sum()));
+                // G1 = pepA + pepShared = 100+30 and 200+60. G2 = pepShared + pepC = 30+7 and 60+14.
+                // Neither is reachable without the shared peptide -- the companion test below pins
+                // what the same input produces when it is excluded.
+                Assert.That(g1ByChannel["126"], Is.EqualTo(130.0));
+                Assert.That(g1ByChannel["127N"], Is.EqualTo(260.0));
+                Assert.That(g2ByChannel["126"], Is.EqualTo(37.0));
+                Assert.That(g2ByChannel["127N"], Is.EqualTo(74.0));
+            });
+        }
+
+        [Test]
+        public void Engine_WithSharedPeptidesOff_LeavesTheSharedPeptideOut()
+        {
+            var (g1ByChannel, g2ByChannel, result) = RunSharedPeptideScenario(useSharedPeptides: false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Success, Is.True, result.Summary);
+
+                // Same input, unique peptides only: G1 is pepA alone and G2 is pepC alone. Every value
+                // differs from the shared-peptide run, so the pair of tests distinguishes the two
+                // behaviours rather than merely agreeing with each other.
+                Assert.That(g1ByChannel["126"], Is.EqualTo(100.0));
+                Assert.That(g1ByChannel["127N"], Is.EqualTo(200.0));
+                Assert.That(g2ByChannel["126"], Is.EqualTo(7.0));
+                Assert.That(g2ByChannel["127N"], Is.EqualTo(14.0));
             });
         }
 


### PR DESCRIPTION
`QuantificationParameters.UseSharedPeptidesForProteinQuant` is a public settable bool. Setting it `true` made `QuantificationEngine.Run()` throw `NotImplementedException` from `RunProteinQuant`:

```csharp
var proteinMap = Parameters.UseSharedPeptidesForProteinQuant
    ? GetAllPeptideToProteinMap(peptideMatrixNorm)   // throw new NotImplementedException();
    : GetUniquePeptideToProteinMap(peptideMatrixNorm, BioPolymerGroups);
```

Settable and unusable, with nothing saying so until a search had already run. It was the only `TODO` left in the Quantification project.

### What the map does

It differs from `GetUniquePeptideToProteinMap` in exactly one way: a shared peptide belongs to more than one protein group, so its row index appears in more than one list, and its intensity contributes to every group it was assigned to. Everything else matches the sibling — an entry for every group, and an empty list rather than a missing key for a group whose peptides aren't in the matrix, because the roll-up strategy iterates the map either way.

### Two details worth naming

**Row indices are sorted.** `AllBioPolymersWithSetMods` is a `HashSet` and its enumeration order is not guaranteed stable, so an unsorted list would let roll-up results depend on set ordering. That's the same class of irreproducibility as #1155.

**The matrix rows are indexed once** into a dictionary rather than rescanned per protein group, so the cost is linear in peptides plus group memberships rather than their product.

### One signature change

Made `static` and given the protein-group list, matching `GetUniquePeptideToProteinMap` immediately above it. Changing a public signature is normally a break — but the method threw unconditionally, so no caller can exist.

### Tests

7 new, including one that runs the engine end to end with the flag on: the call that used to throw. The contrast test asserts both maps on the same input, so the shared row being absent from one and present twice in the other is visible in a single assertion block.

`Test.Quantification`, `Test.Omics` and `FlashLFQ` are green — 1031 passed.
