### PR TITLE
Exclude ambiguous spectral matches from quantification, and say how many

### DIFF
--- a/mzLib/Quantification/QuantificationEngine.cs
+++ b/mzLib/Quantification/QuantificationEngine.cs
@@ -103,10 +103,19 @@ public class QuantificationEngine
         OverwriteSampleIntensities(peptideMatrix);
         OverwriteSampleIntensities(proteinMatrix);
 
+        // Report the matches the peptide map had to drop, so an unexpectedly small result set has a
+        // stated cause rather than being silently smaller than the search.
+        int ambiguousExcluded = SpectralMatches
+            .Count(sm => sm.Intensities != null && sm.GetIdentifiedBioPolymersWithSetMods().Take(2).Count() != 1);
+
         return new QuantificationResults
         {
-            Summary = "Quantification completed successfully.",
+            Summary = ambiguousExcluded == 0
+                ? "Quantification completed successfully."
+                : $"Quantification completed successfully. {ambiguousExcluded} spectral match(es) were " +
+                  "excluded because they did not identify exactly one biopolymer.",
             Success = true,
+            AmbiguousSpectralMatchesExcluded = ambiguousExcluded,
             Samples = proteinMatrix.ColumnKeys.ToList(),
             PeptideIntensities = BuildIntensityTable(peptideMatrix),
             ProteinIntensities = BuildIntensityTable(proteinMatrix),
@@ -491,8 +500,11 @@ public class QuantificationEngine
     /// Creates a mapping from each specified modified biopolymer to a list of indices that identify the position of corresponding
     /// spectral matches in the smMatrix
     /// </summary>
-    /// <remarks>The mapping assumes that each PM in the matrix is associated with a single, unambiguous
-    /// modified biopolymer. Biopolymers not present in the input list are ignored.</remarks>
+    /// <remarks>A spectral match is quantified only when it identifies exactly one modified biopolymer.
+    /// An ambiguous match -- one that identifies several -- is excluded rather than attributed to whichever
+    /// biopolymer happens to be enumerated first, and a match that identifies none is excluded rather than
+    /// throwing. Biopolymers not present in the input list are ignored.
+    /// <see cref="QuantificationResults.AmbiguousSpectralMatchesExcluded"/> reports how many were dropped.</remarks>
     /// <param name="smMatrix">The matrix containing spectrum matches to be mapped to their corresponding modified bioPolymer.</param>
     /// <param name="modifiedBioPolymers">The list of modified bioPolymers for which to generate the mapping.
     /// Only SMs corresponding to these bioPolymers are included in the result.</param>
@@ -508,7 +520,16 @@ public class QuantificationEngine
         for (int i = 0; i < smMatrix.RowKeys.Count; i++)
         {
             var sm = smMatrix.RowKeys[i];
-            var peptide = sm.GetIdentifiedBioPolymersWithSetMods().First(); // Assumes unambiguous mapping
+
+            // Only unambiguous matches are quantified. Take(2) is enough to tell "exactly one" from
+            // "more than one" without enumerating a long ambiguity list.
+            var identified = sm.GetIdentifiedBioPolymersWithSetMods().Take(2).ToList();
+            if (identified.Count != 1)
+            {
+                continue;
+            }
+
+            var peptide = identified[0];
             if (!peptideToPsmMap.ContainsKey(peptide))
             {
                 continue;

--- a/mzLib/Quantification/QuantificationEngine.cs
+++ b/mzLib/Quantification/QuantificationEngine.cs
@@ -105,8 +105,9 @@ public class QuantificationEngine
 
         // Report the matches the peptide map had to drop, so an unexpectedly small result set has a
         // stated cause rather than being silently smaller than the search.
+        // Same predicate the peptide map applies, so the count cannot drift from what was dropped.
         int ambiguousExcluded = SpectralMatches
-            .Count(sm => sm.Intensities != null && sm.GetIdentifiedBioPolymersWithSetMods().Take(2).Count() != 1);
+            .Count(sm => sm.Intensities != null && SingleIdentifiedBioPolymerOrNull(sm) == null);
 
         return new QuantificationResults
         {
@@ -510,6 +511,34 @@ public class QuantificationEngine
     /// Only SMs corresponding to these bioPolymers are included in the result.</param>
     /// <returns>A dictionary mapping each modified bioPolymer in the input list to a list of indices of PSMs in the matrix that
     /// are associated with it. If a bioPolymer has no corresponding PSMs, its list will be empty.</returns>
+    /// <summary>
+    /// The single biopolymer a spectral match identifies, or null when it identifies none or several.
+    /// This is the unambiguous filter, in one place, so that the quantified set and the count reported
+    /// as <see cref="QuantificationResults.AmbiguousSpectralMatchesExcluded"/> cannot disagree.
+    /// </summary>
+    /// <remarks>
+    /// Distinct, not raw count. A match that names the same biopolymer more than once -- once per
+    /// protein it maps to, for instance -- identifies one peptide in substance, and dropping it as
+    /// ambiguous would discard a perfectly good measurement. Nulls are ignored for the same reason.
+    /// Take(2) still short-circuits, so a long ambiguity list is not enumerated.
+    /// </remarks>
+    internal static IBioPolymerWithSetMods SingleIdentifiedBioPolymerOrNull(ISpectralMatch spectralMatch)
+    {
+        var identified = spectralMatch.GetIdentifiedBioPolymersWithSetMods();
+        if (identified == null)
+        {
+            return null;
+        }
+
+        var distinct = identified
+            .Where(bp => bp != null)
+            .Distinct()
+            .Take(2)
+            .ToList();
+
+        return distinct.Count == 1 ? distinct[0] : null;
+    }
+
     public static Dictionary<IBioPolymerWithSetMods, List<int>> GetPsmToPeptideMap(QuantMatrix<ISpectralMatch> smMatrix, List<IBioPolymerWithSetMods> modifiedBioPolymers)
     {
         var peptideToPsmMap = new Dictionary<IBioPolymerWithSetMods, List<int>>();
@@ -521,15 +550,13 @@ public class QuantificationEngine
         {
             var sm = smMatrix.RowKeys[i];
 
-            // Only unambiguous matches are quantified. Take(2) is enough to tell "exactly one" from
-            // "more than one" without enumerating a long ambiguity list.
-            var identified = sm.GetIdentifiedBioPolymersWithSetMods().Take(2).ToList();
-            if (identified.Count != 1)
+            // Only unambiguous matches are quantified.
+            var peptide = SingleIdentifiedBioPolymerOrNull(sm);
+            if (peptide == null)
             {
                 continue;
             }
 
-            var peptide = identified[0];
             if (!peptideToPsmMap.ContainsKey(peptide))
             {
                 continue;

--- a/mzLib/Quantification/QuantificationResults.cs
+++ b/mzLib/Quantification/QuantificationResults.cs
@@ -69,6 +69,15 @@ namespace Quantification
         /// </summary>
         public string OutputDirectory { get; internal set; }
 
+        /// <summary>
+        /// How many spectral matches were left out of quantification because they did not identify
+        /// exactly one biopolymer -- an ambiguous match, or one carrying no identification at all.
+        /// Such a match cannot be attributed to a peptide without guessing, so it is dropped; this
+        /// count is here so that dropping it is visible rather than silent. It is also echoed in
+        /// <see cref="Summary"/> when it is not zero.
+        /// </summary>
+        public int AmbiguousSpectralMatchesExcluded { get; internal set; }
+
         internal static QuantificationResults Failure(string summary) =>
             new QuantificationResults { Summary = summary, Success = false };
     }

--- a/mzLib/Test/Quantification/AmbiguousMatchFilterTests.cs
+++ b/mzLib/Test/Quantification/AmbiguousMatchFilterTests.cs
@@ -1,0 +1,188 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using MassSpectrometry;
+using NUnit.Framework;
+using Omics;
+using Omics.BioPolymerGroup;
+using Omics.Digestion;
+using Omics.Modifications;
+using Omics.SpectralMatch;
+using Proteomics;
+using Proteomics.ProteolyticDigestion;
+using Quantification;
+using Test.Omics;
+
+namespace Test.Quantification
+{
+    /// <summary>
+    /// Tests the unambiguous filter in GetPsmToPeptideMap. Before this, the map took
+    /// GetIdentifiedBioPolymersWithSetMods().First() with the comment "Assumes unambiguous mapping",
+    /// so an ambiguous match was attributed to whichever biopolymer came first and a match with no
+    /// identification threw InvalidOperationException.
+    /// </summary>
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class AmbiguousMatchFilterTests
+    {
+        private const string File = "file1.raw";
+
+        private class TestExperimentalDesign : IExperimentalDesign
+        {
+            public Dictionary<string, ISampleInfo[]> FileNameSampleInfoDictionary { get; }
+
+            public TestExperimentalDesign(Dictionary<string, ISampleInfo[]> dict)
+            {
+                FileNameSampleInfoDictionary = dict;
+            }
+        }
+
+        private static IBioPolymerWithSetMods Peptide(string sequence, string accession)
+        {
+            var protein = new Protein(sequence, accession);
+            var digestionParams = new DigestionParams(maxMissedCleavages: 0, minPeptideLength: 5);
+            return protein.Digest(digestionParams, new List<Modification>(), new List<Modification>()).First();
+        }
+
+        private static List<ISampleInfo> Columns() => new List<ISampleInfo>
+        {
+            new IsobaricQuantSampleInfo(File, "Control", 0, 0, 0, 0, "126", 126.0, false),
+            new IsobaricQuantSampleInfo(File, "Treatment", 0, 0, 0, 0, "127N", 127.1, false)
+        };
+
+        private static TestExperimentalDesign Design(List<ISampleInfo> columns) =>
+            new TestExperimentalDesign(new Dictionary<string, ISampleInfo[]> { [File] = columns.ToArray() });
+
+        private static MockSpectralMatch Match(int scan, params IBioPolymerWithSetMods[] identified) =>
+            new MockSpectralMatch(File, $"SEQ{scan}", $"SEQ{scan}", 100.0, scan, identified)
+            {
+                Intensities = new[] { 1000.0, 2000.0 }
+            };
+
+        private static QuantMatrix<ISpectralMatch> MatrixOf(params ISpectralMatch[] matches)
+        {
+            var columns = Columns();
+            return new QuantMatrix<ISpectralMatch>(matches.ToList(), columns, Design(columns));
+        }
+
+        [Test]
+        public void AmbiguousMatch_IsExcluded_NotAttributedToTheFirstCandidate()
+        {
+            var pepA = Peptide("PEPTIDEK", "P1");
+            var pepB = Peptide("SEQUENCEK", "P2");
+
+            var unambiguous = Match(1, pepA);
+            var ambiguous = Match(2, pepA, pepB); // could be either -- so it is neither
+
+            var matrix = MatrixOf(unambiguous, ambiguous);
+
+            var map = QuantificationEngine.GetPsmToPeptideMap(
+                matrix, new List<IBioPolymerWithSetMods> { pepA, pepB });
+
+            Assert.Multiple(() =>
+            {
+                // Row 1 is the ambiguous match. Previously it landed on pepA, because pepA is first.
+                Assert.That(map[pepA], Is.EqualTo(new List<int> { 0 }));
+                Assert.That(map[pepB], Is.Empty);
+            });
+        }
+
+        [Test]
+        public void MatchWithNoIdentification_IsExcludedRatherThanThrowing()
+        {
+            var pepA = Peptide("PEPTIDEK", "P1");
+
+            var matrix = MatrixOf(Match(1, pepA), Match(2));
+
+            // .First() on an empty sequence threw InvalidOperationException here.
+            Dictionary<IBioPolymerWithSetMods, List<int>> map = null;
+            Assert.DoesNotThrow(() => map = QuantificationEngine.GetPsmToPeptideMap(
+                matrix, new List<IBioPolymerWithSetMods> { pepA }));
+
+            Assert.That(map[pepA], Is.EqualTo(new List<int> { 0 }));
+        }
+
+        [Test]
+        public void UnambiguousMatches_AreUnaffected()
+        {
+            var pepA = Peptide("PEPTIDEK", "P1");
+            var pepB = Peptide("SEQUENCEK", "P2");
+
+            var matrix = MatrixOf(Match(1, pepA), Match(2, pepB), Match(3, pepA));
+
+            var map = QuantificationEngine.GetPsmToPeptideMap(
+                matrix, new List<IBioPolymerWithSetMods> { pepA, pepB });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(map[pepA], Is.EqualTo(new List<int> { 0, 2 }));
+                Assert.That(map[pepB], Is.EqualTo(new List<int> { 1 }));
+            });
+        }
+
+        [Test]
+        public void Engine_ReportsHowManyMatchesItExcluded()
+        {
+            var pepA = Peptide("PEPTIDEK", "P1");
+            var pepB = Peptide("SEQUENCEK", "P2");
+            var peptides = new List<IBioPolymerWithSetMods> { pepA, pepB };
+
+            var group = new BioPolymerGroup(
+                new HashSet<IBioPolymer> { new Protein("MPEPTIDEK", "G1") },
+                new HashSet<IBioPolymerWithSetMods>(peptides),
+                new HashSet<IBioPolymerWithSetMods>(peptides));
+
+            var matches = new List<ISpectralMatch>
+            {
+                Match(1, pepA),
+                Match(2, pepB),
+                Match(3, pepA, pepB), // ambiguous
+                Match(4)              // no identification
+            };
+
+            var columns = Columns();
+            var parameters = QuantificationParameters.GetSimpleParameters();
+            var engine = new QuantificationEngine(
+                parameters, Design(columns), matches, peptides,
+                new List<IBioPolymerGroup> { group });
+
+            var result = engine.Run();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Success, Is.True, result.Summary);
+                // Dropping these is correct; dropping them silently is not.
+                Assert.That(result.AmbiguousSpectralMatchesExcluded, Is.EqualTo(2));
+                Assert.That(result.Summary, Does.Contain("2 spectral match(es) were excluded"));
+            });
+        }
+
+        [Test]
+        public void Engine_SaysNothingExtraWhenNothingWasExcluded()
+        {
+            var pepA = Peptide("PEPTIDEK", "P1");
+            var peptides = new List<IBioPolymerWithSetMods> { pepA };
+
+            var group = new BioPolymerGroup(
+                new HashSet<IBioPolymer> { new Protein("MPEPTIDEK", "G1") },
+                new HashSet<IBioPolymerWithSetMods>(peptides),
+                new HashSet<IBioPolymerWithSetMods>(peptides));
+
+            var columns = Columns();
+            var engine = new QuantificationEngine(
+                QuantificationParameters.GetSimpleParameters(),
+                Design(columns),
+                new List<ISpectralMatch> { Match(1, pepA) },
+                peptides,
+                new List<IBioPolymerGroup> { group });
+
+            var result = engine.Run();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.AmbiguousSpectralMatchesExcluded, Is.Zero);
+                Assert.That(result.Summary, Is.EqualTo("Quantification completed successfully."));
+            });
+        }
+    }
+}

--- a/mzLib/Test/Quantification/AmbiguousMatchFilterTests.cs
+++ b/mzLib/Test/Quantification/AmbiguousMatchFilterTests.cs
@@ -103,6 +103,73 @@ namespace Test.Quantification
         }
 
         [Test]
+        public void SamePeptideNamedTwice_IsNotAmbiguous()
+        {
+            var pepA = Peptide("PEPTIDEK", "P1");
+
+            // A match can name one peptide once per protein it maps to. That identifies a single
+            // peptide in substance, so counting raw entries would throw away a good measurement.
+            var matrix = MatrixOf(Match(1, pepA, pepA));
+
+            var map = QuantificationEngine.GetPsmToPeptideMap(
+                matrix, new List<IBioPolymerWithSetMods> { pepA });
+
+            Assert.That(map[pepA], Is.EqualTo(new List<int> { 0 }));
+        }
+
+        [Test]
+        public void NullAlongsideOneIdentification_IsNotAmbiguous()
+        {
+            var pepA = Peptide("PEPTIDEK", "P1");
+
+            var matrix = MatrixOf(Match(1, pepA, null));
+
+            var map = QuantificationEngine.GetPsmToPeptideMap(
+                matrix, new List<IBioPolymerWithSetMods> { pepA });
+
+            Assert.That(map[pepA], Is.EqualTo(new List<int> { 0 }));
+        }
+
+        [Test]
+        public void TheReportedCountMatchesWhatWasActuallyDropped()
+        {
+            var pepA = Peptide("PEPTIDEK", "P1");
+            var pepB = Peptide("SEQUENCEK", "P2");
+            var peptides = new List<IBioPolymerWithSetMods> { pepA, pepB };
+
+            var group = new BioPolymerGroup(
+                new HashSet<IBioPolymer> { new Protein("MPEPTIDEK", "G1") },
+                new HashSet<IBioPolymerWithSetMods>(peptides),
+                new HashSet<IBioPolymerWithSetMods>(peptides));
+
+            var matches = new List<ISpectralMatch>
+            {
+                Match(1, pepA),
+                Match(2, pepA, pepA),   // one peptide, named twice -- kept
+                Match(3, pepA, null),   // one peptide plus a null -- kept
+                Match(4, pepA, pepB),   // genuinely ambiguous -- dropped
+                Match(5)                // no identification -- dropped
+            };
+
+            var columns = Columns();
+            var engine = new QuantificationEngine(
+                QuantificationParameters.GetSimpleParameters(), Design(columns), matches, peptides,
+                new List<IBioPolymerGroup> { group });
+
+            var result = engine.Run();
+
+            // The count and the filter run off one predicate, so this pins them together.
+            var matrix = MatrixOf(matches.ToArray());
+            var kept = QuantificationEngine.GetPsmToPeptideMap(matrix, peptides).Values.Sum(v => v.Count);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.AmbiguousSpectralMatchesExcluded, Is.EqualTo(2));
+                Assert.That(kept, Is.EqualTo(matches.Count - result.AmbiguousSpectralMatchesExcluded));
+            });
+        }
+
+        [Test]
         public void UnambiguousMatches_AreUnaffected()
         {
             var pepA = Peptide("PEPTIDEK", "P1");

--- a/mzLib/Test/Quantification/AmbiguousMatchFilterTests.cs
+++ b/mzLib/Test/Quantification/AmbiguousMatchFilterTests.cs
@@ -102,6 +102,35 @@ namespace Test.Quantification
             Assert.That(map[pepA], Is.EqualTo(new List<int> { 0 }));
         }
 
+        /// <summary>
+        /// A match whose identification collection is null rather than empty. MockSpectralMatch always
+        /// returns a list, so reaching that branch takes a match that does not.
+        /// </summary>
+        private class NullIdentificationMatch : BaseSpectralMatch
+        {
+            public NullIdentificationMatch(int scan)
+                : base(File, scan, 100.0, $"SEQ{scan}", $"SEQ{scan}")
+            {
+                Intensities = new[] { 1000.0, 2000.0 };
+            }
+
+            public override IEnumerable<IBioPolymerWithSetMods> GetIdentifiedBioPolymersWithSetMods() => null;
+        }
+
+        [Test]
+        public void MatchWithANullIdentificationCollection_IsExcludedRatherThanThrowing()
+        {
+            var pepA = Peptide("PEPTIDEK", "P1");
+
+            var matrix = MatrixOf(Match(1, pepA), new NullIdentificationMatch(2));
+
+            Dictionary<IBioPolymerWithSetMods, List<int>> map = null;
+            Assert.DoesNotThrow(() => map = QuantificationEngine.GetPsmToPeptideMap(
+                matrix, new List<IBioPolymerWithSetMods> { pepA }));
+
+            Assert.That(map[pepA], Is.EqualTo(new List<int> { 0 }));
+        }
+
         [Test]
         public void SamePeptideNamedTwice_IsNotAmbiguous()
         {


### PR DESCRIPTION
`GetPsmToPeptideMap` did this:

```csharp
var peptide = sm.GetIdentifiedBioPolymersWithSetMods().First(); // Assumes unambiguous mapping
```

The assumption is not checked anywhere. A match that identified several biopolymers was attributed to whichever one came first — a plausible intensity recorded against a peptide that may not be the one measured, with nothing to indicate it happened. #996's pipeline specifies an unambiguous filter at exactly this point; this is it.

MetaMorpheus avoids the bug by filtering at its own call site with `includeAmbiguous: false`, so it has been exercising the safe path all along. No other consumer of the engine gets that for free.

### What changes

**A spectral match is quantified only when it identifies exactly one biopolymer.** `Take(2)` distinguishes "exactly one" from "more than one" without walking a long ambiguity list.

That also removes a crash: `.First()` on a match carrying no identification threw `InvalidOperationException` from inside the engine.

**`QuantificationResults.AmbiguousSpectralMatchesExcluded` reports how many were dropped**, and the count is echoed in `Summary` when it isn't zero:

> Quantification completed successfully. 2 spectral match(es) were excluded because they did not identify exactly one biopolymer.

Dropping them is correct. Dropping them *silently* would leave a result set smaller than the search with no stated cause — the kind of gap that gets noticed a paper later. `Summary` is unchanged when the count is zero, so existing assertions on that exact string still hold.

### Tests

5 new. The first asserts the ambiguous row lands on *neither* candidate rather than on the first one; the rest cover the no-identification case, the unaffected happy path, and both branches of the summary text.

`Test.Quantification`, `Test.Omics` and `FlashLFQ` are green — 1029 passed.
