### PR TITLE
ci(dependabot): group the minor and patch action bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,19 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      # Minor and patch bumps travel together. They are the ones that need no changelog
+      # read, so one PR a month for all of them costs two approvals instead of two per
+      # action, and loses nothing.
+      #
+      # Majors are deliberately left out and still arrive one at a time. A major is where
+      # an action changes a default or drops an input -- actions/checkout v5 to v7 is two
+      # of them at once -- and that is exactly the change that should not be reviewed as
+      # one line inside a batch. The first run of this config opened three PRs and all
+      # three were majors, which is the case grouping must not hide.
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
#1201 turned Dependabot on for the github-actions ecosystem, ungrouped. That means one PR per action, and master requires two approvals, so a routine version bump costs two reviews from a pool of about five people. The first run opened three PRs at once.

This groups minor and patch bumps into a single monthly PR.

**Majors are deliberately excluded and still arrive one at a time.** A major is where an action changes a default or drops an input — `actions/checkout` v5 to v7 is two of those at once — and that is the change that should not be reviewed as one line inside a batch of five. Grouping everything would have bundled exactly the three changelog-worthy bumps the first run produced.

Steady state should be zero or one action major a month, so the grouping costs nothing when there is nothing to group and saves the approvals when there is.

Two things worth knowing:

- It does **not** retroactively combine #1228, #1229 and #1230. Those stay as they are; this applies from the next run.
- `directory: "/"` and the monthly cadence are unchanged from #1201.

Config parses as valid Dependabot v2 (`patterns: ["*"]` with `update-types: [minor, patch]`).