### PR TITLE
Reject an unset quantification strategy by name, instead of throwing from mid-run

### DIFF
--- a/mzLib/Quantification/Interfaces/ICollapseStrategy.cs
+++ b/mzLib/Quantification/Interfaces/ICollapseStrategy.cs
@@ -18,6 +18,21 @@ namespace Quantification.Interfaces
         string Name { get; }
 
         /// <summary>
+        /// Whether <see cref="CollapseSamples{T}"/> reads the aggregation strategy it is handed.
+        /// </summary>
+        /// <remarks>
+        /// A strategy that groups nothing never reduces two values to one, so it has no use for an
+        /// aggregator -- and requiring the caller to supply one anyway would mean naming a behaviour
+        /// that does not happen. <see cref="QuantificationEngine"/> reads this to decide whether a null
+        /// <see cref="QuantificationParameters.CollapseAggregationStrategy"/> is a configuration error
+        /// or simply unused.
+        ///
+        /// Defaults to true, which is the safe answer: an implementation that does aggregate gets the
+        /// check without opting in, and only a genuine no-op has to say so.
+        /// </remarks>
+        bool RequiresAggregation => true;
+
+        /// <summary>
         /// Combines the columns this strategy groups together, reducing each group to a single column
         /// with <paramref name="aggregation"/>.
         /// </summary>

--- a/mzLib/Quantification/QuantificationEngine.cs
+++ b/mzLib/Quantification/QuantificationEngine.cs
@@ -198,6 +198,33 @@ public class QuantificationEngine
     }
 
     /// <summary>
+    /// The strategies every run needs, in the order the engine applies them, each paired with the name
+    /// to report when it is missing. <see cref="QuantificationParameters.CollapseAggregationStrategy"/>
+    /// is deliberately absent: it is needed only when the collapse strategy reads it, which is
+    /// <see cref="ValidateEngine"/>'s separate check.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="QuantificationParameters"/> leaves all of these null, and none has a defensible
+    /// default -- summing and taking a median are different answers, not different spellings of one.
+    /// So the only thing validation can do is say which are missing, and it is worth doing early: the
+    /// first dereference is in <see cref="RunPeptideQuant"/>, which <see cref="Run"/> reaches after it
+    /// has already started writing the raw matrix. Without this check the run leaves that file behind
+    /// and then throws a NullReferenceException naming nothing.
+    ///
+    /// Spelled out rather than reflected over, so that a strategy added to the parameters is a
+    /// deliberate addition here too, and the reported name comes from <c>nameof</c> either way.
+    /// </remarks>
+    private static readonly (string Name, Func<QuantificationParameters, object> Get)[] RequiredStrategies =
+    {
+        (nameof(QuantificationParameters.SpectralMatchNormalizationStrategy), p => p.SpectralMatchNormalizationStrategy),
+        (nameof(QuantificationParameters.SpectralMatchToPeptideRollUpStrategy), p => p.SpectralMatchToPeptideRollUpStrategy),
+        (nameof(QuantificationParameters.PeptideNormalizationStrategy), p => p.PeptideNormalizationStrategy),
+        (nameof(QuantificationParameters.CollapseStrategy), p => p.CollapseStrategy),
+        (nameof(QuantificationParameters.PeptideToProteinRollUpStrategy), p => p.PeptideToProteinRollUpStrategy),
+        (nameof(QuantificationParameters.ProteinNormalizationStrategy), p => p.ProteinNormalizationStrategy),
+    };
+
+    /// <summary>
     /// Checks Engine state for validity before running quantification.
     /// </summary>
     /// <param name="badResults"> Return quant results with descriptive Summary if problem was encountered; null otherwise</param>
@@ -205,6 +232,35 @@ public class QuantificationEngine
     internal bool ValidateEngine(out QuantificationResults badResults)
     {
         badResults = null;
+        if (Parameters == null)
+        {
+            badResults = QuantificationResults.Failure("QuantificationEngine Error: Parameters are null.");
+            return false;
+        }
+        // Every strategy has to be present before anything runs, and they are reported together rather
+        // than one per run: a caller who reached here with one unset most likely reached here with
+        // several, and finding that out a run at a time is the slower way to learn it.
+        var missingStrategies = RequiredStrategies
+            .Where(strategy => strategy.Get(Parameters) == null)
+            .Select(strategy => strategy.Name)
+            .ToList();
+        // The aggregation strategy is required only when the collapse strategy reads it, so that a run
+        // that collapses nothing need not name a behaviour that never happens. Left unrequired, a
+        // collapsing run would still fail -- CollapseStrategyBase throws ArgumentNullException -- but
+        // from inside the run, after the raw matrix has been written.
+        if (Parameters.CollapseStrategy?.RequiresAggregation == true
+            && Parameters.CollapseAggregationStrategy == null)
+        {
+            missingStrategies.Add(nameof(QuantificationParameters.CollapseAggregationStrategy));
+        }
+        if (missingStrategies.Count > 0)
+        {
+            badResults = QuantificationResults.Failure(
+                $"QuantificationEngine Error: Required quantification strateg{(missingStrategies.Count == 1 ? "y is" : "ies are")} " +
+                $"not set: {string.Join(", ", missingStrategies)}. Every strategy on QuantificationParameters " +
+                "defaults to null, so each one has to be assigned before the engine runs.");
+            return false;
+        }
         if (ExperimentalDesign == null)
         {
             badResults = QuantificationResults.Failure("QuantificationEngine Error: Experimental design is null.");

--- a/mzLib/Quantification/Strategies/Collapse/NoCollapse.cs
+++ b/mzLib/Quantification/Strategies/Collapse/NoCollapse.cs
@@ -11,6 +11,9 @@ namespace Quantification.Strategies
     {
         public string Name => "No Collapse";
 
+        /// <inheritdoc />
+        public bool RequiresAggregation => false;
+
         public QuantMatrix<T> CollapseSamples<T>(QuantMatrix<T> quantMatrix, IAggregationStrategy aggregation)
             where T : IEquatable<T>
         {

--- a/mzLib/Test/Quantification/CollapseStrategyTests.cs
+++ b/mzLib/Test/Quantification/CollapseStrategyTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Reflection;
 
 namespace Test.Quantification;
 
@@ -37,7 +38,60 @@ public class CollapseStrategyTests
 
     private static double[] SingleRow<T>(QuantMatrix<T> matrix) where T : IEquatable<T> => matrix.GetRow(0);
 
+    /// <summary>Every concrete collapse strategy shipped in the Quantification assembly.</summary>
+    private static IEnumerable<ICollapseStrategy> EveryCollapseStrategy() =>
+        typeof(NoCollapse).Assembly.GetTypes()
+            .Where(t => typeof(ICollapseStrategy).IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface)
+            .Where(t => t.GetConstructor(Type.EmptyTypes) != null)
+            .Select(t => (ICollapseStrategy)Activator.CreateInstance(t));
+
     #endregion
+
+    /// <summary>
+    /// <see cref="ICollapseStrategy.RequiresAggregation"/> is a second representation of a fact the
+    /// method body already carries -- whether <see cref="ICollapseStrategy.CollapseSamples{T}"/> reads
+    /// the aggregator it is handed. QuantificationEngine.ValidateEngine trusts it: a strategy that
+    /// answers false is allowed to run with a null aggregation strategy. If the two ever disagree, the
+    /// NullReferenceException that validation exists to prevent comes straight back, from a strategy
+    /// that declared it could not happen.
+    ///
+    /// So the declaration is checked against the behaviour for every strategy in the assembly, in both
+    /// directions, rather than trusting each implementer to keep them in step. This is the plan's
+    /// standing rule -- a milestone that introduces a second representation ships the cross-check with
+    /// it -- applied to the representation mzLib #1242 introduced.
+    /// </summary>
+    [Test]
+    public void RequiresAggregationMatchesWhetherTheStrategyActuallyReadsIt()
+    {
+        var columns = new List<ISampleInfo>
+        {
+            Lfq("cond", biorep: 1, techrep: 1, fraction: 1),
+            Lfq("cond", biorep: 1, techrep: 1, fraction: 2),
+        };
+
+        var strategies = EveryCollapseStrategy().ToList();
+        Assert.That(strategies, Is.Not.Empty, "premise: the reflection finds the strategies at all");
+
+        foreach (var strategy in strategies)
+        {
+            // A fresh matrix per strategy: a collapsing one consumes the columns it is given.
+            var matrix = Matrix(columns, 1.0, 2.0);
+
+            if (strategy.RequiresAggregation)
+            {
+                Assert.That(() => strategy.CollapseSamples(matrix, null),
+                    Throws.TypeOf<ArgumentNullException>(),
+                    $"{strategy.GetType().Name} declares it needs an aggregator, so it must reject a null "
+                    + "one rather than dereference it");
+            }
+            else
+            {
+                Assert.That(() => strategy.CollapseSamples(matrix, null), Throws.Nothing,
+                    $"{strategy.GetType().Name} declares it needs no aggregator, and the engine lets a run "
+                    + "with none through on the strength of that -- so it must genuinely not read one");
+            }
+        }
+    }
 
     /// <summary>
     /// Collapsing fractions must leave technical replicates standing. This is the distinction the

--- a/mzLib/Test/Quantification/QuantificationTests.cs
+++ b/mzLib/Test/Quantification/QuantificationTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using MassSpectrometry;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
@@ -12,6 +14,7 @@ using Omics.Modifications;
 using Proteomics;
 using Proteomics.ProteolyticDigestion;
 using Quantification;
+using Quantification.Interfaces;
 using Quantification.Strategies;
 using Test.Omics;
 using Omics.SpectralMatch;
@@ -387,6 +390,182 @@ namespace Test.Quantification
             var result4 = engine4.Run();
             Assert.That(result4.Summary, Does.Contain("No biopolymer groups"));
         }
+
+        #region Missing strategies
+
+        /// <summary>
+        /// Every strategy-typed property on <see cref="QuantificationParameters"/>, found by reflection
+        /// rather than listed, so that a strategy added later is covered by these tests without anyone
+        /// remembering to add it here.
+        /// </summary>
+        private static IEnumerable<string> StrategyPropertyNames() =>
+            typeof(QuantificationParameters).GetProperties()
+                .Where(p => p.PropertyType.IsInterface && p.PropertyType.Namespace == "Quantification.Interfaces")
+                .Select(p => p.Name);
+
+        /// <summary>
+        /// Parameters in which every strategy is genuinely required. GetSimpleParameters collapses
+        /// nothing, and a strategy that groups nothing never reads an aggregator, so a collapsing
+        /// strategy is substituted to put all of them on the same footing.
+        /// </summary>
+        private static QuantificationParameters AllStrategiesRequired()
+        {
+            var parameters = QuantificationParameters.GetSimpleParameters();
+            parameters.CollapseStrategy = new CollapseFractions();
+            return parameters;
+        }
+
+        private static QuantificationEngine EngineWith(QuantificationParameters parameters)
+        {
+            var proteinGroups = CreateTestProteins(out var peptides);
+            return new QuantificationEngine(
+                parameters,
+                CreateTestExperimentalDesign(1, 2),
+                CreateTestSpectralMatches(peptides, 1, 2),
+                peptides.ToList(),
+                proteinGroups);
+        }
+
+        /// <summary>
+        /// The strategies are all null on a freshly constructed <see cref="QuantificationParameters"/>,
+        /// and nothing before this check reads them: the first dereference is inside the run itself, so
+        /// an external caller who left one unset used to get a NullReferenceException naming nothing,
+        /// from a stack frame several steps removed from the property they forgot.
+        ///
+        /// Each is nulled in turn so that the message is shown to name the one that is actually missing,
+        /// rather than whichever the engine happens to check first.
+        /// </summary>
+        [Test]
+        [TestCaseSource(nameof(StrategyPropertyNames))]
+        public void MissingStrategyIsRejectedByName(string strategyName)
+        {
+            var parameters = AllStrategiesRequired();
+            var property = typeof(QuantificationParameters).GetProperty(strategyName);
+            Assert.That(property, Is.Not.Null, "premise: the property this case names still exists");
+            Assert.That(property.GetValue(parameters), Is.Not.Null,
+                "premise: these parameters set every strategy, so nulling it is what the case varies");
+            property.SetValue(parameters, null);
+
+            QuantificationResults results = null;
+            Assert.That(() => results = EngineWith(parameters).Run(), Throws.Nothing,
+                "a missing strategy has to be reported, not thrown");
+
+            Assert.That(results.Success, Is.False);
+            Assert.That(results.Summary, Does.Contain(strategyName));
+        }
+
+        /// <summary>
+        /// The realistic shape of the bug is not one missing strategy but a caller who constructed the
+        /// parameters and set none of them. Reporting only the first would make that caller learn the
+        /// list one run at a time, so all of them are named at once.
+        ///
+        /// The aggregation strategy is the one exclusion, and not an oversight: with no collapse
+        /// strategy set there is nothing to ask whether an aggregator will be read, and demanding one
+        /// that may never be used would be guessing. It is reported once the collapse strategy is known
+        /// to want it, which <see cref="ACollapsingStrategyRequiresAnAggregationStrategy"/> covers.
+        /// </summary>
+        [Test]
+        public void ParametersWithNoStrategiesSetNameEveryStrategyTheRunNeeds()
+        {
+            var results = EngineWith(new QuantificationParameters()).Run();
+
+            Assert.That(results.Success, Is.False);
+            foreach (string strategyName in StrategyPropertyNames()
+                         .Where(name => name != nameof(QuantificationParameters.CollapseAggregationStrategy)))
+            {
+                Assert.That(results.Summary, Does.Contain(strategyName));
+            }
+        }
+
+        /// <summary>
+        /// A run that collapses nothing never reduces two values to one, so it has no aggregator to
+        /// name. Requiring one anyway would reject a configuration that works -- it is how the delivery
+        /// tests build their parameters -- so the requirement follows
+        /// <see cref="ICollapseStrategy.RequiresAggregation"/> rather than being unconditional.
+        /// </summary>
+        [Test]
+        public void NoCollapseNeedsNoAggregationStrategy()
+        {
+            var parameters = QuantificationParameters.GetSimpleParameters();
+            Assert.That(parameters.CollapseStrategy, Is.TypeOf<NoCollapse>(), "premise: this run collapses nothing");
+            parameters.CollapseAggregationStrategy = null;
+
+            var results = EngineWith(parameters).Run();
+
+            Assert.That(results.Success, Is.True, results.Summary);
+        }
+
+        /// <summary>
+        /// The other arm: once the collapse strategy does group columns, the aggregator decides what the
+        /// grouped values become and its absence is a configuration error. CollapseStrategyBase does
+        /// already throw ArgumentNullException for this, so what changes here is not the naming but the
+        /// timing -- that throw comes from inside the run, after the raw matrix has been written.
+        /// </summary>
+        [Test]
+        public void ACollapsingStrategyRequiresAnAggregationStrategy()
+        {
+            var parameters = AllStrategiesRequired();
+            parameters.CollapseAggregationStrategy = null;
+
+            QuantificationResults results = null;
+            Assert.That(() => results = EngineWith(parameters).Run(), Throws.Nothing);
+
+            Assert.That(results.Success, Is.False);
+            Assert.That(results.Summary, Does.Contain(nameof(QuantificationParameters.CollapseAggregationStrategy)));
+        }
+
+        /// <summary>
+        /// Validation reads Parameters to reach the strategies, and the output-directory fallback reads
+        /// it again, so a null Parameters has to be caught before either -- otherwise the check meant to
+        /// replace a NullReferenceException throws one of its own.
+        /// </summary>
+        [Test]
+        public void NullParametersAreRejectedRatherThanDereferenced()
+        {
+            QuantificationResults results = null;
+            Assert.That(() => results = EngineWith(null).Run(), Throws.Nothing);
+
+            Assert.That(results.Success, Is.False);
+            Assert.That(results.Summary, Does.Contain("Parameters are null"));
+        }
+
+        /// <summary>
+        /// Why this is worth validating rather than letting it throw: Run starts writing the raw matrix
+        /// before it reaches the first strategy, so the old failure left RawQuantification.tsv on disk
+        /// from a run that then died. Rejecting up front means a run that cannot finish also does not
+        /// start.
+        /// </summary>
+        [Test]
+        public void AMissingStrategyIsRejectedBeforeAnythingIsWritten()
+        {
+            string outputDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "MissingStrategyNoWrite");
+            if (Directory.Exists(outputDirectory)) Directory.Delete(outputDirectory, true);
+            Directory.CreateDirectory(outputDirectory);
+
+            try
+            {
+                var parameters = AllStrategiesRequired();
+                parameters.OutputDirectory = outputDirectory;
+                parameters.WriteRawInformation = true;
+                parameters.WritePeptideInformation = true;
+                parameters.WriteProteinInformation = true;
+                parameters.SpectralMatchNormalizationStrategy = null;
+
+                var results = EngineWith(parameters).Run();
+
+                Assert.That(results.Success, Is.False);
+                Assert.That(results.WrittenFiles, Is.Empty);
+                Assert.That(Directory.GetFiles(outputDirectory), Is.Empty,
+                    "the raw matrix is written before the first strategy is read, so a run rejected here "
+                    + "must not have started writing");
+            }
+            finally
+            {
+                Directory.Delete(outputDirectory, true);
+            }
+        }
+
+        #endregion
 
         [Test]
         public void QuantificationEngine_ComplexScenario_MultipleProteinsAndFiles()


### PR DESCRIPTION
`QuantificationParameters` leaves its strategy properties null and `ValidateEngine` never looked at
them. An external caller who missed one got a `NullReferenceException` from
`QuantificationEngine.cs:348` — a frame several steps removed from the property they forgot, naming
nothing. This is on the released 1.0.588 surface.

### The timing is worse than the message

`Run` starts writing the raw matrix *before* it reads the first strategy:

```csharp
if (Parameters.WriteRawInformation)
    rawWriter = Task.Run(() => QuantificationWriter.WriteRawData(...));   // starts here
RunPeptideQuant(out var peptideMatrix);                                   // throws here
```

So the failing run left `RawQuantification.tsv` on disk and then died. I confirmed that by probe
rather than by reading: against the unfixed engine the file is present after the throw. Validation
now rejects the run before anything is written, and returns a `QuantificationResults` failure rather
than throwing — the contract the rest of `ValidateEngine` already keeps.

### Six required, reported together

The six are reported in one message rather than one per run. A caller who missed one has most likely
missed several, and learning the list a run at a time is the slower way to find out.

### The seventh is conditional, and this is the substantive finding

The plan I was working from called this "seven strategy properties". The repo disagrees, and the repo
is right.

`NoCollapse` already documents that it ignores the aggregator — *"The aggregation strategy is unused,
because no group ever has more than one member"* — and `QuantificationDeliveryTests.SimpleParameters`
builds exactly that configuration: `NoCollapse`, with `CollapseAggregationStrategy` left unset. It
works today. Requiring the property outright would have rejected a working setup and forced callers
to name a behaviour that never happens.

So `ICollapseStrategy` now declares whether it reads one:

```csharp
bool RequiresAggregation => true;
```

A default interface member, so nothing external breaks, and defaulting to `true` is the safe
direction: an implementation that *does* aggregate is covered without opting in, and only a genuine
no-op has to say otherwise. `NoCollapse` overrides it to `false`.

**Those delivery tests pass unmodified.** That is the evidence the conditional is the right shape
rather than a convenience — had I required all seven, the correct move would have been to edit them,
and the bug would have been in the contract instead of the code.

### The cross-check, added in `24b4c01f`

`RequiresAggregation` is itself a second representation of a fact `CollapseSamples`' body already
carries — and `ValidateEngine` **trusts** it, letting a strategy that answers `false` run with a null
aggregator. So a strategy whose declaration and body disagree brings back the exact
`NullReferenceException` this PR removes, from a strategy that declared it could not happen.

`RequiresAggregationMatchesWhetherTheStrategyActuallyReadsIt` checks the declaration against the
behaviour for every concrete `ICollapseStrategy` in the assembly, in both directions — declaring
`false` means a null aggregator must not throw, declaring `true` means it must. The strategies are
found by reflection, so one added later is covered without anyone remembering to add it.

Both mutants verified: `CollapseStrategyBase` claiming `false` fails on `CollapseBiologicalReplicates`;
`NoCollapse` claiming `true` fails on `NoCollapse`.

That arm is still worth validating even though `CollapseStrategyBase` already throws
`ArgumentNullException` for a null aggregator: what changes is not the naming but the timing, since
that throw also comes from inside the run, after the raw matrix is written.

### `Parameters` itself

Checked first. Both the new strategy lookup and the existing output-directory fallback dereference it,
so without that check the validation meant to replace a `NullReferenceException` would throw one of
its own.

### Tests

Ten, in `QuantificationTests`. Each strategy is nulled in turn and asserted to be named — driven off
a *reflected* list of the strategy-typed properties on `QuantificationParameters`, so a strategy added
later is covered without anyone remembering to add it here, and one that nobody registers in
`RequiredStrategies` fails. Both arms of the aggregation condition are pinned, as is the
no-file-written consequence.

All ten fail against the unfixed engine, and the seven per-strategy cases fail with the
`NullReferenceException` each was written for.

122 tests green in `Test.Quantification`; the full suite is 5834 passed / 29 skipped / 0 failed.

Companion to PR-B (`QuantificationResults.Samples`), which is independent of this one.
