### PR TITLE
Make the Test project's nullable annotations mean something

### DIFF
--- a/mzLib/Test/Test.csproj
+++ b/mzLib/Test/Test.csproj
@@ -2,6 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <!-- Annotations only, not warnings. Test code already writes `string?` in ~200 places and the
+         compiler was ignoring every one of them (CS8632). This makes those annotations mean what
+         they say without turning on the nullability warnings, which would add hundreds more. Safe
+         to do here and not in the shipping projects: nothing consumes this assembly, so the
+         nullability metadata it emits is nobody's contract. -->
+    <Nullable>annotations</Nullable>
     <IsPackable>false</IsPackable>
     <Platforms>x64</Platforms>
   </PropertyGroup>


### PR DESCRIPTION
🤖 Test code writes `string?` and friends in 212 places, and the compiler ignored every one of them: the project never set `<Nullable>`, so the annotation context was off and each `?` raised CS8632 instead of doing anything. Those 212 warnings were a quarter of the solution's total.

`<Nullable>annotations</Nullable>` turns on the annotation context and leaves the warning context off, so the existing `?` marks start meaning what they say and no new nullability warnings appear.

Measured across the whole solution: **898 → 686**, all 212 of them CS8632 in Test, nothing added anywhere, and **no source changes at all** — the diff is six lines of csproj.

**Annotations only, and only here.** Enabling the same thing on a shipping project would emit nullability metadata into the NuGet package, where every un-annotated reference type becomes a non-nullable claim that consumers would believe — and in a half-migrated codebase many of those claims would be false. Nothing consumes the Test assembly, so its metadata is nobody's contract, which is what makes this safe here and not there.

The remaining 51 CS8632 are all in shipping projects and are left alone here deliberately: making those annotations true rather than merely legal is a per-file job, not a project setting.
