### PR TITLE
Make the quantification table rectangular, so values stay under their headers

### DIFF
--- a/mzLib/Omics/BioPolymerGroup/BioPolymerGroup.cs
+++ b/mzLib/Omics/BioPolymerGroup/BioPolymerGroup.cs
@@ -285,27 +285,6 @@ namespace Omics.BioPolymerGroup
         /// Header includes columns for biopolymer information, quantification, and statistical metrics.
         /// </summary>
         /// <returns>Tab-separated header string suitable for TSV file output.</returns>
-        /// <summary>
-        /// Whether this group was handed to a quantification engine at all, which is what decides
-        /// whether the intensity columns exist.
-        /// </summary>
-        /// <remarks>
-        /// Deliberately NOT <see cref="SampleGroupResult.HasIntensityData"/>. That answers a per-group
-        /// question -- did this sample group get a value -- and using it to choose columns made the
-        /// table ragged: a group whose samples were all unobserved emitted two columns per sample
-        /// group where its neighbour emitted four. The header is written once, from one group, while
-        /// every row writes its own, so every value after the disagreement landed under the wrong
-        /// column name.
-        ///
-        /// Quantification is a property of the run, not of one sample group: an engine either
-        /// populated this entity or it did not. <see cref="IHasSampleIntensities.IntensitiesBySample"/>
-        /// is assigned for every row of the matrix -- a dictionary, empty if nothing was observed --
-        /// so all groups in one run agree, the table is rectangular by construction, and an unobserved
-        /// sample yields an empty cell rather than a vanished column, which keeps absent
-        /// distinguishable from an observed zero. It stays null when no engine ran, which is what
-        /// omits the columns altogether.
-        /// </remarks>
-        private bool IsQuantified => IntensitiesBySample is not null;
         public string GetTabSeparatedHeader()
         {
             var sb = new StringBuilder();
@@ -327,7 +306,7 @@ namespace Omics.BioPolymerGroup
             #region Quantification Header Building
             if (SampleGroupResults is null) PopulateSampleGroupResults();
 
-            bool quantified = IsQuantified;
+            bool quantified = HasAssignedSampleIntensities;
             foreach (var group in SampleGroupResults!)
             {
                 sb.Append($"SpectralCount_{group.Label}\t");
@@ -348,6 +327,38 @@ namespace Omics.BioPolymerGroup
             sb.Append("Best Sequence Notch QValue");
             return sb.ToString();
         }
+
+        /// <summary>
+        /// Whether sample intensities have been assigned to this group -- a non-empty sample list
+        /// AND an assigned dictionary -- which is what decides whether the intensity columns exist.
+        /// Named for what it tests rather than for "was quantified": the setters are public and
+        /// non-coalescing, so an assignment is evidence that something populated this group, not
+        /// proof that an engine did.
+        /// Protected rather than private so a derived group can adopt the same predicate instead of
+        /// copying the expression.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately NOT <see cref="SampleGroupResult.HasIntensityData"/>. That answers a per-group
+        /// question -- did this sample group get a value -- and using it to choose columns made rows
+        /// disagree with the header: a group whose samples were all unobserved emitted two columns per
+        /// sample group where its neighbour emitted four, so every value after the disagreement was
+        /// written under the wrong column name.
+        ///
+        /// Both fields are required. <see cref="IHasSampleIntensities.IntensitiesBySample"/> alone is
+        /// not enough: <see cref="ConstructSubsetBioPolymerGroup"/> assigns an empty-but-non-null
+        /// dictionary alongside an empty sample list when no sample matches the requested file, and
+        /// gating on the dictionary alone would then advertise intensity columns that
+        /// <see cref="PopulateSampleGroupResults"/> can never fill.
+        ///
+        /// SCOPE, because this does not make every table rectangular. It makes the four columns per
+        /// sample group agree across the groups of one quantified run. When no engine has run,
+        /// <see cref="PopulateSampleGroupResults"/> builds one result per file in each group's OWN
+        /// spectral matches, so two groups covering different files still emit different column
+        /// counts -- a pre-existing defect on the unquantified path that no per-group flag can fix,
+        /// because a single group does not know the run's full file list.
+        /// </remarks>
+        protected bool HasAssignedSampleIntensities =>
+            SamplesForQuantification is { Count: > 0 } && IntensitiesBySample is not null;
 
         /// <summary>
         /// Returns a tab-separated string representation of this biopolymer group,
@@ -438,7 +449,7 @@ namespace Omics.BioPolymerGroup
                 : AllBioPolymersWithSetMods.Select(p => p.BaseSequence).Distinct().OrderBy(s => s))
                 .ToList();
 
-            bool quantifiedRow = IsQuantified;
+            bool quantifiedRow = HasAssignedSampleIntensities;
             foreach (var group in SampleGroupResults!)
             {
                 sb.Append(group.SpectralCount);
@@ -446,8 +457,10 @@ namespace Omics.BioPolymerGroup
 
                 if (quantifiedRow)
                 {
-                    // Empty, not 0: this sample was never observed, and writing a zero
-                    // would claim a measurement that was not made.
+                    // Empty rather than 0, so the cell does not assert a measurement that was
+                    // not made. Note this does not make absent distinguishable from a measured zero
+                    // through the engine: QuantificationEngine.OverwriteSampleIntensities drops
+                    // zero-valued cells, so a genuine zero never reaches IntensitiesBySample either.
                     if (group.HasIntensityData)
                         sb.Append(group.Intensity);
                     sb.Append("\t");

--- a/mzLib/Omics/BioPolymerGroup/BioPolymerGroup.cs
+++ b/mzLib/Omics/BioPolymerGroup/BioPolymerGroup.cs
@@ -284,8 +284,15 @@ namespace Omics.BioPolymerGroup
         /// Returns a tab-separated header line for output files, matching the format of <see cref="ToString"/>.
         /// Header includes columns for biopolymer information, quantification, and statistical metrics.
         /// </summary>
+        /// <remarks>
+        /// Virtual because <see cref="ToString"/> is, and the two must be overridden together or a
+        /// writer pairs one type's header with another type's rows. A derived group that hides this
+        /// with <c>new</c> while overriding <see cref="ToString"/> is dispatched inconsistently: a
+        /// call through <see cref="IBioPolymerGroup"/> or a base reference gets this header and the
+        /// derived row. Overriding both keeps the pair together however the call is typed.
+        /// </remarks>
         /// <returns>Tab-separated header string suitable for TSV file output.</returns>
-        public string GetTabSeparatedHeader()
+        public virtual string GetTabSeparatedHeader()
         {
             var sb = new StringBuilder();
             sb.Append("BioPolymer Accession" + '\t');

--- a/mzLib/Omics/BioPolymerGroup/BioPolymerGroup.cs
+++ b/mzLib/Omics/BioPolymerGroup/BioPolymerGroup.cs
@@ -285,6 +285,27 @@ namespace Omics.BioPolymerGroup
         /// Header includes columns for biopolymer information, quantification, and statistical metrics.
         /// </summary>
         /// <returns>Tab-separated header string suitable for TSV file output.</returns>
+        /// <summary>
+        /// Whether this group was handed to a quantification engine at all, which is what decides
+        /// whether the intensity columns exist.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately NOT <see cref="SampleGroupResult.HasIntensityData"/>. That answers a per-group
+        /// question -- did this sample group get a value -- and using it to choose columns made the
+        /// table ragged: a group whose samples were all unobserved emitted two columns per sample
+        /// group where its neighbour emitted four. The header is written once, from one group, while
+        /// every row writes its own, so every value after the disagreement landed under the wrong
+        /// column name.
+        ///
+        /// Quantification is a property of the run, not of one sample group: an engine either
+        /// populated this entity or it did not. <see cref="IHasSampleIntensities.IntensitiesBySample"/>
+        /// is assigned for every row of the matrix -- a dictionary, empty if nothing was observed --
+        /// so all groups in one run agree, the table is rectangular by construction, and an unobserved
+        /// sample yields an empty cell rather than a vanished column, which keeps absent
+        /// distinguishable from an observed zero. It stays null when no engine ran, which is what
+        /// omits the columns altogether.
+        /// </remarks>
+        private bool IsQuantified => IntensitiesBySample is not null;
         public string GetTabSeparatedHeader()
         {
             var sb = new StringBuilder();
@@ -306,13 +327,14 @@ namespace Omics.BioPolymerGroup
             #region Quantification Header Building
             if (SampleGroupResults is null) PopulateSampleGroupResults();
 
+            bool quantified = IsQuantified;
             foreach (var group in SampleGroupResults!)
             {
                 sb.Append($"SpectralCount_{group.Label}\t");
-                if (group.HasIntensityData)
+                if (quantified)
                     sb.Append($"Intensity_{group.Label}\t");
                 sb.Append($"CountOccupancy_{group.Label}\t");
-                if (group.HasIntensityData)
+                if (quantified)
                     sb.Append($"IntensityOccupancy_{group.Label}\t");
             }
             #endregion
@@ -416,23 +438,28 @@ namespace Omics.BioPolymerGroup
                 : AllBioPolymersWithSetMods.Select(p => p.BaseSequence).Distinct().OrderBy(s => s))
                 .ToList();
 
+            bool quantifiedRow = IsQuantified;
             foreach (var group in SampleGroupResults!)
             {
                 sb.Append(group.SpectralCount);
                 sb.Append("\t");
 
-                if (group.HasIntensityData)
+                if (quantifiedRow)
                 {
-                    sb.Append(group.Intensity);
+                    // Empty, not 0: this sample was never observed, and writing a zero
+                    // would claim a measurement that was not made.
+                    if (group.HasIntensityData)
+                        sb.Append(group.Intensity);
                     sb.Append("\t");
                 }
 
                 sb.Append(TruncateString(group.FormatOccupancy(orderedKeys, isParentLevel, intensityBased: false)));
                 sb.Append("\t");
 
-                if (group.HasIntensityData)
+                if (quantifiedRow)
                 {
-                    sb.Append(TruncateString(group.FormatOccupancy(orderedKeys, isParentLevel, intensityBased: true)));
+                    if (group.HasIntensityData)
+                        sb.Append(TruncateString(group.FormatOccupancy(orderedKeys, isParentLevel, intensityBased: true)));
                     sb.Append("\t");
                 }
             }

--- a/mzLib/Test/Quantification/QuantificationDeliveryTests.cs
+++ b/mzLib/Test/Quantification/QuantificationDeliveryTests.cs
@@ -583,4 +583,123 @@ public class QuantificationDeliveryTests
         Assert.That(QuantificationWriter.WriteRawData(unquantified, string.Empty), Is.Null);
         Assert.That(QuantificationWriter.WriteRawData(new List<ISpectralMatch>(), string.Empty), Is.Null);
     }
+
+    /// <summary>
+    /// The rendered table must be rectangular. Every row of a protein table is written by
+    /// <see cref="BioPolymerGroup.ToString"/> while the header is written once, from the first group
+    /// in the list -- so if two groups disagree about which columns exist, every value after the
+    /// disagreement lands under the wrong header and the file is silently wrong rather than obviously
+    /// broken.
+    ///
+    /// They disagreed because <c>HasIntensityData</c> gated the two intensity columns per sample
+    /// group, and it is false for a group whose samples were all unobserved. P002 here is seen only in
+    /// file1, so its three file2 groups carry no intensity: it emitted two columns per group where
+    /// P001 emitted four.
+    ///
+    /// The gate is now whether the entity was quantified at all, not whether a particular group has a
+    /// value, so an unobserved sample yields an empty cell rather than a missing column. That keeps
+    /// absent distinguishable from zero -- see
+    /// <see cref="Run_OmitsUnobservedSamplesRatherThanStoringZero"/>, which pins the same distinction
+    /// on the data model.
+    /// </summary>
+    [Test]
+    public void RenderedTable_IsRectangular_WhenAGroupHasUnobservedSamples()
+    {
+        BuildFixture(out var design, out var spectralMatches, out var peptides, out var proteinGroups);
+
+        // P002 is observed in file1 only, so its three file2 samples have no intensity.
+        string p002Peptide = peptides.Single(p => ((Protein)p.Parent).Accession == "P002").BaseSequence;
+        spectralMatches = spectralMatches
+            .Where(sm => !(sm.FullFilePath == File2 && sm.BaseSequence == p002Peptide))
+            .ToList();
+
+        new QuantificationEngine(SimpleParameters(), design, spectralMatches, peptides, proteinGroups).Run();
+
+        // Render the table the way a writer does: one header, taken from the first group, then a row
+        // per group from its own ToString().
+        string header = proteinGroups.First().GetTabSeparatedHeader();
+        var rows = proteinGroups.Select(g => g.ToString()).ToList();
+
+        int headerFields = header.Split('\t').Length;
+        Assert.Multiple(() =>
+        {
+            for (int i = 0; i < rows.Count; i++)
+            {
+                Assert.That(rows[i].Split('\t'), Has.Length.EqualTo(headerFields),
+                    $"row {i} ({proteinGroups[i].BioPolymerGroupName}) does not line up with the header; "
+                    + "every value after the first missing column is written under the wrong name");
+            }
+        });
+    }
+
+    /// <summary>
+    /// The same invariant for a group the engine quantified but found nothing for -- a decoy, or a
+    /// group whose peptides all fell below threshold. It is a matrix row like any other
+    /// (<see cref="QuantificationEngine.GetUniquePeptideToProteinMap"/> gives every group an entry,
+    /// empty or not), so it gets a full row of zeros, no intensities, and previously no intensity
+    /// columns at all -- while its neighbours emitted them. That is the whole-file version of the
+    /// same defect, because the header may be taken from either kind of group.
+    /// </summary>
+    [Test]
+    public void RenderedTable_IsRectangular_WhenAGroupWasQuantifiedButHasNoValues()
+    {
+        BuildFixture(out var design, out var spectralMatches, out var peptides, out var proteinGroups);
+
+        // A third group with no peptide in the matrix: quantified, but nothing to show for it.
+        var orphan = new Protein("ORPHANK", "P003");
+        var orphanPeptide = orphan
+            .Digest(new DigestionParams(maxMissedCleavages: 0, minPeptideLength: 5), new List<Modification>(), new List<Modification>())
+            .First();
+        proteinGroups.Add(new BioPolymerGroup(
+            new HashSet<IBioPolymer> { orphan },
+            new HashSet<IBioPolymerWithSetMods> { orphanPeptide },
+            new HashSet<IBioPolymerWithSetMods> { orphanPeptide }));
+
+        new QuantificationEngine(SimpleParameters(), design, spectralMatches, peptides, proteinGroups).Run();
+
+        var p003 = proteinGroups.Single(g => g.BioPolymerGroupName.Contains("P003"));
+        Assert.That(p003.SamplesForQuantification, Is.Not.Null,
+            "every protein group is a matrix row, so the engine should have written the sample list");
+        Assert.That(p003.IntensitiesBySample, Is.Empty,
+            "nothing was observed for it, so no sample carries a value");
+
+        string header = proteinGroups.First().GetTabSeparatedHeader();
+        int headerFields = header.Split('\t').Length;
+
+        Assert.Multiple(() =>
+        {
+            foreach (var group in proteinGroups)
+                Assert.That(group.ToString().Split('\t'), Has.Length.EqualTo(headerFields),
+                    $"{group.BioPolymerGroupName} does not line up with the header");
+        });
+
+        // And the header must be the same whichever group happens to be first -- the writer takes it
+        // from proteinGroups.First(), which is not necessarily a quantified one.
+        Assert.That(p003.GetTabSeparatedHeader(), Is.EqualTo(header),
+            "an unquantified group must describe the same columns as a quantified one");
+    }
+
+    /// <summary>
+    /// An entity the engine never touched keeps the spectral-count-only shape. This is what
+    /// distinguishes "quantification did not run" from "it ran and found nothing", and it is why the
+    /// gate is <see cref="IHasSampleIntensities.SamplesForQuantification"/> rather than a per-group
+    /// flag: a run either quantified its groups or it did not, and every group in one run agrees.
+    /// </summary>
+    [Test]
+    public void RenderedTable_OmitsIntensityColumnsEntirely_WhenNothingWasQuantified()
+    {
+        BuildFixture(out _, out _, out _, out var proteinGroups);
+
+        var unquantified = proteinGroups.First();
+        Assert.That(unquantified.SamplesForQuantification, Is.Null, "fixture starts unquantified");
+
+        string header = unquantified.GetTabSeparatedHeader();
+        Assert.Multiple(() =>
+        {
+            Assert.That(header, Does.Not.Contain("Intensity_"),
+                "no quantification ran, so there is nothing for an intensity column to hold");
+            Assert.That(header, Does.Not.Contain("IntensityOccupancy_"));
+            Assert.That(unquantified.ToString().Split('\t'), Has.Length.EqualTo(header.Split('\t').Length));
+        });
+    }
 }

--- a/mzLib/Test/Quantification/QuantificationDeliveryTests.cs
+++ b/mzLib/Test/Quantification/QuantificationDeliveryTests.cs
@@ -681,9 +681,12 @@ public class QuantificationDeliveryTests
 
     /// <summary>
     /// An entity the engine never touched keeps the spectral-count-only shape. This is what
-    /// distinguishes "quantification did not run" from "it ran and found nothing", and it is why the
-    /// gate is <see cref="IHasSampleIntensities.SamplesForQuantification"/> rather than a per-group
-    /// flag: a run either quantified its groups or it did not, and every group in one run agrees.
+    /// distinguishes "quantification did not run" from "it ran and found nothing". The gate is both
+    /// <see cref="IHasSampleIntensities.SamplesForQuantification"/> being non-empty AND
+    /// <see cref="IHasSampleIntensities.IntensitiesBySample"/> being non-null, rather than a
+    /// per-group flag: a run either quantified its groups or it did not, and every group of one
+    /// quantified entity agrees. Both fields are needed because ConstructSubsetBioPolymerGroup can
+    /// leave an empty sample list beside a non-null dictionary.
     /// </summary>
     [Test]
     public void RenderedTable_OmitsIntensityColumnsEntirely_WhenNothingWasQuantified()
@@ -746,6 +749,43 @@ public class QuantificationDeliveryTests
                     $"{name} was never observed, so its cell must be empty rather than a fabricated zero");
             foreach (var (name, i) in present)
                 Assert.That(row[i], Is.Not.Empty, $"{name} was observed and must carry its value");
+        });
+    }
+
+    /// <summary>
+    /// A subset group built for a file that none of the parent's samples match gets an empty sample
+    /// list beside an empty-but-non-null intensity dictionary
+    /// (<see cref="BioPolymerGroup.ConstructSubsetBioPolymerGroup"/>). Gating the columns on the
+    /// dictionary alone would then advertise intensity columns that
+    /// <see cref="BioPolymerGroup.PopulateSampleGroupResults"/> can never fill, because with no
+    /// samples it falls back to grouping by spectral-match file path.
+    ///
+    /// So the gate requires a non-empty sample list as well. This pins that: the subset describes no
+    /// intensity columns rather than permanently empty ones.
+    /// </summary>
+    [Test]
+    public void SubsetGroupForAnUnmatchedFile_DoesNotAdvertiseIntensityColumnsItCannotFill()
+    {
+        BuildFixture(out var design, out var spectralMatches, out var peptides, out var proteinGroups);
+        new QuantificationEngine(SimpleParameters(), design, spectralMatches, peptides, proteinGroups).Run();
+
+        var parent = proteinGroups.First();
+        Assert.That(parent.SamplesForQuantification, Is.Not.Null.And.Not.Empty, "parent was quantified");
+
+        // The fixture's samples carry bare file names, so an absolute path matches none of them --
+        // the path/bare-name mismatch this repo's own fixtures produce.
+        var subset = parent.ConstructSubsetBioPolymerGroup(@"C:\somewhereile1.raw");
+
+        Assert.That(subset.SamplesForQuantification, Is.Empty, "no sample matched that path");
+        Assert.That(subset.IntensitiesBySample, Is.Not.Null.And.Empty,
+            "the subset still gets a dictionary, which is why the dictionary alone cannot be the gate");
+
+        string header = subset.GetTabSeparatedHeader();
+        Assert.Multiple(() =>
+        {
+            Assert.That(header, Does.Not.Contain("Intensity_"),
+                "nothing can fill these, so they must not be advertised");
+            Assert.That(subset.ToString().Split('	'), Has.Length.EqualTo(header.Split('	').Length));
         });
     }
 }

--- a/mzLib/Test/Quantification/QuantificationDeliveryTests.cs
+++ b/mzLib/Test/Quantification/QuantificationDeliveryTests.cs
@@ -702,4 +702,50 @@ public class QuantificationDeliveryTests
             Assert.That(unquantified.ToString().Split('\t'), Has.Length.EqualTo(header.Split('\t').Length));
         });
     }
+
+    /// <summary>
+    /// The rectangular table must not have been bought by inventing zeros. An unobserved sample gets
+    /// an empty cell; a sample observed at zero would get "0". Rectangularity is a field-count
+    /// property and this is a field-content one, so the tests above cannot see the difference -- a
+    /// change that wrote 0 into the absent cells would keep them all passing while claiming a
+    /// measurement that was never made.
+    /// </summary>
+    [Test]
+    public void RenderedRow_LeavesAnUnobservedSampleEmpty_RatherThanWritingZero()
+    {
+        BuildFixture(out var design, out var spectralMatches, out var peptides, out var proteinGroups);
+
+        string p002Peptide = peptides.Single(p => ((Protein)p.Parent).Accession == "P002").BaseSequence;
+        spectralMatches = spectralMatches
+            .Where(sm => !(sm.FullFilePath == File2 && sm.BaseSequence == p002Peptide))
+            .ToList();
+
+        new QuantificationEngine(SimpleParameters(), design, spectralMatches, peptides, proteinGroups).Run();
+
+        var p002 = proteinGroups.Single(g => g.BioPolymerGroupName.Contains("P002"));
+        var header = p002.GetTabSeparatedHeader().Split('	');
+        var row = p002.ToString().Split('	');
+
+        // The three file2 channels are unobserved for P002; the three file1 channels are not.
+        var absent = header
+            .Select((name, i) => (name, i))
+            .Where(x => x.name.StartsWith("Intensity_") && x.name.Contains(File2.Replace(".raw", "")))
+            .ToList();
+        var present = header
+            .Select((name, i) => (name, i))
+            .Where(x => x.name.StartsWith("Intensity_") && x.name.Contains(File1.Replace(".raw", "")))
+            .ToList();
+
+        Assert.That(absent, Is.Not.Empty, "the unobserved channels should still have columns");
+        Assert.That(present, Is.Not.Empty, "the observed channels should too");
+
+        Assert.Multiple(() =>
+        {
+            foreach (var (name, i) in absent)
+                Assert.That(row[i], Is.Empty,
+                    $"{name} was never observed, so its cell must be empty rather than a fabricated zero");
+            foreach (var (name, i) in present)
+                Assert.That(row[i], Is.Not.Empty, $"{name} was observed and must carry its value");
+        });
+    }
 }


### PR DESCRIPTION
A protein group whose samples were all unobserved emitted two columns per sample group where its neighbour emitted four. The header is written once, from `proteinGroups.First()`, while every row writes its own `ToString()` — so every value after the disagreement landed under the wrong column name. No exception, no warning: a file that looks fine and is wrong.

Measured on the delivery fixture: a group observed in one file of two came out **39 fields against a 45-field header**; a group the engine quantified but found nothing for came out **33**.

## Cause

`SampleGroupResult.HasIntensityData` answers a per-group question — did *this* sample group get a value — and both `GetTabSeparatedHeader` and `ToString` were using it to decide whether a column *exists*. Whether the columns exist has to be a property of the entity, or a row cannot line up with a header written from a different row.

The gate is now `HasAssignedSampleIntensities` — a non-empty `SamplesForQuantification` **and** an assigned `IntensitiesBySample`. `QuantificationEngine.OverwriteSampleIntensities` sets both for every row of the matrix, and `GetUniquePeptideToProteinMap` gives every protein group a row, so all groups of one quantified run agree.

Both fields are required. `ConstructSubsetBioPolymerGroup` assigns an empty-but-non-null dictionary beside an empty sample list when no sample matches the requested file — the normal case for a per-file subset, since the engine omits zero cells — and gating on the dictionary alone would advertise intensity columns that `PopulateSampleGroupResults` can never fill. An earlier revision of this PR did exactly that; there is now a test for it.

## What it deliberately does not do

**Store zeros for unobserved samples.** That would also square the table and was the first thing suggested, but it destroys the difference between *not observed* and *observed as zero*, which `Run_OmitsUnobservedSamplesRatherThanStoringZero` pins on the data model. An unobserved sample now renders as an **empty cell** rather than a vanished column.

Worth being precise, because the obvious reading is wrong: absent and a measured zero are **not** distinguishable end-to-end today, because `OverwriteSampleIntensities` drops zero-valued cells, so a genuine zero never reaches `IntensitiesBySample` either. The empty cell is still right — it does not assert a measurement that was not made — but it is not currently carrying that distinction.

## Scope — this narrows the seam, it does not close it

Rectangularity cannot be established from inside `BioPolymerGroup`. The *number* of sample groups comes from `PopulateSampleGroupResults`, whose no-design branch builds one result per file in that groups **own** spectral matches — so two groups covering different files still emit different column counts, and a group that never entered the matrix keeps null intensities while its neighbours do not. The header is written once per file, from one group; the rows come from many. **Only a writer-level decision — one column set chosen for the whole file — makes every table square.**

This fixes the case that matters now: the four columns agree across the groups of one quantified run, which is the shape MetaMorpheus #2755 introduces. The remarks in the code say the rest plainly rather than implying it is solved.

## `virtual`, and its MetaMorpheus counterpart

`ToString` is virtual and `GetTabSeparatedHeader` was not, so a subclass could only *hide* the header with `new` while genuinely overriding the row. `IBioPolymerGroup` declares `GetTabSeparatedHeader`, so an interface-typed call would get this header paired with a derived row.

No such call site exists today — every caller in either repo resolves on a concrete type — but calling `QuantificationEngine` from `PostSearchAnalysisTask` is exactly the change that starts passing groups through `IBioPolymerGroup`-typed plumbing, and it is in flight. Making it `virtual` closes that before it lands. It is a recompile concern rather than a source one.

**Counterpart PR, not yet opened:** MetaMorpheuss `EngineLayer.ProteinGroup` carries its own copy of this rendering block and hides the header with `new`. After a release ships this, that becomes `override`, and its own `Intensity_` gate — still per-group — needs the same treatment. MetaMorpheus is not currently ragged only because it writes FlashLFQs zeros explicitly, which makes `HasIntensityData` uniformly true; the TMT path in #2755 omits them and removes that protection. `ProteinGroupTest.cs:280` is the existing guard rail and should be extended to a group whose intensities were *omitted* rather than zeroed.

## Tests

Five, asserting at the **file** level, because a unit test on `GetTabSeparatedHeader` cannot see a misalignment — render a header and every row, then assert each row has the headers field count.

- a group with unobserved samples
- a group quantified with no values — also asserts an unquantified group describes the same columns as a quantified one, since the writer may take the header from either
- a group no engine touched still has no intensity columns at all
- the absent cell is empty, not a fabricated zero (verified by mutation: with the inner check removed, this fails on three cells with `Expected: <empty> But was: "0"` while the rectangularity tests still pass — which is why it exists)
- a subset group for an unmatched file does not advertise columns it cannot fill (verified by reverting the gate)

**No existing test needed changing.** Full suite: 5827 passed, 29 skipped, 0 failed.