### PR TITLE
Declare that PeptideWithSetModifications.Parent shadows the base

### DIFF
--- a/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
+++ b/mzLib/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cs
@@ -220,7 +220,14 @@ namespace Proteomics.ProteolyticDigestion
         private string? _fullSequenceWithMassShifts;
         public string FullSequenceWithMassShifts => _fullSequenceWithMassShifts ??= this.FullSequenceWithMassShift();
 
-        public IBioPolymer Parent => Protein;
+        /// <summary>
+        /// Shadows <see cref="DigestionProduct.Parent"/> rather than overriding it, which is not
+        /// possible because the base property is not virtual. The two can disagree: the base backing
+        /// field is [NonSerialized], so it is null on a deserialized peptide until
+        /// SetNonSerializedPeptideInfo runs, while Protein is repopulated. Members inherited from the
+        /// base -- PreviousResidue, NextResidue, BaseSequence -- read the base field, not this.
+        /// </summary>
+        public new IBioPolymer Parent => Protein;
 
 
         /// <summary>


### PR DESCRIPTION
🤖 Clears the CS0108 on `PeptideWithSetModifications.Parent`.

```csharp
// DigestionProduct.cs               [field: NonSerialized] public IBioPolymer Parent { get; protected set; }
// PeptideWithSetModifications.cs    public IBioPolymer Parent => Protein;
```

The derived property hides the base one without saying so. `override` is not available — the base is a plain auto-property, not virtual — so this adds `new`, which **changes nothing at all**. It states the shadowing that already happens, plus a comment recording where the two can disagree.

## They can disagree, and it looks deliberate

The base backing field is `[NonSerialized]`, so on a peptide read back from a serialized index it is null until `SetNonSerializedPeptideInfo` repopulates the protein, while `Protein` itself is restored. Members inherited from the base — `PreviousResidue`, `NextResidue`, `BaseSequence` — read the base field, so they see null where a caller reading `peptide.Parent` sees the protein.

That is a plausible reason for the property to exist, which is why this PR documents the split rather than removing it.

## What would be better, and why it is not here

Unifying the two — set the base field and drop this property, so every caller sees one value — is the better end state. It is not done here because it changes what base-typed callers observe and runs straight into the serialization behaviour above. That wants whoever owns `SetNonSerializedPeptideInfo` to confirm the intent first.

Solution builds clean and the warning is gone.
