### PR TITLE
docs(release-notes): add 1.0.587 and 1.0.588

### DIFF
--- a/release-notes/1.0.587.md
+++ b/release-notes/1.0.587.md
@@ -1,0 +1,85 @@
+# mzLib 1.0.587 — quantification, and four defects that changed the numbers
+**Source:** `1.0.586..1.0.587` (12 PRs)
+**Contributors:** @Alexander-Sol, @acesnik, @trishorts
+
+Four items in this release change values that earlier versions reported. If you have FlashLFQ output
+from 1.0.586 or earlier that you intend to compare against output from this version, read the first
+four items before you do.
+
+- **A merged match-between-runs peak was published twice (#1202)** — `MatchBetweenRuns` added the
+  winning peak to the acceptor file's results inside the charge-state merge block and then again
+  unconditionally right after it, so any peak that went through charge-state merging appeared twice
+  in `_results.Peaks`. One line. Closes #1198 and #1160, which are the same defect reported twice.
+
+- **Match-between-runs no longer crosses digestion agents (#1148)** — MBR treated every file as a
+  possible acceptor for every donor peptide, so in a dataset with one protease per file — how
+  MetaMorpheus's multiprotease search works — a tryptic peptide could be "found" in a Glu-C file.
+  It is not in that digest, so the transferred peak was noise or a coeluting species at the same
+  mass. Digestion agent is now a hard constraint on transfer, as fraction already was. Datasets
+  using a single protease are unaffected. This is the mzLib half of MetaMorpheus #1034, filed in
+  2018 and the last issue in the MetaMorpheus 1.0 milestone.
+
+- **Ambiguous spectral matches are excluded from quantification (#1210)** — `GetPsmToPeptideMap`
+  took `.First()` on the identified biopolymers with a comment saying it assumed unambiguous
+  mapping, and nothing checked. A match identifying several biopolymers was attributed to whichever
+  came first, recording a plausible intensity against a peptide that may not be the one measured,
+  with nothing in the output to say so. Ambiguous matches are now filtered out and the count is
+  reported. Protein and peptide intensities will move for any dataset that had them.
+
+- **Merged results dropped retention times and protein groups (#1147)** —
+  `FlashLfqResults.MergeResultsWith` copied intensity and detection type but not retention time, so
+  merged peptides reported `0` in the retention-time column for every merged-in file while their
+  intensities were correct. `Peptide.ProteinGroups` was likewise not unioned, dropping protein
+  associations found only in the second run. This went unnoticed because the method has no callers
+  in production code and its one test asserted only collection counts. Match-between-runs is
+  deliberately unchanged: there the donor's retention time is *not* carried, because the transferred
+  peak's retention time is the acceptor file's own apex.
+
+- **Peak width is reported per chromatographic peak (#1180)** — Full width at half maximum of the
+  apex charge state's trace, in minutes, exposed as `ChromatographicPeak.PeakWidth` and written to
+  the quantified-peaks file as two new columns, `Peak FWHM` and `Peak FWHM Status`. They sit
+  **between `Peak RT End` and `Peak MZ`**, not at the end of the row, so anything reading that file
+  by column position rather than by header name reads the wrong column from this version on.
+  mzLib's own `QuantifiedPeakFile` reader is unaffected — it maps by header name and has no member
+  for the new columns, so it ignores them and still reads files written by older versions.
+  `PeakWidthSummary` aggregates a per-file median; a peak with no apex reports `NoApex` rather than
+  a number. Answers MetaMorpheus #1624, open since 2019.
+
+- **Quantification results reach the entities that write them (#1193)** — `QuantificationEngine.Run`
+  computed a `QuantMatrix` and returned it, and nothing ever wrote those values onto
+  `IBioPolymerGroup.IntensitiesBySample`. A body of already-merged, already-tested output machinery
+  — `SampleGroupResult`, `PopulateSampleGroupResults` including its per-channel isobaric branch,
+  and the group's `ToString`/`GetTabSeparatedHeader` — therefore could not be fed by a run. It can
+  now, and `QuantificationWriter` is the writer.
+
+- **Shared-peptide protein quantification runs (#1209)** —
+  `QuantificationParameters.UseSharedPeptidesForProteinQuant` was a public settable bool whose
+  `true` branch threw `NotImplementedException`. `GetAllPeptideToProteinMap` is implemented, so
+  setting it now does what it says.
+
+- **Top3 protein estimation (#1212)** — The average of the three most intense observed peptides
+  (Silva et al. 2006). Summing peptides makes a protein's intensity depend on how many of its
+  peptides were identified, which is a property of the search as much as of the sample; Top3 removes
+  that. A protein with fewer than three observations averages what is there rather than dividing by
+  three, since dividing would report a protein seen twice as smaller than the same protein seen
+  three times — the exact bias Top3 exists to remove. Opt-in; nothing changes unless you select it.
+
+- **Collapse and roll-up split into grouping and aggregation (#1194, #1211)** — `SumCollapse` and
+  `MeanCollapse` each grouped by one hardcoded key; `SumRollUp` and `MedianRollUp` were two copies
+  of one loop differing in a single line. Which rows get combined is now separate from how their
+  values are combined, so adding an estimator is a two-line subclass rather than a fresh copy.
+  **No caller changes and no result changes** — the 69 existing quantification tests pass untouched.
+  Zeros are excluded before aggregating, which `MedianRollUp` already did and which cannot change a
+  sum.
+
+- **A shipping `IExperimentalDesign` implementation (#1208)** — the interface previously had four
+  implementations in the repository and all four were test scaffolding.
+
+- **The Test project's nullable annotations now mean something (#1221)** — test code wrote `string?`
+  in 212 places with the annotation context off, so every one raised `CS8632` and did nothing.
+  Setting `<Nullable>annotations</Nullable>` takes the solution from 898 warnings to 686 with no
+  source changes at all. Deliberately not done on shipping projects: that would emit nullability
+  metadata into the package, where every un-annotated reference type becomes a non-nullable claim
+  consumers would believe, and in a half-migrated codebase many would be false.
+
+**Full Changelog**: https://github.com/smith-chem-wisc/mzLib/compare/1.0.586...1.0.587

--- a/release-notes/1.0.588.md
+++ b/release-notes/1.0.588.md
@@ -1,0 +1,62 @@
+# mzLib 1.0.588 — what the package carries
+**Source:** `1.0.587..1.0.588` (10 PRs)
+**Contributors:** @acesnik, @trishorts, @app/dependabot
+
+No library behaviour changes in this release. What changes is the contents of the NuGet package: it
+gains XML documentation and roughly 6.8 MB of modification data, and loses one Thermo assembly that
+could not load on arm64.
+
+- **The package ships XML documentation (#1162)** — Every assembly mzLib ships now has its `.xml`
+  beside it, so consumers get tooltips in the IDE for the roughly 1,900 summaries that already
+  existed in the tree and previously reached nobody outside this repository. Generation is scoped to
+  the seventeen projects that ship; `Test` and `Development` are excluded. Two doc diagnostics
+  (`CS1591` missing comment, `CS1573` missing param tag) are suppressed as incomplete-but-harmless,
+  and the six that mean a comment renders wrongly are left visible and are all at zero. The package
+  is correspondingly larger. No API changes.
+
+- **Modification data files ship alongside the assemblies (#1185)** — `Mods.txt`, `RnaMods.txt`,
+  `TMT.txt`, `ptmlist.txt`, `PSI-MOD.obo.xml`, `unimod.xml`, and the newly adopted
+  `substitutions.txt` and `surfactants.txt` are now in the package under `modificationData\`, so an
+  application can expose an editable `Mods\` folder rather than only the copies embedded in
+  `Omics.dll`. **This adds roughly 6.8 MB to the download for everyone**, whether or not they use
+  it — the opt-in controls only whether the files are copied out beside the application, not whether
+  they are shipped. Opt in with
+  `<MzLibIncludeModificationData>true</MzLibIncludeModificationData>`.
+
+  Two things to know. The package now contains `build\mzLib.targets`, which NuGet imports into every
+  consuming project automatically; it is inert unless that property is set. And the protease
+  cleavage modification `Test on M` is renamed to `Homoserine lactone N-terminal on M` — it was
+  never a fixture, it is the cleavage modification for the shipped protease `CNBr_N`, and
+  MetaMorpheus is about to surface these names to users. Nothing in MetaMorpheus referenced the old
+  name.
+
+- **The architecture-stamped Thermo assembly is gone (#1156)** —
+  `ThermoFisher.CommonCore.MassPrecisionEstimator.dll` is no longer in the package. It is IL-only
+  but its PE machine field is stamped AMD64, so CoreCLR will not load it on arm64; any use of it
+  would have taken `.raw` reading down on every non-x64 platform. Nothing referenced it — not a
+  source file, not a csproj, not another Thermo binary by name — so no consumer loses anything a
+  build was using. A test now fails the build if any assembly in the output ever references an
+  architecture-stamped one again. The paired MetaMorpheus installer change (#2726) merged first, so
+  MetaMorpheus's WiX build is already consistent with this.
+
+- **Release pages are created from the tag automatically (#1206)** — Pushing a tag now publishes
+  `release-notes/<version>.md` as the Release body when that file exists on the tagged commit, and
+  falls back to generated notes under a placeholder line when it does not. Previously a tag created
+  no page at all, which left the Releases sidebar and the `github/v/release` badge advertising the
+  previous version until somebody wrote the page by hand. This release is the first published that
+  way.
+
+- **Coverage upload was silently misconfigured (#1197)** — `token`, `files` and `verbose` were
+  passed to `codecov/codecov-action` under `env:` rather than `with:`, so they were ordinary
+  lowercase environment variables the action never read. The explicit report glob was inert, and
+  coverage uploaded only because the action falls back to searching the workspace. They are inputs
+  now, and the action moved from v4 to v7. Repository metric only; nothing in the package changes.
+
+- **CI maintenance** — the workflow actions move off the deprecated Node 20 runtime (#1190), and
+  Dependabot now watches the github-actions ecosystem monthly so the pins stop rotting unnoticed
+  (#1201), its first round bumping `actions/upload-artifact` to v7 (#1228), `actions/checkout` to
+  v7 (#1229) and `actions/setup-dotnet` to v6 (#1230). `actions/checkout` v7 blocks checking out
+  fork pull-request code under `pull_request_target` and `workflow_run`; mzLib's workflows use
+  neither. No production changes.
+
+**Full Changelog**: https://github.com/smith-chem-wisc/mzLib/compare/1.0.587...1.0.588


### PR DESCRIPTION
Two notes files.

**`1.0.588.md` is on the critical path for the next release.** #1206 publishes `release-notes/<version>.md` as the Release body, and the release job checks out the tag — so this has to be on master *before* `1.0.588` is pushed, or the page gets the generated fallback. 1.0.588 will be the first release published through that automation.

**`1.0.587.md` is retroactive.** That release went out earlier today with no notes file, so its page currently carries the placeholder body. Merging this does not change that page; it still needs `gh release edit 1.0.587 --notes-file release-notes/1.0.587.md`. The file is here so the repo's record is complete.

### Worth a reviewer's eye

1.0.587 contains four changes to values earlier versions reported, and the notes open by saying output from 1.0.586 and earlier is not directly comparable: the duplicated MBR peak (#1202), MBR no longer crossing digestion agents (#1148), ambiguous matches excluded from quantification (#1210), and merged results dropping retention times and protein groups (#1147). If any of those characterisations is wrong, this is the place to catch it.

1.0.588 has no behaviour changes — it is what the package carries: XML documentation in (#1162), ~6.8 MB of modification data in (#1185), one arm64-hostile Thermo assembly out (#1156).

### One correction embedded here

`Get-ReleaseChangeset.ps1` placed #1180 (FWHM) in the 1.0.588 changeset. Tag `1.0.587` points at #1180's merge commit — `compare 071d1abb...1.0.587` returns `identical` — so it shipped in 1.0.587. Both changesets here came from `gh api compare/<prev>...<head>` instead. The script appears to filter by merge timestamp rather than ancestry, which goes wrong when a tag is cut minutes after a merge, as it was today.

Docs only; no code, no tests.