### PR TITLE
Collapse the peptide matrix where the caller can see it, so one sample list keys both tables

### DIFF
--- a/mzLib/Quantification/QuantificationEngine.cs
+++ b/mzLib/Quantification/QuantificationEngine.cs
@@ -364,14 +364,27 @@ public class QuantificationEngine
         // 5) Normalize combined peptide matrix
         peptideMatrixNorm = Parameters.PeptideNormalizationStrategy
             .NormalizeIntensities(combinedPeptideMatrix);
+
+        // 6) Collapse samples (fractions, technical replicates).
+        //
+        // This belongs here rather than in RunProteinQuant, where it used to sit. Run hands the peptide
+        // matrix on BY VALUE, so collapsing there reassigned a parameter the caller never saw again: the
+        // protein matrix came out collapsed while the caller's peptide matrix stayed uncollapsed, and the
+        // two were then reported side by side keyed differently. Doing it at the end of the peptide stage
+        // is also the order this class's summary already describes -- collapse, then write peptides, then
+        // roll up to proteins -- so the written peptide file now matches its own documentation.
+        peptideMatrixNorm = Parameters.CollapseStrategy
+            .CollapseSamples(peptideMatrixNorm, Parameters.CollapseAggregationStrategy);
     }
 
+    /// <summary>
+    /// Rolls the peptide matrix up to protein groups and normalizes the result. The matrix arrives
+    /// already collapsed -- <see cref="RunPeptideQuant"/> does that, so the peptide results the caller
+    /// keeps and the protein results derived from them are keyed by the same samples.
+    /// </summary>
     internal void RunProteinQuant(QuantMatrix<IBioPolymerWithSetMods> peptideMatrixNorm,
         out QuantMatrix<IBioPolymerGroup> proteinMatrixNorm)
     {
-        // 6) Collapse samples (technical replicates, fractions)
-        peptideMatrixNorm = Parameters.CollapseStrategy.CollapseSamples(peptideMatrixNorm, Parameters.CollapseAggregationStrategy);
-
         // 7) Roll up to proteins
         var proteinMap = Parameters.UseSharedPeptidesForProteinQuant
             ? GetAllPeptideToProteinMap(peptideMatrixNorm, BioPolymerGroups)

--- a/mzLib/Quantification/QuantificationResults.cs
+++ b/mzLib/Quantification/QuantificationResults.cs
@@ -39,6 +39,12 @@ namespace Quantification
         /// The samples that form the columns of <see cref="PeptideIntensities"/> and
         /// <see cref="ProteinIntensities"/>, in output order. Empty on failure.
         /// </summary>
+        /// <remarks>
+        /// One list covers both tables because the protein matrix is rolled up from the peptide matrix
+        /// after it has been collapsed, so the two carry the same columns by construction rather than by
+        /// agreement. That is worth stating: when the collapse ran on the protein side only, this list
+        /// described the protein table and silently did not match the peptide one.
+        /// </remarks>
         public IReadOnlyList<ISampleInfo> Samples { get; internal set; } = new List<ISampleInfo>();
 
         /// <summary>

--- a/mzLib/Test/Quantification/QuantificationTests.cs
+++ b/mzLib/Test/Quantification/QuantificationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using MassSpectrometry;
 using NUnit.Framework;
@@ -387,6 +388,137 @@ namespace Test.Quantification
             var result4 = engine4.Run();
             Assert.That(result4.Summary, Does.Contain("No biopolymer groups"));
         }
+
+        #region Collapse reaches the peptide results
+
+        /// <summary>
+        /// A run whose collapse strategy actually groups columns. Two files at different fractions of
+        /// the same conditions, so collapsing fractions halves the column count -- which is what makes
+        /// a mismatch between the two tables visible at all. With NoCollapse every table is keyed the
+        /// same by construction and none of this can be observed.
+        /// </summary>
+        private static QuantificationResults RunCollapsingByFraction(out int uncollapsedSampleCount)
+        {
+            var experimentalDesign = CreateTestExperimentalDesign(2, 2, multipleFractions: true);
+            uncollapsedSampleCount = experimentalDesign.FileNameSampleInfoDictionary.Values.Sum(samples => samples.Length);
+
+            var proteinGroups = CreateTestProteins(out var peptides);
+            var parameters = QuantificationParameters.GetSimpleParameters();
+            parameters.CollapseStrategy = new CollapseFractions();
+            parameters.CollapseAggregationStrategy = new SumAggregation();
+
+            return new QuantificationEngine(
+                parameters,
+                experimentalDesign,
+                CreateTestSpectralMatches(peptides, 2, 2),
+                peptides.ToList(),
+                proteinGroups).Run();
+        }
+
+        /// <summary>
+        /// Samples is documented as the columns of BOTH intensity tables. It is assigned from the
+        /// protein matrix, and the peptide matrix the caller holds was never collapsed -- Run passes it
+        /// to RunProteinQuant by value, and the collapse there reassigns the parameter, which the caller
+        /// never sees. So with any collapse strategy that groups anything, the peptide table is keyed by
+        /// the uncollapsed samples while Samples and the protein table are keyed by the collapsed ones,
+        /// and a caller who joins the two on Samples silently gets nothing for the peptides.
+        /// </summary>
+        [Test]
+        public void SamplesKeysBothIntensityTables()
+        {
+            var results = RunCollapsingByFraction(out _);
+            Assert.That(results.Success, Is.True, results.Summary);
+
+            Assert.That(results.PeptideIntensities, Is.Not.Empty, "premise: there are peptide rows to key");
+            Assert.That(results.ProteinIntensities, Is.Not.Empty, "premise: there are protein rows to key");
+
+            foreach (var row in results.ProteinIntensities.Values)
+            {
+                Assert.That(row.Keys, Is.SubsetOf(results.Samples), "protein table");
+            }
+            foreach (var row in results.PeptideIntensities.Values)
+            {
+                Assert.That(row.Keys, Is.SubsetOf(results.Samples), "peptide table");
+            }
+        }
+
+        /// <summary>
+        /// The same defect seen from the other side, and the reason it is worth more than a doc fix: the
+        /// collapse never reaches the peptide results at all. The class summary numbers the pipeline
+        /// "4) Collapse the peptide matrix ... * Writes peptide information ... 5) Roll up to proteins",
+        /// so the written peptide file and the delivered peptide intensities are both supposed to be
+        /// collapsed. Today the protein numbers are collapsed and the peptide numbers are not, in the
+        /// same result object.
+        /// </summary>
+        [Test]
+        public void CollapseReachesThePeptideTableAndNotOnlyTheProteinTable()
+        {
+            var results = RunCollapsingByFraction(out int uncollapsedSampleCount);
+            Assert.That(results.Success, Is.True, results.Summary);
+            Assert.That(results.Samples.Count, Is.LessThan(uncollapsedSampleCount),
+                "premise: this collapse strategy really does group columns");
+
+            var peptideKeys = results.PeptideIntensities.Values
+                .SelectMany(row => row.Keys).Distinct().ToList();
+
+            Assert.That(peptideKeys, Is.EquivalentTo(results.Samples),
+                "the peptide table must be keyed by the collapsed samples the run reports, not by the "
+                + "uncollapsed ones it started from");
+        }
+
+        /// <summary>
+        /// The same claim at the file level, which is where a user meets it. The peptide and protein
+        /// files are written from two different matrices at two different points in Run, so agreement
+        /// between their headers is the end-to-end statement that one collapse governed both. Before the
+        /// fix these two headers named different samples, and nothing in the output said so.
+        /// </summary>
+        [Test]
+        public void TheWrittenPeptideAndProteinFilesShareOneSetOfSampleColumns()
+        {
+            string outputDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "CollapsedPeptideFile");
+            if (Directory.Exists(outputDirectory)) Directory.Delete(outputDirectory, true);
+            Directory.CreateDirectory(outputDirectory);
+
+            try
+            {
+                var experimentalDesign = CreateTestExperimentalDesign(2, 2, multipleFractions: true);
+                var proteinGroups = CreateTestProteins(out var peptides);
+                var parameters = QuantificationParameters.GetSimpleParameters();
+                parameters.CollapseStrategy = new CollapseFractions();
+                parameters.CollapseAggregationStrategy = new SumAggregation();
+                parameters.OutputDirectory = outputDirectory;
+                parameters.WritePeptideInformation = true;
+                parameters.WriteProteinInformation = true;
+
+                var results = new QuantificationEngine(
+                    parameters,
+                    experimentalDesign,
+                    CreateTestSpectralMatches(peptides, 2, 2),
+                    peptides.ToList(),
+                    proteinGroups).Run();
+
+                Assert.That(results.Success, Is.True, results.Summary);
+
+                string[] peptideColumns = File
+                    .ReadLines(Path.Combine(outputDirectory, QuantificationWriter.PeptideFileName))
+                    .First().Split('\t').Skip(1).ToArray();
+                string[] proteinColumns = File
+                    .ReadLines(Path.Combine(outputDirectory, QuantificationWriter.ProteinGroupFileName))
+                    .First().Split('\t').Skip(1).ToArray();
+
+                Assert.That(peptideColumns, Is.Not.Empty, "premise: the peptide file has sample columns");
+                Assert.That(peptideColumns, Is.EqualTo(proteinColumns),
+                    "one collapse governs the whole run, so both files name the same samples in the "
+                    + "same order");
+                Assert.That(peptideColumns.Length, Is.EqualTo(results.Samples.Count));
+            }
+            finally
+            {
+                Directory.Delete(outputDirectory, true);
+            }
+        }
+
+        #endregion
 
         [Test]
         public void QuantificationEngine_ComplexScenario_MultipleProteinsAndFiles()


### PR DESCRIPTION
`QuantificationResults.Samples` is documented as the columns of **both** `PeptideIntensities` and
`ProteinIntensities`. It is assigned `proteinMatrix.ColumnKeys` only, and with any collapse strategy
that groups anything the peptide table is keyed differently. This is on the released 1.0.588 surface.

Not "described wrongly" — *disjoint*. In the fixture added here:

```
Samples          : Reference_Bio0_Frac0_Tech0_Collapsed_Channel_0, Control_..._Channel_1
peptide table    : file1_Channel_0, file1_Channel_1, file2_Channel_0, file2_Channel_1
```

A caller who joins the two tables on `Samples` gets nothing back for the peptides.

### The cause is a by-value parameter, which makes this bigger than a doc fix

`Run` calls `RunProteinQuant(peptideMatrix, out proteinMatrix)`, and `RunProteinQuant` collapsed by
reassigning **its own parameter**:

```csharp
internal void RunProteinQuant(QuantMatrix<IBioPolymerWithSetMods> peptideMatrixNorm, ...)
{
    peptideMatrixNorm = Parameters.CollapseStrategy.CollapseSamples(peptideMatrixNorm, ...);
```

The caller never saw that. So the collapse reached the protein matrix and nothing else, and **three**
things followed rather than one:

- `Samples` described the protein table only;
- `PeptideQuantification.tsv` was written from the uncollapsed matrix, so the two written files named
  different samples and neither said so;
- `OverwriteSampleIntensities` wrote uncollapsed per-sample values back onto the peptide entities
  while the protein entities got collapsed ones.

### The fix is where the class already said it was

Moving the collapse to the end of `RunPeptideQuant` fixes all three at once — and it is the order
this class's own summary describes:

> 4) Collapse the peptide matrix, combining fractions and technical replicates
> \* Writes peptide information (if enabled)
> 5) Roll up to proteins

The code had drifted from its own documented order. Now the protein matrix is rolled up **from the
collapsed peptide matrix**, so both tables carry the same columns by construction rather than by
agreement — which is what `Samples` can honestly claim, and the `Samples` doc now says why.

### Blast radius

**None for a run using `NoCollapse`**, which is every production caller today: collapsing nothing is
the identity either way. Callers that do collapse get peptide numbers that match their protein
numbers, which they did not before.

### Tests

Three, all failing against the unfixed engine:

- `SamplesKeysBothIntensityTables` — the direct claim.
- `CollapseReachesThePeptideTableAndNotOnlyTheProteinTable` — the peptide table carries the collapsed
  samples, not the uncollapsed ones it started from.
- `TheWrittenPeptideAndProteinFilesShareOneSetOfSampleColumns` — the same claim at the file level,
  where a user actually meets it. The two files are written from two different matrices at two
  different points in `Run`, so agreement between their headers is the end-to-end statement that one
  collapse governed the whole run.

112 green in `Test.Quantification`, 159 with the FlashLFQ fixtures.

Independent of #1242 — different regions of `QuantificationEngine.cs`, no shared interface. If both
land, expect a trivial conflict in `QuantificationTests.cs` and nothing more.
