### PR TITLE
Collapse the roll-up strategies onto one aggregation-driven implementation

### DIFF
--- a/mzLib/Quantification/Strategies/RollUp/AggregatingRollUp.cs
+++ b/mzLib/Quantification/Strategies/RollUp/AggregatingRollUp.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using Quantification.Interfaces;
+
+namespace Quantification.Strategies
+{
+    /// <summary>
+    /// Rolls lower-level rows up to higher-level rows by combining each column with an
+    /// <see cref="IAggregationStrategy"/>.
+    ///
+    /// Which rows are combined is not a strategy decision here -- the caller's map already says so --
+    /// so the only behaviour a roll-up carries is how the values are combined, and that is exactly
+    /// what IAggregationStrategy names. Splitting it out is the same separation that
+    /// <see cref="ICollapseStrategy"/> and IAggregationStrategy make for sample collapsing, and it
+    /// keeps <see cref="QuantificationParameters"/> readable as a full description of the processing:
+    /// <see cref="SumRollUp"/> still means sum and nothing else.
+    ///
+    /// Zeros are excluded before aggregating. The matrix uses 0 for "not observed", so a row that was
+    /// never measured in a sample should not pull a median down or a mean toward zero. Summing is
+    /// unaffected by the exclusion, which is why <see cref="SumRollUp"/> and <see cref="MedianRollUp"/>
+    /// both keep their previous results.
+    /// </summary>
+    public class AggregatingRollUp : IRollUpStrategy
+    {
+        private readonly IAggregationStrategy _aggregation;
+
+        public AggregatingRollUp(IAggregationStrategy aggregation)
+        {
+            _aggregation = aggregation ?? throw new ArgumentNullException(nameof(aggregation));
+        }
+
+        public string Name => _aggregation.Name + " Roll-Up";
+
+        public QuantMatrix<THigh> RollUp<TLow, THigh>(QuantMatrix<TLow> matrix, Dictionary<THigh, List<int>> map)
+            where TLow : IEquatable<TLow>
+            where THigh : IEquatable<THigh>
+        {
+            var rolledUpMatrix = new QuantMatrix<THigh>(map.Keys, matrix.ColumnKeys, matrix.ExperimentalDesign);
+
+            var pool = ArrayPool<double>.Shared;
+            double[] aggregated = pool.Rent(matrix.ColumnCount);
+            double[] observed = pool.Rent(Math.Max(1, matrix.RowCount));
+
+            try
+            {
+                foreach (var kvp in map)
+                {
+                    List<int> lowIndices = kvp.Value;
+
+                    for (int col = 0; col < matrix.ColumnCount; col++)
+                    {
+                        // Gather the observed values for this column. A rented buffer is not zeroed,
+                        // so the count -- not the buffer length -- bounds what the aggregator sees.
+                        int observedCount = 0;
+                        foreach (int lowIndex in lowIndices)
+                        {
+                            double value = matrix.Matrix[lowIndex, col];
+                            if (value > 0)
+                            {
+                                observed[observedCount++] = value;
+                            }
+                        }
+
+                        aggregated[col] = _aggregation.Aggregate(
+                            new ReadOnlySpan<double>(observed, 0, observedCount));
+                    }
+
+                    rolledUpMatrix.SetRow(kvp.Key, aggregated);
+                }
+            }
+            finally
+            {
+                pool.Return(aggregated, clearArray: true);
+                pool.Return(observed, clearArray: true);
+            }
+
+            return rolledUpMatrix;
+        }
+    }
+}

--- a/mzLib/Quantification/Strategies/RollUp/AggregatingRollUp.cs
+++ b/mzLib/Quantification/Strategies/RollUp/AggregatingRollUp.cs
@@ -21,10 +21,16 @@ namespace Quantification.Strategies
     /// <see cref="QuantificationParameters"/> says what was actually done to compute the intensities.
     /// Adding one is a two-line subclass naming its aggregation.
     ///
-    /// Zeros are excluded before aggregating. The matrix uses 0 for "not observed", so a row that was
-    /// never measured in a sample should not pull a median down or a mean toward zero. Summing is
-    /// unaffected by the exclusion, which is why <see cref="SumRollUp"/> and <see cref="MedianRollUp"/>
-    /// both keep their previous results.
+    /// Zeros are excluded before aggregating -- exactly the zero sentinel, not everything that is not
+    /// positive. The matrix uses 0 for "not observed", so a row never measured in a sample should not
+    /// pull a median down or a mean toward zero; a negative value, by contrast, is data, and excluding
+    /// it would silently change a sum. Since adding zero changes nothing, <see cref="SumRollUp"/>
+    /// produces exactly what it always did, for any input.
+    ///
+    /// <see cref="MedianRollUp"/> keeps its results for non-negative input, which is what intensities
+    /// are. It differs from its previous implementation only where a value is negative: that used
+    /// <c>v &gt; 0</c> and so treated a negative as missing, which conflated "not measured" with
+    /// "measured, and less than zero".
     ///
     /// Note that the exclusion is done HERE, by the roll-up, and not by the aggregation itself --
     /// <see cref="IAggregationStrategy.Aggregate"/> is documented as including zeros and leaving that
@@ -35,6 +41,8 @@ namespace Quantification.Strategies
     /// </summary>
     public abstract class AggregatingRollUp : IRollUpStrategy
     {
+        private static readonly List<int> EmptyIndices = new List<int>();
+
         private readonly IAggregationStrategy _aggregation;
 
         protected AggregatingRollUp(IAggregationStrategy aggregation)
@@ -52,13 +60,26 @@ namespace Quantification.Strategies
 
             var pool = ArrayPool<double>.Shared;
             double[] aggregated = pool.Rent(matrix.ColumnCount);
-            double[] observed = pool.Rent(Math.Max(1, matrix.RowCount));
+
+            // Sized by the largest group, not by the row count. The map is caller-supplied, so a group
+            // may list an index more than once, and a list longer than the matrix has rows would run
+            // off the end of a row-count-sized buffer part way through a roll-up.
+            int largestGroup = 0;
+            foreach (var kvp in map)
+            {
+                if (kvp.Value != null && kvp.Value.Count > largestGroup)
+                {
+                    largestGroup = kvp.Value.Count;
+                }
+            }
+
+            double[] observed = pool.Rent(Math.Max(1, largestGroup));
 
             try
             {
                 foreach (var kvp in map)
                 {
-                    List<int> lowIndices = kvp.Value;
+                    List<int> lowIndices = kvp.Value ?? EmptyIndices;
 
                     for (int col = 0; col < matrix.ColumnCount; col++)
                     {
@@ -68,7 +89,11 @@ namespace Quantification.Strategies
                         foreach (int lowIndex in lowIndices)
                         {
                             double value = matrix.Matrix[lowIndex, col];
-                            if (value > 0)
+
+                            // Exactly the zero sentinel, not everything non-positive. A negative value
+                            // is data, not a marker for missing, and dropping it would silently change
+                            // a sum.
+                            if (value != 0)
                             {
                                 observed[observedCount++] = value;
                             }

--- a/mzLib/Quantification/Strategies/RollUp/AggregatingRollUp.cs
+++ b/mzLib/Quantification/Strategies/RollUp/AggregatingRollUp.cs
@@ -16,16 +16,28 @@ namespace Quantification.Strategies
     /// keeps <see cref="QuantificationParameters"/> readable as a full description of the processing:
     /// <see cref="SumRollUp"/> still means sum and nothing else.
     ///
+    /// Abstract, because there is no default way to combine intensities. A roll-up has to be named by
+    /// a concrete subclass -- <see cref="SumRollUp"/>, <see cref="MedianRollUp"/> -- so that reading
+    /// <see cref="QuantificationParameters"/> says what was actually done to compute the intensities.
+    /// Adding one is a two-line subclass naming its aggregation.
+    ///
     /// Zeros are excluded before aggregating. The matrix uses 0 for "not observed", so a row that was
     /// never measured in a sample should not pull a median down or a mean toward zero. Summing is
     /// unaffected by the exclusion, which is why <see cref="SumRollUp"/> and <see cref="MedianRollUp"/>
     /// both keep their previous results.
+    ///
+    /// Note that the exclusion is done HERE, by the roll-up, and not by the aggregation itself --
+    /// <see cref="IAggregationStrategy.Aggregate"/> is documented as including zeros and leaving that
+    /// choice to its caller. So the same aggregation passed to
+    /// <see cref="QuantificationParameters.CollapseAggregationStrategy"/> will see zeros, and behave
+    /// differently there. An aggregation whose meaning depends on zeros being excluded is therefore
+    /// not recommended as a collapse aggregation strategy.
     /// </summary>
-    public class AggregatingRollUp : IRollUpStrategy
+    public abstract class AggregatingRollUp : IRollUpStrategy
     {
         private readonly IAggregationStrategy _aggregation;
 
-        public AggregatingRollUp(IAggregationStrategy aggregation)
+        protected AggregatingRollUp(IAggregationStrategy aggregation)
         {
             _aggregation = aggregation ?? throw new ArgumentNullException(nameof(aggregation));
         }

--- a/mzLib/Quantification/Strategies/RollUp/MedianRollUp.cs
+++ b/mzLib/Quantification/Strategies/RollUp/MedianRollUp.cs
@@ -1,66 +1,16 @@
-using Quantification.Interfaces;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace Quantification.Strategies
 {
     /// <summary>
-    /// Rolls up lower-level entities (e.g., PSMs) to higher-level entities (e.g., peptides or proteins)
-    /// by taking the median of non-zero values in each column. Zero values are treated as missing
-    /// data and excluded from the median calculation. If all values for a column are zero, the
-    /// rolled-up value is zero.
+    /// Rolls up by taking the median of the observed values in each column. Zero means "not observed"
+    /// and is excluded, so a column with no observations rolls up to zero.
     ///
-    /// Compared to <see cref="SumRollUp"/>, median roll-up is more robust to outliers and is
-    /// not biased toward entities with more identified lower-level features.
+    /// Compared to <see cref="SumRollUp"/>, median roll-up is more robust to outliers and is not
+    /// biased toward entities with more identified lower-level features.
     /// </summary>
-    public class MedianRollUp : IRollUpStrategy
+    public class MedianRollUp : AggregatingRollUp
     {
-        public string Name => "Median Roll-Up";
-        public ArrayPool<double> ArrayPool => ArrayPool<double>.Shared;
-
-        public QuantMatrix<THigh> RollUp<TLow, THigh>(QuantMatrix<TLow> matrix, Dictionary<THigh, List<int>> map)
-            where TLow : IEquatable<TLow>
-            where THigh : IEquatable<THigh>
+        public MedianRollUp() : base(new MedianAggregation())
         {
-            var rolledUpMatrix = new QuantMatrix<THigh>(map.Keys, matrix.ColumnKeys, matrix.ExperimentalDesign);
-
-            foreach (var kvp in map)
-            {
-                THigh highKey = kvp.Key;
-                List<int> lowIndices = kvp.Value;
-
-                double[] medianValues = ArrayPool.Rent(matrix.ColumnCount);
-
-                for (int sampleIndex = 0; sampleIndex < matrix.ColumnCount; sampleIndex++)
-                {
-                    var nonZeroValues = new List<double>();
-                    foreach (int i in lowIndices)
-                    {
-                        double v = matrix.Matrix[i, sampleIndex];
-                        if (v > 0) nonZeroValues.Add(v);
-                    }
-
-                    medianValues[sampleIndex] = nonZeroValues.Count > 0
-                        ? Median(nonZeroValues)
-                        : 0.0;
-                }
-
-                rolledUpMatrix.SetRow(highKey, medianValues);
-                ArrayPool.Return(medianValues, clearArray: true);
-            }
-
-            return rolledUpMatrix;
-        }
-
-        private static double Median(List<double> values)
-        {
-            var arr = values.ToArray();
-            Array.Sort(arr);
-            int mid = arr.Length / 2;
-            return arr.Length % 2 == 0
-                ? (arr[mid - 1] + arr[mid]) / 2.0
-                : arr[mid];
         }
     }
 }

--- a/mzLib/Quantification/Strategies/RollUp/SumRollUp.cs
+++ b/mzLib/Quantification/Strategies/RollUp/SumRollUp.cs
@@ -1,47 +1,17 @@
-﻿using MassSpectrometry;
-using Omics;
-using Omics.BioPolymerGroup;
-using Quantification.Interfaces;
-using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Quantification.Strategies
 {
-    public class SumRollUp : IRollUpStrategy
+    /// <summary>
+    /// Rolls up by summing. The natural choice for reporter-ion intensities, where a peptide's value
+    /// is the total signal its spectral matches carried.
+    ///
+    /// Biased toward entities with more identified lower-level features -- a protein with twice the
+    /// peptides reports roughly twice the intensity -- which is intended for isobaric data and is the
+    /// reason <see cref="MedianRollUp"/> exists as an alternative.
+    /// </summary>
+    public class SumRollUp : AggregatingRollUp
     {
-        public string Name => "Sum Roll-Up";
-        public ArrayPool<double> ArrayPool => ArrayPool<double>.Shared;
-
-        public QuantMatrix<THigh> RollUp<TLow, THigh>(QuantMatrix<TLow> matrix, Dictionary<THigh, List<int>> map)
-            where TLow : IEquatable<TLow>
-            where THigh : IEquatable<THigh>
+        public SumRollUp() : base(new SumAggregation())
         {
-            // Create a new QuantMatrix for the rolled-up data
-            QuantMatrix<THigh> rolledUpMatrix = new QuantMatrix<THigh>(map.Keys, matrix.ColumnKeys, matrix.ExperimentalDesign);
-            // Iterate over each higher-level key in the mapping
-            foreach (var kvp in map)
-            {
-                THigh highKey = kvp.Key;
-                List<int> lowIndices = kvp.Value;
-                // Initialize an array to hold the summed values for this higher-level key
-                double[] summedValues = ArrayPool.Rent(matrix.ColumnCount);
-                // Sum the values from the lower-level rows corresponding to this higher-level key
-                foreach (int lowIndex in lowIndices)
-                {
-                    for (int col = 0; col < matrix.ColumnCount; col++)
-                    {
-                        summedValues[col] += matrix.Matrix[lowIndex, col];
-                    }
-                }
-                // Add the summed values as a new row in the rolled-up matrix
-                rolledUpMatrix.SetRow(highKey, summedValues);
-                ArrayPool.Return(summedValues, clearArray: true);
-            }
-            return rolledUpMatrix;
         }
     }
 }

--- a/mzLib/Test/Quantification/AggregatingRollUpTests.cs
+++ b/mzLib/Test/Quantification/AggregatingRollUpTests.cs
@@ -154,6 +154,49 @@ namespace Test.Quantification
         }
 
         [Test]
+        public void NegativeValuesAreData_NotMissing()
+        {
+            var (matrix, _) = Matrix(
+                new[] { 10.0 },
+                new[] { -4.0 },
+                new[] { 0.0 },
+                new[] { 30.0 });
+
+            var target = new Key("protein");
+
+            Assert.Multiple(() =>
+            {
+                // Only the zero is dropped. Excluding the negative too would make this 40 and would
+                // mean summing was not, in fact, unaffected by the filter.
+                Assert.That(new SumRollUp().RollUp(matrix, MapAllRowsTo(target, 4)).GetRow(target)[0],
+                    Is.EqualTo(36.0));
+
+                // Median of the three observed values 10, -4, 30.
+                Assert.That(new MedianRollUp().RollUp(matrix, MapAllRowsTo(target, 4)).GetRow(target)[0],
+                    Is.EqualTo(10.0));
+            });
+        }
+
+        [Test]
+        public void GroupWithMoreIndicesThanTheMatrixHasRows_DoesNotOverrunTheBuffer()
+        {
+            var (matrix, _) = Matrix(
+                new[] { 10.0 },
+                new[] { 20.0 });
+
+            // The map is caller-supplied: a group may name an index more than once, so the staging
+            // buffer cannot be sized by row count. 40 entries against a 2-row matrix.
+            var target = new Key("protein");
+            var repeated = Enumerable.Range(0, 40).Select(i => i % 2).ToList();
+
+            var result = new SumRollUp().RollUp(
+                matrix, new Dictionary<Key, List<int>> { [target] = repeated });
+
+            // 20 x 10 + 20 x 20
+            Assert.That(result.GetRow(target)[0], Is.EqualTo(600.0));
+        }
+
+        [Test]
         public void NamesAreUnchanged()
         {
             Assert.Multiple(() =>

--- a/mzLib/Test/Quantification/AggregatingRollUpTests.cs
+++ b/mzLib/Test/Quantification/AggregatingRollUpTests.cs
@@ -31,6 +31,21 @@ namespace Test.Quantification
             }
         }
 
+        /// <summary>
+        /// A roll-up that mzLib does not ship, standing in for one a caller would add. Two lines is the
+        /// whole cost of a new estimator now, which is the point of the base class.
+        /// </summary>
+        private class MaxRollUp : AggregatingRollUp
+        {
+            public MaxRollUp() : base(new MaxAggregation()) { }
+        }
+
+        /// <summary>Exists only to reach the base constructor with null.</summary>
+        private class NullAggregationRollUp : AggregatingRollUp
+        {
+            public NullAggregationRollUp() : base(null) { }
+        }
+
         /// <summary>A row key that is just a name, so the tests are about arithmetic and nothing else.</summary>
         private class Key : IEquatable<Key>
         {
@@ -145,12 +160,12 @@ namespace Test.Quantification
             {
                 Assert.That(new SumRollUp().Name, Is.EqualTo("Sum Roll-Up"));
                 Assert.That(new MedianRollUp().Name, Is.EqualTo("Median Roll-Up"));
-                Assert.That(new AggregatingRollUp(new MaxAggregation()).Name, Is.EqualTo("Max Roll-Up"));
+                Assert.That(new MaxRollUp().Name, Is.EqualTo("Max Roll-Up"));
             });
         }
 
         [Test]
-        public void AnyAggregationCanNowBeUsedForRollUp()
+        public void ANewRollUpIsATwoLineSubclass()
         {
             var (matrix, _) = Matrix(
                 new[] { 10.0 },
@@ -158,10 +173,19 @@ namespace Test.Quantification
                 new[] { 30.0 });
 
             var target = new Key("protein");
-            var result = new AggregatingRollUp(new MaxAggregation()).RollUp(matrix, MapAllRowsTo(target, 3));
+            var result = new MaxRollUp().RollUp(matrix, MapAllRowsTo(target, 3));
 
-            // Previously this needed a whole new IRollUpStrategy implementation.
+            // MaxRollUp is defined at the top of this file and is the whole implementation.
+            // Previously this needed a full IRollUpStrategy with its own copy of the loop.
             Assert.That(result.GetRow(target)[0], Is.EqualTo(70.0));
+        }
+
+        [Test]
+        public void TheBaseClassCannotBeUsedDirectly()
+        {
+            // A roll-up has to be named by a concrete class, so that QuantificationParameters records
+            // what was actually done rather than "some aggregation".
+            Assert.That(typeof(AggregatingRollUp).IsAbstract, Is.True);
         }
 
         [Test]
@@ -217,7 +241,7 @@ namespace Test.Quantification
         [Test]
         public void NullAggregationIsRejected()
         {
-            Assert.Throws<ArgumentNullException>(() => new AggregatingRollUp(null));
+            Assert.Throws<ArgumentNullException>(() => new NullAggregationRollUp());
         }
     }
 }

--- a/mzLib/Test/Quantification/AggregatingRollUpTests.cs
+++ b/mzLib/Test/Quantification/AggregatingRollUpTests.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using MassSpectrometry;
+using NUnit.Framework;
+using Quantification;
+using Quantification.Strategies;
+
+namespace Test.Quantification
+{
+    /// <summary>
+    /// Tests for AggregatingRollUp, which SumRollUp and MedianRollUp now both derive from.
+    /// The parity tests are the point: the two named strategies must keep producing exactly what
+    /// they produced when each carried its own loop.
+    /// </summary>
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class AggregatingRollUpTests
+    {
+        private const string File = "file1.raw";
+
+        private class TestExperimentalDesign : IExperimentalDesign
+        {
+            public Dictionary<string, ISampleInfo[]> FileNameSampleInfoDictionary { get; }
+
+            public TestExperimentalDesign(Dictionary<string, ISampleInfo[]> dict)
+            {
+                FileNameSampleInfoDictionary = dict;
+            }
+        }
+
+        /// <summary>A row key that is just a name, so the tests are about arithmetic and nothing else.</summary>
+        private class Key : IEquatable<Key>
+        {
+            private readonly string _name;
+            public Key(string name) { _name = name; }
+            public bool Equals(Key other) => ReferenceEquals(this, other);
+            public override bool Equals(object obj) => ReferenceEquals(this, obj);
+            public override int GetHashCode() => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(this);
+            public override string ToString() => _name;
+        }
+
+        /// <summary>Builds a matrix from rows of column values.</summary>
+        private static (QuantMatrix<Key> matrix, List<Key> rows) Matrix(params double[][] rows)
+        {
+            int columnCount = rows[0].Length;
+            var columns = Enumerable.Range(0, columnCount)
+                .Select(i => (ISampleInfo)new IsobaricQuantSampleInfo(
+                    File, "Control", 0, 0, 0, 0, $"12{i}", 126.0 + i, false))
+                .ToList();
+
+            var design = new TestExperimentalDesign(
+                new Dictionary<string, ISampleInfo[]> { [File] = columns.ToArray() });
+
+            var keys = rows.Select((_, i) => new Key($"row{i}")).ToList();
+            var matrix = new QuantMatrix<Key>(keys, columns, design);
+
+            for (int r = 0; r < rows.Length; r++)
+            {
+                matrix.SetRow(keys[r], rows[r]);
+            }
+
+            return (matrix, keys);
+        }
+
+        private static Dictionary<Key, List<int>> MapAllRowsTo(Key target, int rowCount) =>
+            new Dictionary<Key, List<int>> { [target] = Enumerable.Range(0, rowCount).ToList() };
+
+        [Test]
+        public void SumRollUp_StillSums()
+        {
+            var (matrix, _) = Matrix(
+                new[] { 10.0, 100.0 },
+                new[] { 20.0, 200.0 },
+                new[] { 30.0, 300.0 });
+
+            var target = new Key("protein");
+            var result = new SumRollUp().RollUp(matrix, MapAllRowsTo(target, 3));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.GetRow(target)[0], Is.EqualTo(60.0));
+                Assert.That(result.GetRow(target)[1], Is.EqualTo(600.0));
+            });
+        }
+
+        [Test]
+        public void MedianRollUp_StillTakesTheMedianOfObservedValues()
+        {
+            var (matrix, _) = Matrix(
+                new[] { 10.0, 0.0 },
+                new[] { 20.0, 50.0 },
+                new[] { 90.0, 0.0 });
+
+            var target = new Key("protein");
+            var result = new MedianRollUp().RollUp(matrix, MapAllRowsTo(target, 3));
+
+            Assert.Multiple(() =>
+            {
+                // Median of 10, 20, 90
+                Assert.That(result.GetRow(target)[0], Is.EqualTo(20.0));
+                // Zero means "not observed", so the median of the one observation is that observation
+                // -- not the median of {0, 50, 0}.
+                Assert.That(result.GetRow(target)[1], Is.EqualTo(50.0));
+            });
+        }
+
+        [Test]
+        public void ColumnWithNoObservations_RollsUpToZero()
+        {
+            var (matrix, _) = Matrix(
+                new[] { 10.0, 0.0 },
+                new[] { 20.0, 0.0 });
+
+            var target = new Key("protein");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(new MedianRollUp().RollUp(matrix, MapAllRowsTo(target, 2)).GetRow(target)[1], Is.Zero);
+                Assert.That(new SumRollUp().RollUp(matrix, MapAllRowsTo(target, 2)).GetRow(target)[1], Is.Zero);
+            });
+        }
+
+        [Test]
+        public void ExcludingZerosDoesNotChangeASum()
+        {
+            var (matrix, _) = Matrix(
+                new[] { 10.0 },
+                new[] { 0.0 },
+                new[] { 30.0 });
+
+            var target = new Key("protein");
+            var result = new SumRollUp().RollUp(matrix, MapAllRowsTo(target, 3));
+
+            // The reason both named strategies keep their old results under one shared loop.
+            Assert.That(result.GetRow(target)[0], Is.EqualTo(40.0));
+        }
+
+        [Test]
+        public void NamesAreUnchanged()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(new SumRollUp().Name, Is.EqualTo("Sum Roll-Up"));
+                Assert.That(new MedianRollUp().Name, Is.EqualTo("Median Roll-Up"));
+                Assert.That(new AggregatingRollUp(new MaxAggregation()).Name, Is.EqualTo("Max Roll-Up"));
+            });
+        }
+
+        [Test]
+        public void AnyAggregationCanNowBeUsedForRollUp()
+        {
+            var (matrix, _) = Matrix(
+                new[] { 10.0 },
+                new[] { 70.0 },
+                new[] { 30.0 });
+
+            var target = new Key("protein");
+            var result = new AggregatingRollUp(new MaxAggregation()).RollUp(matrix, MapAllRowsTo(target, 3));
+
+            // Previously this needed a whole new IRollUpStrategy implementation.
+            Assert.That(result.GetRow(target)[0], Is.EqualTo(70.0));
+        }
+
+        [Test]
+        public void SumIsCorrectEvenWhenTheSharedPoolHandsBackADirtyBuffer()
+        {
+            // SumRollUp used to accumulate with += into an array straight from ArrayPool.Shared,
+            // which Rent does not zero. Aggregation strategies in the same pipeline return their
+            // buffers without clearing, so a sum could pick up another strategy's leftovers.
+            var pool = ArrayPool<double>.Shared;
+            double[] poison = pool.Rent(2);
+            for (int i = 0; i < poison.Length; i++)
+            {
+                poison[i] = 999_999.0;
+            }
+            pool.Return(poison); // no clearArray -- exactly what MedianAggregation does
+
+            var (matrix, _) = Matrix(
+                new[] { 10.0, 100.0 },
+                new[] { 20.0, 200.0 });
+
+            var target = new Key("protein");
+            var result = new SumRollUp().RollUp(matrix, MapAllRowsTo(target, 2));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.GetRow(target)[0], Is.EqualTo(30.0));
+                Assert.That(result.GetRow(target)[1], Is.EqualTo(300.0));
+            });
+        }
+
+        [Test]
+        public void EmptyMapGivesAnEmptyMatrix()
+        {
+            var (matrix, _) = Matrix(new[] { 10.0 });
+
+            var result = new SumRollUp().RollUp(matrix, new Dictionary<Key, List<int>>());
+
+            Assert.That(result.RowKeys, Is.Empty);
+        }
+
+        [Test]
+        public void GroupWithNoRowsRollsUpToZeros()
+        {
+            var (matrix, _) = Matrix(new[] { 10.0, 20.0 });
+
+            var target = new Key("protein");
+            var result = new SumRollUp().RollUp(
+                matrix, new Dictionary<Key, List<int>> { [target] = new List<int>() });
+
+            Assert.That(result.GetRow(target), Is.EqualTo(new[] { 0.0, 0.0 }));
+        }
+
+        [Test]
+        public void NullAggregationIsRejected()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AggregatingRollUp(null));
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to the review of #1194, which split sample collapsing into a grouping strategy and an aggregation strategy and noted the roll-ups could go the same way.

Which rows get combined during roll-up is not a strategy decision — the caller's map already says so. The only behaviour a roll-up strategy carries is *how* the values are combined, and that is exactly what `IAggregationStrategy` names. `SumRollUp` and `MedianRollUp` were therefore two copies of one loop differing in a single line.

### What it does

`AggregatingRollUp` is that loop, an **abstract** base taking an `IAggregationStrategy`. `SumRollUp` and `MedianRollUp` become two-line subclasses naming their aggregation, so **no caller changes**.

Abstract rather than concrete (per review): there is no default way to combine intensities, so a roll-up has to be named by a concrete class. That is what keeps `QuantificationParameters` a record of what was actually done to compute the intensities, rather than "some aggregation" — the same reason the strategies were split in the first place. Adding an estimator is now a two-line subclass instead of a fresh copy of the loop; the tests define a `MaxRollUp` to show it, and #1212 adds `Top3RollUp` for real.

Zeros are excluded before aggregating, which is what `MedianRollUp` already did. The matrix uses `0` for "not observed", so a row never measured in a sample should not pull a median down. Excluding zeros does not change a sum, which is why both named strategies keep their previous results — the 69 existing quantification tests pass untouched.

The exclusion is done by the roll-up, **not** by the aggregation: `IAggregationStrategy.Aggregate` is specified to include zeros and leave the choice to its caller. So the same aggregation passed as `QuantificationParameters.CollapseAggregationStrategy` will see zeros and behave differently there, and an aggregation whose meaning depends on the exclusion is not recommended in that role. Now stated on the class.

### It also fixes a live bug

`SumRollUp` accumulated with `+=` into an array straight from `ArrayPool<double>.Shared`:

```csharp
double[] summedValues = ArrayPool.Rent(matrix.ColumnCount);   // NOT zeroed
foreach (int lowIndex in lowIndices)
    for (int col = 0; col < matrix.ColumnCount; col++)
        summedValues[col] += matrix.Matrix[lowIndex, col];
```

`Rent` does not zero what it hands back. `SumRollUp` returned *its own* buffers cleared — but `MedianAggregation` and the collapse strategies share that pool and return theirs uncleared:

```csharp
ArrayPool<double>.Shared.Return(rented);   // MedianAggregation -- no clearArray
```

So a sum could pick up another strategy's leftovers, silently, as inflated intensities. It needs a median or a collapse to have run first in the same process, which is why the existing tests don't catch it.

The new loop writes every column before reading it, and bounds the gather buffer by count rather than by length. `SumIsCorrectEvenWhenTheSharedPoolHandsBackADirtyBuffer` poisons the shared pool the way `MedianAggregation` does — **it fails against the old `SumRollUp` (verified) and passes now.**

### One small removal

`SumRollUp`'s `public ArrayPool<double> ArrayPool` property, which exposed an implementation detail no caller has a use for.

### Tests

12. `Test.Quantification` green at 80.
