### PR TITLE
Assemble an entrapment sequence from a target one

### DIFF
--- a/mzLib/Test/DatabaseTests/TestDecoyProteinValidator.cs
+++ b/mzLib/Test/DatabaseTests/TestDecoyProteinValidator.cs
@@ -4,6 +4,7 @@ using Proteomics.ProteolyticDigestion;
 using Proteomics;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using MzLibUtil;
 using UsefulProteomicsDatabases;
 using Transcriptomics.Digestion;
@@ -215,4 +216,105 @@ public class DecoySequenceValidatorTests
         Assert.That("KEK", Is.EqualTo(scrambledDecoy.BaseSequence));
     }
 
+    #region Deterministic permutation (entrapment generation)
+
+    private static List<DigestionMotif> Trypsin => DigestionMotif.ParseDigestionMotifsFromString("K|,R|");
+
+    [Test]
+    public void PermutationSpaceSize_IsTheMultinomialOverFreePositions()
+    {
+        // No K or R, so all nine residues are free: T x6, P x2, A x1 -> 9!/(6!*2!*1!) = 252.
+        Assert.That(DecoySequenceValidator.PermutationSpaceSize("TTTPAPTTT", Trypsin), Is.EqualTo(new BigInteger(252)));
+
+        // R is pinned and the six free residues are identical, so exactly one arrangement exists.
+        // This is not a collision -- it is arithmetic, and no amount of searching can help.
+        Assert.That(DecoySequenceValidator.PermutationSpaceSize("SSSSSSR", Trypsin), Is.EqualTo(BigInteger.One));
+
+        // Seven distinct free residues with K pinned -> 7! = 5040.
+        Assert.That(DecoySequenceValidator.PermutationSpaceSize("ACDEFGHK", Trypsin), Is.EqualTo(new BigInteger(5040)));
+    }
+
+    [Test]
+    public void UnrankPermutation_IsDeterministicAndEnumeratesTheSpaceExactly()
+    {
+        const string sequence = "TTTPAPTTT";
+        BigInteger size = DecoySequenceValidator.PermutationSpaceSize(sequence, Trypsin);
+        var distinct = new HashSet<string>();
+
+        for (BigInteger i = BigInteger.Zero; i < size; i++)
+        {
+            string once = DecoySequenceValidator.UnrankPermutation(sequence, Trypsin, i, out _);
+            string twice = DecoySequenceValidator.UnrankPermutation(sequence, Trypsin, i, out _);
+
+            Assert.That(twice, Is.EqualTo(once), "the same index must always give the same permutation");
+            Assert.That(string.Concat(once.OrderBy(c => c)), Is.EqualTo(string.Concat(sequence.OrderBy(c => c))),
+                "the permutation must be composition-preserving, hence isomeric with its target");
+            distinct.Add(once);
+        }
+
+        Assert.That(distinct.Count, Is.EqualTo(252), "every index must give a different permutation");
+    }
+
+    [Test]
+    public void UnrankPermutation_LeavesEveryCleavageSiteInPlace()
+    {
+        const string sequence = "ACDKEFGRHK";
+        BigInteger size = DecoySequenceValidator.PermutationSpaceSize(sequence, Trypsin);
+
+        for (BigInteger i = BigInteger.Zero; i < BigInteger.Min(size, 200); i++)
+        {
+            string permuted = DecoySequenceValidator.UnrankPermutation(sequence, Trypsin, i, out _);
+            Assert.That(permuted[3], Is.EqualTo('K'));
+            Assert.That(permuted[7], Is.EqualTo('R'));
+            Assert.That(permuted[9], Is.EqualTo('K'));
+        }
+    }
+
+    [Test]
+    public void UnrankPermutation_SwappedPositionArrayMapsOldIndexToNew()
+    {
+        // Same contract as ScrambleSequence's out parameter: previous position (index) -> new position (value).
+        const string sequence = "ACDEFGHK";
+        string permuted = DecoySequenceValidator.UnrankPermutation(sequence, Trypsin, new BigInteger(1234), out int[] swapped);
+
+        Assert.That(swapped.Length, Is.EqualTo(sequence.Length));
+        for (int i = 0; i < sequence.Length; i++)
+        {
+            Assert.That(permuted[swapped[i]], Is.EqualTo(sequence[i]),
+                "the residue at old index " + i + " must be found at its mapped new index");
+        }
+    }
+
+    [Test]
+    public void UnrankPermutation_RejectsAnIndexOutsideTheSpace()
+    {
+        BigInteger size = DecoySequenceValidator.PermutationSpaceSize("TTTPAPTTT", Trypsin);
+        Assert.Throws<MzLibException>(() =>
+            DecoySequenceValidator.UnrankPermutation("TTTPAPTTT", Trypsin, size, out _));
+        Assert.Throws<MzLibException>(() =>
+            DecoySequenceValidator.UnrankPermutation("TTTPAPTTT", Trypsin, BigInteger.MinusOne, out _));
+    }
+
+    [Test]
+    public void CleavageSitePositions_PinTheFullMotifSpanNotJustItsFirstResidue()
+    {
+        // StcE's TX|T matches three residues. ScrambleSequence pins only the match location, so a
+        // scramble there can move the X and the trailing T -- destroying a real cleavage site and
+        // inventing others. The entrapment path must pin the whole span.
+        var stcE = DigestionMotif.ParseDigestionMotifsFromString("TX|T");
+        var pinned = DecoySequenceValidator.CleavageSitePositions("ATPTA", stcE);
+
+        Assert.That(pinned.OrderBy(p => p), Is.EqualTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public void CleavageSitePositions_HonourThePreventingResidue()
+    {
+        // trypsin|P must not pin the K in "AKP", because that K is not a cleavage site.
+        var trypsinP = DigestionMotif.ParseDigestionMotifsFromString("K[P]|,R[P]|");
+        Assert.That(DecoySequenceValidator.CleavageSitePositions("AKPCR", trypsinP).OrderBy(p => p),
+            Is.EqualTo(new[] { 4 }));
+    }
+
+    #endregion
 }

--- a/mzLib/Test/DatabaseTests/TestDecoyProteinValidator.cs
+++ b/mzLib/Test/DatabaseTests/TestDecoyProteinValidator.cs
@@ -289,10 +289,55 @@ public class DecoySequenceValidatorTests
     public void UnrankPermutation_RejectsAnIndexOutsideTheSpace()
     {
         BigInteger size = DecoySequenceValidator.PermutationSpaceSize("TTTPAPTTT", Trypsin);
-        Assert.Throws<MzLibException>(() =>
+
+        // The message names the offending index and the size of the space; a caller probing for a
+        // free permutation reads it to tell "exhausted" from "asked for the wrong thing".
+        var toolarge = Assert.Throws<MzLibException>(() =>
             DecoySequenceValidator.UnrankPermutation("TTTPAPTTT", Trypsin, size, out _));
-        Assert.Throws<MzLibException>(() =>
+        Assert.That(toolarge!.Message, Does.Contain("252").And.Contain("TTTPAPTTT"));
+
+        var negative = Assert.Throws<MzLibException>(() =>
             DecoySequenceValidator.UnrankPermutation("TTTPAPTTT", Trypsin, BigInteger.MinusOne, out _));
+        Assert.That(negative!.Message, Does.Contain("-1"));
+    }
+
+    [Test]
+    public void PermutationOfAnEmptyOrUnmotifedSequenceIsWellDefined()
+    {
+        // An empty sequence has exactly one arrangement, not zero, and must not throw.
+        Assert.That(DecoySequenceValidator.PermutationSpaceSize("", Trypsin), Is.EqualTo(BigInteger.One));
+        Assert.That(DecoySequenceValidator.UnrankPermutation("", Trypsin, BigInteger.Zero, out int[] swapped),
+            Is.EqualTo(""));
+        Assert.That(swapped, Is.Empty);
+
+        // No motifs at all -- a top-down "protease" -- pins nothing, so every residue is free.
+        var noMotifs = new List<DigestionMotif>();
+        Assert.That(DecoySequenceValidator.CleavageSitePositions("ACDEFGHK", noMotifs), Is.Empty);
+        Assert.That(DecoySequenceValidator.PermutationSpaceSize("ACDEFGHK", noMotifs),
+            Is.EqualTo(new BigInteger(40320)));   // 8! -- the K is free now
+    }
+
+    [Test]
+    public void CleavageSitePositions_AreEmptyForAnEmptySequenceOrNoMotifs()
+    {
+        Assert.That(DecoySequenceValidator.CleavageSitePositions("", Trypsin), Is.Empty);
+        Assert.That(DecoySequenceValidator.CleavageSitePositions(null!, Trypsin), Is.Empty);
+        Assert.That(DecoySequenceValidator.CleavageSitePositions("ACDEFGHK", null!), Is.Empty);
+    }
+
+    [Test]
+    public void CleavageSitePositions_NeverReturnAnIndexOutsideTheSequence()
+    {
+        // A multi-residue motif matching at the very end must not run off the end of the sequence.
+        var stcE = DigestionMotif.ParseDigestionMotifsFromString("TX|T");
+        foreach (string sequence in new[] { "ATPT", "TPT", "TTTPAPTTT", "AAATPTGGGSQSCCC" })
+        {
+            foreach (int position in DecoySequenceValidator.CleavageSitePositions(sequence, stcE))
+            {
+                Assert.That(position, Is.InRange(0, sequence.Length - 1),
+                    "position " + position + " is outside '" + sequence + "'");
+            }
+        }
     }
 
     // Golden vectors. The properties asserted above -- exhaustive enumeration, preserved

--- a/mzLib/Test/DatabaseTests/TestDecoyProteinValidator.cs
+++ b/mzLib/Test/DatabaseTests/TestDecoyProteinValidator.cs
@@ -295,6 +295,23 @@ public class DecoySequenceValidatorTests
             DecoySequenceValidator.UnrankPermutation("TTTPAPTTT", Trypsin, BigInteger.MinusOne, out _));
     }
 
+    // Golden vectors. The properties asserted above -- exhaustive enumeration, preserved
+    // composition, fixed cleavage sites -- all hold for ANY consistent ordering, so none of them
+    // would notice if the ordering itself changed. Entrapment pairing depends on a given index
+    // always yielding the same string, so the ordering is part of the contract and is pinned here.
+    // Expected values come from an independent implementation, not from a snapshot of this one.
+    [TestCase("ACDEFGHK", 0, "ACDEFGHK", TestName = "Unrank golden - first index is lexicographically smallest")]
+    [TestCase("ACDEFGHK", 1234, "CGDEHAFK", TestName = "Unrank golden - interior index")]
+    [TestCase("ACDEFGHK", 5039, "HGFEDCAK", TestName = "Unrank golden - last index is lexicographically largest")]
+    [TestCase("TTTPAPTTT", 0, "APPTTTTTT", TestName = "Unrank golden - repeated residues, first index")]
+    [TestCase("TTTPAPTTT", 251, "TTTTTTPPA", TestName = "Unrank golden - repeated residues, last index")]
+    [TestCase("ACDKEFGRHK", 0, "ACDKEFGRHK", TestName = "Unrank golden - interior cleavage sites stay put")]
+    public void UnrankPermutation_OrderingIsPartOfTheContract(string sequence, int index, string expected)
+    {
+        Assert.That(DecoySequenceValidator.UnrankPermutation(sequence, Trypsin, new BigInteger(index), out _),
+            Is.EqualTo(expected));
+    }
+
     [Test]
     public void CleavageSitePositions_PinTheFullMotifSpanNotJustItsFirstResidue()
     {

--- a/mzLib/Test/DatabaseTests/TestDecoyProteinValidator.cs
+++ b/mzLib/Test/DatabaseTests/TestDecoyProteinValidator.cs
@@ -318,6 +318,17 @@ public class DecoySequenceValidatorTests
     }
 
     [Test]
+    public void PermutationOfANullSequenceIsWellDefined()
+    {
+        // The null guards are load-bearing, not decorative: without them the free-position scan
+        // dereferences the sequence. Covered here so a later tidy-up cannot quietly drop them.
+        Assert.That(DecoySequenceValidator.PermutationSpaceSize(null!, Trypsin), Is.EqualTo(BigInteger.One));
+        Assert.That(DecoySequenceValidator.UnrankPermutation(null!, Trypsin, BigInteger.Zero, out int[] swapped),
+            Is.Null);
+        Assert.That(swapped, Is.Empty);
+    }
+
+    [Test]
     public void CleavageSitePositions_AreEmptyForAnEmptySequenceOrNoMotifs()
     {
         Assert.That(DecoySequenceValidator.CleavageSitePositions("", Trypsin), Is.Empty);

--- a/mzLib/Test/DatabaseTests/TestEntrapmentAssembly.cs
+++ b/mzLib/Test/DatabaseTests/TestEntrapmentAssembly.cs
@@ -128,9 +128,12 @@ public class EntrapmentAssemblyTests
         const string target = "SYKALADQMNLLLSKSSSSSSRGGVDTTPFAWENDR";
         EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden);
 
+        // Pieces are SYK | ALADQMNLLLSK | SSSSSSR | GGVDTTPFAWENDR, and the third is excised, so the
+        // retained ordinals are 0, 1, 3. At two missed cleavages the runs that straddle that gap are
+        // {0,1,3} and {1,3} -- exactly two. An exact count, not "more than none": the arithmetic here
+        // is nested and off-by-one prone, and a loose assertion would not notice it drifting.
         Assert.That(assembly.ExcisedCount, Is.EqualTo(1));
-        Assert.That(assembly.MissedCleavagePeptidesSpanningAnExcision, Is.GreaterThan(0),
-            "an excision in the middle of a protein necessarily breaks the peptides that spanned it");
+        Assert.That(assembly.MissedCleavagePeptidesSpanningAnExcision, Is.EqualTo(2));
     }
 
     [Test]

--- a/mzLib/Test/DatabaseTests/TestEntrapmentAssembly.cs
+++ b/mzLib/Test/DatabaseTests/TestEntrapmentAssembly.cs
@@ -1,0 +1,233 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using NUnit.Framework;
+using Omics.Digestion;
+using Proteomics.ProteolyticDigestion;
+using UsefulProteomicsDatabases.EntrapmentGeneration;
+
+namespace Test.DatabaseTests;
+
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class EntrapmentAssemblyTests
+{
+    private static readonly HashSet<string> NothingForbidden = new();
+
+    private static IDigestionParams Tryptic(int minLength = 7) =>
+        new DigestionParams("trypsin", minPeptideLength: minLength, maxMissedCleavages: 2);
+
+    /// <summary>Base pieces of a sequence under the same partition the assembler uses.</summary>
+    private static List<string> BasePieces(string sequence, IDigestionParams digestionParams)
+    {
+        List<int> sites = digestionParams.DigestionAgent.GetDigestionSiteIndices(sequence);
+        sites.Sort();
+        return Enumerable.Range(0, sites.Count - 1)
+            .Select(i => sequence.Substring(sites[i], sites[i + 1] - sites[i]))
+            .ToList();
+    }
+
+    private static string Sorted(string s) => string.Concat(s.OrderBy(c => c));
+
+    [Test]
+    public void Assemble_ProducesOnePermutedPieceForEachTargetPiece()
+    {
+        const string target = "SYKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK";
+        IDigestionParams digestion = Tryptic();
+
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, digestion, NothingForbidden);
+
+        List<string> targetPieces = BasePieces(target, digestion);
+        List<string> entrapmentPieces = BasePieces(assembly.EntrapmentSequence, digestion);
+
+        Assert.That(assembly.ExcisedCount, Is.Zero);
+        Assert.That(entrapmentPieces.Count, Is.EqualTo(targetPieces.Count),
+            "the entrapment protein must digest into the same number of pieces");
+        for (int i = 0; i < targetPieces.Count; i++)
+        {
+            Assert.That(Sorted(entrapmentPieces[i]), Is.EqualTo(Sorted(targetPieces[i])),
+                "piece " + i + " must be isomeric with its target counterpart");
+        }
+    }
+
+    [Test]
+    public void Assemble_KeepsTheWholeProteinIsomeric()
+    {
+        const string target = "SYKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK";
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden);
+
+        Assert.That(assembly.EntrapmentSequence, Is.Not.EqualTo(target));
+        Assert.That(Sorted(assembly.EntrapmentSequence), Is.EqualTo(Sorted(target)));
+        Assert.That(assembly.EntrapmentSequence.Count(c => c is 'S' or 'T'),
+            Is.EqualTo(target.Count(c => c is 'S' or 'T')));
+    }
+
+    [Test]
+    public void Assemble_KeepsASubLengthPieceVerbatimRatherThanExcisingIt()
+    {
+        // "AK" has no permutation once K is pinned, but it is below the minimum peptide length, so
+        // it is never identifiable on its own. Keeping it verbatim puts no real target peptide into
+        // the entrapment search space, and identity is a permutation, so isomerism still holds.
+        // Excising every such piece instead would gut the database.
+        const string target = "AKSYKALADQMNLLLSKGGVDTTPFAWENDR";
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden);
+
+        Assert.That(assembly.ExcisedCount, Is.Zero, "a sub-length piece must not be excised");
+        Assert.That(assembly.KeptVerbatimCount, Is.GreaterThan(0));
+        Assert.That(assembly.EntrapmentSequence, Does.StartWith("AK"));
+        Assert.That(assembly.EntrapmentSequence.Length, Is.EqualTo(target.Length));
+    }
+
+    [Test]
+    public void Assemble_ExcisesASearchablePieceThatHasNoPermutation()
+    {
+        // "SSSSSSR" is long enough to be identified and has exactly one arrangement, so there is no
+        // honest partner for it. It is removed rather than emitted unchanged, because emitting it
+        // would place a genuine target peptide inside the entrapment database.
+        const string target = "SYKALADQMNLLLSKSSSSSSRGGVDTTPFAWENDR";
+        IDigestionParams digestion = Tryptic();
+
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, digestion, NothingForbidden);
+
+        Assert.That(assembly.ExcisedCount, Is.EqualTo(1));
+        Assert.That(assembly.EntrapmentSequence, Does.Not.Contain("SSSSSSR"));
+        Assert.That(assembly.EntrapmentSequence.Length, Is.EqualTo(target.Length - 7));
+
+        // Every other piece digests exactly as it would have without the excision.
+        List<string> targetPieces = BasePieces(target, digestion);
+        List<string> entrapmentPieces = BasePieces(assembly.EntrapmentSequence, digestion);
+        Assert.That(entrapmentPieces.Count, Is.EqualTo(targetPieces.Count - 1));
+    }
+
+    [Test]
+    public void Assemble_NeverLeavesATargetPeptideInTheEntrapmentSequence()
+    {
+        const string target = "SYKALADQMNLLLSKSSSSSSRGGVDTTPFAWENDR";
+        IDigestionParams digestion = Tryptic();
+        var targetPeptides = BasePieces(target, digestion).ToHashSet();
+
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, digestion, targetPeptides);
+
+        foreach (string piece in BasePieces(assembly.EntrapmentSequence, digestion))
+        {
+            if (piece.Length >= digestion.MinLength)
+            {
+                Assert.That(targetPeptides, Does.Not.Contain(piece),
+                    "'" + piece + "' is a real target peptide and must not appear as entrapment");
+            }
+        }
+    }
+
+    [Test]
+    public void Assemble_CountsMissedCleavagePeptidesThatSpanAnExcision()
+    {
+        // Base-peptide compositions add, so a missed-cleavage peptide is normally isomeric with its
+        // target counterpart for free. One that spans an excision is not -- it has no counterpart at
+        // all. Those are counted rather than passed off as isomeric, because someone will compute
+        // mass statistics over the entrapment set assuming the invariant holds everywhere.
+        const string target = "SYKALADQMNLLLSKSSSSSSRGGVDTTPFAWENDR";
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden);
+
+        Assert.That(assembly.ExcisedCount, Is.EqualTo(1));
+        Assert.That(assembly.MissedCleavagePeptidesSpanningAnExcision, Is.GreaterThan(0),
+            "an excision in the middle of a protein necessarily breaks the peptides that spanned it");
+    }
+
+    [Test]
+    public void Assemble_MapsEveryRetainedPositionAndMarksExcisedOnes()
+    {
+        const string target = "SYKALADQMNLLLSKSSSSSSRGGVDTTPFAWENDR";
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden);
+
+        Assert.That(assembly.TargetToEntrapmentPosition.Length, Is.EqualTo(target.Length));
+
+        for (int i = 0; i < target.Length; i++)
+        {
+            int mapped = assembly.TargetToEntrapmentPosition[i];
+            if (mapped < 0)
+            {
+                continue;   // excised
+            }
+
+            Assert.That(assembly.EntrapmentSequence[mapped], Is.EqualTo(target[i]),
+                "position " + i + " must map to a position holding the same residue");
+        }
+
+        // The excised stretch, and only it, is unmapped.
+        Assert.That(assembly.TargetToEntrapmentPosition.Count(p => p < 0), Is.EqualTo(7));
+    }
+
+    [Test]
+    public void Assemble_IsDeterministic()
+    {
+        const string target = "SYKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK";
+
+        string first = EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden).EntrapmentSequence;
+        EntrapmentAssembler.Assemble("ACDEFGHIKLMNPQR", Tryptic(), NothingForbidden);  // unrelated work
+
+        Assert.That(EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden).EntrapmentSequence,
+            Is.EqualTo(first));
+        Assert.That(EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden, seed: 2).EntrapmentSequence,
+            Is.Not.EqualTo(first));
+    }
+
+    [Test]
+    public void Assemble_ReproducesTheCandidateSiteDistributionOfTheTarget()
+    {
+        // The check per-peptide equality structurally cannot make. Equality is pointwise over
+        // peptides present in both databases, so a peptide that was dropped satisfies it vacuously;
+        // only the distribution notices an assembly bug. This is the assertion that caught the
+        // rule which excised every short piece.
+        string[] proteins =
+        {
+            "SYKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK",
+            "AKMTTSTTPAPTTTKQEEEKKKGGVDTTPFAWENDRSSSSSSR",
+            "MPSSTSRLLGVDKAAATPTGGGSQSCCCKYPERDNRSTTTK",
+            "QLQGASWELQSLRPSLDQLAAHPWMLGADGGVPESCDLRTTK"
+        };
+        IDigestionParams digestion = Tryptic();
+
+        var expectedSites = new List<int>();
+        var entrapmentSites = new List<int>();
+        int excised = 0;
+
+        foreach (string protein in proteins)
+        {
+            EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(protein, digestion, NothingForbidden);
+
+            // Excision is the ONLY thing allowed to change the distribution, so the target's
+            // contribution is its searchable pieces minus the ones that had no partner.
+            expectedSites.AddRange(assembly.Pieces
+                .Where(p => p.Outcome != PieceOutcome.Excised)
+                .Select(p => p.TargetPiece)
+                .Where(p => p.Length >= digestion.MinLength)
+                .Select(p => p.Count(c => c is 'S' or 'T')));
+            excised += assembly.ExcisedCount;
+
+            entrapmentSites.AddRange(BasePieces(assembly.EntrapmentSequence, digestion)
+                .Where(p => p.Length >= digestion.MinLength)
+                .Select(p => p.Count(c => c is 'S' or 'T')));
+        }
+
+        Assert.That(excised, Is.GreaterThan(0),
+            "this fixture must actually exercise excision, or the assertion below proves nothing");
+        Assert.That(entrapmentSites.OrderBy(n => n).ToList(), Is.EqualTo(expectedSites.OrderBy(n => n).ToList()),
+            "apart from peptides with no possible partner, the entrapment database must present the "
+            + "same distribution of candidate sites as the target");
+    }
+
+    [Test]
+    public void Assemble_GivesEachFoldADifferentProtein()
+    {
+        const string target = "SYKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK";
+
+        var sequences = Enumerable.Range(0, 5)
+            .Select(k => EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden, fold: k, foldCount: 5)
+                .EntrapmentSequence)
+            .ToList();
+
+        Assert.That(sequences.Distinct().Count(), Is.EqualTo(5));
+        Assert.That(sequences.All(s => Sorted(s) == Sorted(target)), Is.True,
+            "every fold stays isomeric with the target");
+    }
+}

--- a/mzLib/Test/DatabaseTests/TestEntrapmentPeptideGenerator.cs
+++ b/mzLib/Test/DatabaseTests/TestEntrapmentPeptideGenerator.cs
@@ -164,14 +164,34 @@ public class EntrapmentPeptideGeneratorTests
         Assert.That(easy.ProbesUsed, Is.EqualTo(1), "an unforbidden space should answer on the first probe");
     }
 
+    // Each guard is asserted through its MESSAGE, not merely through the exception type. Several of
+    // these arguments are rejected by more than one guard, so a type-only assertion still passes
+    // when the guard under test is removed -- the message is what pins which one actually fired.
+    [Test]
+    public void Create_RejectsAnEmptySequence()
+    {
+        var thrown = Assert.Throws<MzLibUtil.MzLibException>(() =>
+            EntrapmentPeptideGenerator.Create("", Trypsin, NothingForbidden));
+        Assert.That(thrown!.Message, Does.Contain("empty"));
+    }
+
+    [Test]
+    public void Create_RejectsAFoldCountBelowOne()
+    {
+        var thrown = Assert.Throws<MzLibUtil.MzLibException>(() =>
+            EntrapmentPeptideGenerator.Create("ACDEFGHIK", Trypsin, NothingForbidden, fold: 0, foldCount: 0));
+        Assert.That(thrown!.Message, Does.Contain("Fold count").And.Contain("0"));
+    }
+
     [Test]
     public void Create_RejectsAFoldOutsideTheRequestedCount()
     {
-        Assert.Throws<MzLibUtil.MzLibException>(() =>
+        var tooHigh = Assert.Throws<MzLibUtil.MzLibException>(() =>
             EntrapmentPeptideGenerator.Create("ACDEFGHIK", Trypsin, NothingForbidden, fold: 3, foldCount: 3));
-        Assert.Throws<MzLibUtil.MzLibException>(() =>
+        Assert.That(tooHigh!.Message, Does.Contain("Fold 3").And.Contain("3 requested folds"));
+
+        var negative = Assert.Throws<MzLibUtil.MzLibException>(() =>
             EntrapmentPeptideGenerator.Create("ACDEFGHIK", Trypsin, NothingForbidden, fold: -1));
-        Assert.Throws<MzLibUtil.MzLibException>(() =>
-            EntrapmentPeptideGenerator.Create("ACDEFGHIK", Trypsin, NothingForbidden, fold: 0, foldCount: 0));
+        Assert.That(negative!.Message, Does.Contain("Fold -1"));
     }
 }

--- a/mzLib/Test/DatabaseTests/TestEntrapmentPeptideGenerator.cs
+++ b/mzLib/Test/DatabaseTests/TestEntrapmentPeptideGenerator.cs
@@ -1,0 +1,177 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Numerics;
+using NUnit.Framework;
+using Omics.Digestion;
+using UsefulProteomicsDatabases.EntrapmentGeneration;
+
+namespace Test.DatabaseTests;
+
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class EntrapmentPeptideGeneratorTests
+{
+    private static List<DigestionMotif> Trypsin => DigestionMotif.ParseDigestionMotifsFromString("K|,R|");
+    private static readonly HashSet<string> NothingForbidden = new();
+
+    [Test]
+    public void Create_ReturnsAnIsomericPeptideThatIsNotTheTarget()
+    {
+        EntrapmentPeptide result = EntrapmentPeptideGenerator.Create("SYKALADQMNLLLSK", Trypsin, NothingForbidden);
+
+        Assert.That(result.Succeeded, Is.True);
+        Assert.That(result.Failure, Is.EqualTo(EntrapmentFailure.None));
+        Assert.That(result.EntrapmentSequence, Is.Not.EqualTo("SYKALADQMNLLLSK"));
+        Assert.That(string.Concat(result.EntrapmentSequence!.OrderBy(c => c)),
+            Is.EqualTo(string.Concat("SYKALADQMNLLLSK".OrderBy(c => c))),
+            "same residues in a different order -- same mass, same composition");
+    }
+
+    [Test]
+    public void Create_PreservesCandidateSiteCountAndCleavageSites()
+    {
+        // The property the glyco localization work depends on: the number of S/T in a peptide is
+        // the number of candidate sites, and comparing site calls at different n compares
+        // different difficulty. Composition preservation gives this for free -- assert it anyway.
+        const string target = "SYKALADQMNLLLSK";
+        EntrapmentPeptide result = EntrapmentPeptideGenerator.Create(target, Trypsin, NothingForbidden);
+
+        Assert.That(result.EntrapmentSequence!.Count(c => c is 'S' or 'T'),
+            Is.EqualTo(target.Count(c => c is 'S' or 'T')));
+        Assert.That(result.EntrapmentSequence[2], Is.EqualTo('K'));
+        Assert.That(result.EntrapmentSequence[14], Is.EqualTo('K'));
+    }
+
+    [Test]
+    public void Create_IsAPureFunctionOfSequenceAndSeed()
+    {
+        // No random state, so the answer cannot depend on how many peptides were processed first,
+        // on which protein this one came from, or on which thread ran it.
+        const string target = "SYKALADQMNLLLSK";
+        string first = EntrapmentPeptideGenerator.Create(target, Trypsin, NothingForbidden).EntrapmentSequence!;
+
+        for (int i = 0; i < 5; i++)
+        {
+            EntrapmentPeptideGenerator.Create("ACDEFGHIK", Trypsin, NothingForbidden);   // unrelated work
+        }
+
+        Assert.That(EntrapmentPeptideGenerator.Create(target, Trypsin, NothingForbidden).EntrapmentSequence,
+            Is.EqualTo(first));
+        Assert.That(EntrapmentPeptideGenerator.Create(target, Trypsin, NothingForbidden, seed: 2).EntrapmentSequence,
+            Is.Not.EqualTo(first), "a different seed must give a different answer");
+    }
+
+    [Test]
+    public void Create_ReportsNoPermutationExistsSeparatelyFromExhaustion()
+    {
+        // Two different failures that must never be merged into one "failed":
+        //   arithmetic -- a homopolymeric tract has exactly one arrangement, so no r helps;
+        //   exhaustion -- the space is real but every member of it is already spoken for.
+        EntrapmentPeptide homopolymer = EntrapmentPeptideGenerator.Create("SSSSSSR", Trypsin, NothingForbidden);
+        Assert.That(homopolymer.Succeeded, Is.False);
+        Assert.That(homopolymer.Failure, Is.EqualTo(EntrapmentFailure.NoPermutationExists));
+        Assert.That(homopolymer.PermutationSpaceSize, Is.EqualTo(BigInteger.One));
+
+        // Forbid the entire space of a small peptide, leaving exhaustion as the only outcome.
+        var everyPermutation = new HashSet<string>();
+        BigInteger size = UsefulProteomicsDatabases.DecoySequenceValidator.PermutationSpaceSize("QEEEKKK", Trypsin);
+        for (BigInteger i = BigInteger.Zero; i < size; i++)
+        {
+            everyPermutation.Add(UsefulProteomicsDatabases.DecoySequenceValidator
+                .UnrankPermutation("QEEEKKK", Trypsin, i, out _));
+        }
+
+        EntrapmentPeptide exhausted = EntrapmentPeptideGenerator.Create("QEEEKKK", Trypsin, everyPermutation);
+        Assert.That(exhausted.Succeeded, Is.False);
+        Assert.That(exhausted.Failure, Is.EqualTo(EntrapmentFailure.AllPermutationsTaken));
+        Assert.That(exhausted.PermutationSpaceSize, Is.GreaterThan(BigInteger.One),
+            "the space exists -- it is simply fully occupied");
+    }
+
+    [Test]
+    public void Create_ReportsWhenTheSpaceCannotSupplyTheRequestedFolds()
+    {
+        // "QEEEKKK" has four arrangements. Asking for nine folds is not exhaustion and not
+        // arithmetic impossibility -- it is a request the database cannot honour, and the caller's
+        // remedy (ask for fewer folds) differs from both.
+        EntrapmentPeptide result = EntrapmentPeptideGenerator.Create("QEEEKKK", Trypsin, NothingForbidden, fold: 8, foldCount: 9);
+
+        Assert.That(result.Succeeded, Is.False);
+        Assert.That(result.Failure, Is.EqualTo(EntrapmentFailure.SpaceTooSmallForFoldCount));
+    }
+
+    [Test]
+    public void Create_GivesMutuallyDistinctPeptidesForEachFold()
+    {
+        const string target = "SYKALADQMNLLLSK";
+        const int folds = 9;
+
+        var sequences = Enumerable.Range(0, folds)
+            .Select(k => EntrapmentPeptideGenerator.Create(target, Trypsin, NothingForbidden, fold: k, foldCount: folds))
+            .ToList();
+
+        Assert.That(sequences.All(s => s.Succeeded), Is.True);
+        Assert.That(sequences.Select(s => s.EntrapmentSequence).Distinct().Count(), Is.EqualTo(folds),
+            "r-fold entrapment needs r distinct partners, not r copies");
+        Assert.That(sequences.All(s => s.EntrapmentSequence != target), Is.True);
+    }
+
+    [Test]
+    public void Create_FoldsAreIndependentOfOneAnother()
+    {
+        // Fold 5 must be the same whether or not folds 0-4 were ever asked for, so a database can
+        // be extended or regenerated in pieces without invalidating what already exists.
+        const string target = "SYKALADQMNLLLSK";
+
+        string alone = EntrapmentPeptideGenerator
+            .Create(target, Trypsin, NothingForbidden, fold: 5, foldCount: 9).EntrapmentSequence!;
+
+        for (int k = 0; k < 5; k++)
+        {
+            EntrapmentPeptideGenerator.Create(target, Trypsin, NothingForbidden, fold: k, foldCount: 9);
+        }
+
+        Assert.That(EntrapmentPeptideGenerator
+            .Create(target, Trypsin, NothingForbidden, fold: 5, foldCount: 9).EntrapmentSequence,
+            Is.EqualTo(alone));
+    }
+
+    [Test]
+    public void Create_NeverReturnsAForbiddenSequence()
+    {
+        const string target = "ACDEFGHIK";
+        var forbidden = new HashSet<string>();
+
+        // Forbid the first few answers and confirm the generator walks past them.
+        for (int i = 0; i < 3; i++)
+        {
+            EntrapmentPeptide step = EntrapmentPeptideGenerator.Create(target, Trypsin, forbidden);
+            Assert.That(step.Succeeded, Is.True);
+            Assert.That(forbidden, Does.Not.Contain(step.EntrapmentSequence));
+            forbidden.Add(step.EntrapmentSequence!);
+        }
+
+        Assert.That(forbidden.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void Create_ReportsTheSpaceSizeAndHowHardItHadToLook()
+    {
+        EntrapmentPeptide easy = EntrapmentPeptideGenerator.Create("TTTPAPTTT", Trypsin, NothingForbidden);
+
+        Assert.That(easy.PermutationSpaceSize, Is.EqualTo(new BigInteger(252)));
+        Assert.That(easy.ProbesUsed, Is.EqualTo(1), "an unforbidden space should answer on the first probe");
+    }
+
+    [Test]
+    public void Create_RejectsAFoldOutsideTheRequestedCount()
+    {
+        Assert.Throws<MzLibUtil.MzLibException>(() =>
+            EntrapmentPeptideGenerator.Create("ACDEFGHIK", Trypsin, NothingForbidden, fold: 3, foldCount: 3));
+        Assert.Throws<MzLibUtil.MzLibException>(() =>
+            EntrapmentPeptideGenerator.Create("ACDEFGHIK", Trypsin, NothingForbidden, fold: -1));
+        Assert.Throws<MzLibUtil.MzLibException>(() =>
+            EntrapmentPeptideGenerator.Create("ACDEFGHIK", Trypsin, NothingForbidden, fold: 0, foldCount: 0));
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/DecoyGeneration/DecoySequenceValidator.cs
+++ b/mzLib/UsefulProteomicsDatabases/DecoyGeneration/DecoySequenceValidator.cs
@@ -215,7 +215,8 @@ public static class DecoySequenceValidator
                     continue;
                 }
 
-                for (int offset = 0; offset < span && i + offset < sequence.Length; offset++)
+                // Fits() has already established that the whole span lies inside the sequence.
+                for (int offset = 0; offset < span; offset++)
                 {
                     positions.Add(i + offset);
                 }
@@ -243,8 +244,7 @@ public static class DecoySequenceValidator
             return BigInteger.One;
         }
 
-        SortedDictionary<char, int> counts = FreeResidueCounts(sequence, motifs, out int freeCount);
-        return Multinomial(counts, freeCount);
+        return Multinomial(FreeResidueCounts(sequence, motifs));
     }
 
     /// <summary>
@@ -297,7 +297,7 @@ public static class DecoySequenceValidator
             queue.Enqueue(position);
         }
 
-        BigInteger size = Multinomial(counts, freePositions.Count);
+        BigInteger size = Multinomial(counts);
         if (index < BigInteger.Zero || index >= size)
         {
             throw new MzLibException(
@@ -339,12 +339,10 @@ public static class DecoySequenceValidator
     }
 
     /// <summary>Residue counts over the positions no cleavage motif holds in place.</summary>
-    private static SortedDictionary<char, int> FreeResidueCounts(string sequence, List<DigestionMotif> motifs,
-        out int freeCount)
+    private static SortedDictionary<char, int> FreeResidueCounts(string sequence, List<DigestionMotif> motifs)
     {
         HashSet<int> pinned = CleavageSitePositions(sequence, motifs);
         SortedDictionary<char, int> counts = new();
-        freeCount = 0;
 
         for (int i = 0; i < sequence.Length; i++)
         {
@@ -355,7 +353,6 @@ public static class DecoySequenceValidator
 
             counts.TryGetValue(sequence[i], out int seen);
             counts[sequence[i]] = seen + 1;
-            freeCount++;
         }
 
         return counts;
@@ -364,7 +361,7 @@ public static class DecoySequenceValidator
     /// <summary>
     /// n! / (m1! * m2! * ...), built from successive binomials so no factorial is ever materialised.
     /// </summary>
-    private static BigInteger Multinomial(SortedDictionary<char, int> counts, int total)
+    private static BigInteger Multinomial(SortedDictionary<char, int> counts)
     {
         BigInteger permutations = BigInteger.One;
         int placed = 0;
@@ -375,17 +372,14 @@ public static class DecoySequenceValidator
             permutations *= Binomial(placed, count);
         }
 
-        return total == 0 ? BigInteger.One : permutations;
+        // An empty multiset falls straight through: it has exactly one arrangement.
+        return permutations;
     }
 
     /// <summary>Binomial coefficient, computed incrementally so every intermediate stays exact.</summary>
+    /// <remarks>Only ever reached from <see cref="Multinomial"/>'s running totals, so 1 &lt;= k &lt;= n.</remarks>
     private static BigInteger Binomial(int n, int k)
     {
-        if (k < 0 || k > n)
-        {
-            return BigInteger.Zero;
-        }
-
         k = Math.Min(k, n - k);
         BigInteger result = BigInteger.One;
         for (int i = 1; i <= k; i++)

--- a/mzLib/UsefulProteomicsDatabases/DecoyGeneration/DecoySequenceValidator.cs
+++ b/mzLib/UsefulProteomicsDatabases/DecoyGeneration/DecoySequenceValidator.cs
@@ -6,6 +6,7 @@ using Omics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using Transcriptomics;
 
 namespace UsefulProteomicsDatabases;
@@ -177,6 +178,222 @@ public static class DecoySequenceValidator
         }
 
         return new string(sequenceArray);
+    }
+
+    /// <summary>
+    /// Every zero-based position that participates in a cleavage-motif match: the FULL span of each
+    /// match, not only the location at which it starts.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ScrambleSequence"/> records only the match location. That is complete for a
+    /// single-residue motif ("K", "R", "E"), but not for a multi-residue one: StcE's "TX|T" matches
+    /// three residues, and leaving the trailing two free lets a rearrangement destroy that cleavage
+    /// site and invent others elsewhere. Rearrangements that must round-trip through digestion --
+    /// entrapment generation -- hold the whole span still, so they use this.
+    /// </remarks>
+    public static HashSet<int> CleavageSitePositions(string sequence, List<DigestionMotif> motifs)
+    {
+        HashSet<int> positions = new();
+        if (string.IsNullOrEmpty(sequence) || motifs is null)
+        {
+            return positions;
+        }
+
+        foreach (DigestionMotif motif in motifs)
+        {
+            int span = motif.InducingCleavage?.Length ?? 0;
+            if (span == 0)
+            {
+                continue;
+            }
+
+            for (int i = 0; i < sequence.Length; i++)
+            {
+                (bool fits, bool prevents) = motif.Fits(sequence, i);
+                if (!fits || prevents)
+                {
+                    continue;
+                }
+
+                for (int offset = 0; offset < span && i + offset < sequence.Length; offset++)
+                {
+                    positions.Add(i + offset);
+                }
+            }
+        }
+
+        return positions;
+    }
+
+    /// <summary>
+    /// The number of DISTINCT rearrangements of <paramref name="sequence"/> that leave every
+    /// cleavage-site residue in place: the multinomial over the free positions, in closed form.
+    /// Nothing is enumerated, so this is cheap even when the answer is astronomically large.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see cref="BigInteger.One"/> when no rearrangement exists -- a homopolymeric tract
+    /// such as "SSSSSSR" has exactly one arrangement once its cleavage sites are pinned. That is
+    /// arithmetic rather than a collision, so no amount of searching or reseeding can improve it.
+    /// Intended for peptide-length sequences; the free-position count drives the cost.
+    /// </remarks>
+    public static BigInteger PermutationSpaceSize(string sequence, List<DigestionMotif> motifs)
+    {
+        if (string.IsNullOrEmpty(sequence))
+        {
+            return BigInteger.One;
+        }
+
+        SortedDictionary<char, int> counts = FreeResidueCounts(sequence, motifs, out int freeCount);
+        return Multinomial(counts, freeCount);
+    }
+
+    /// <summary>
+    /// The rearrangement of <paramref name="sequence"/> at <paramref name="index"/> in lexicographic
+    /// order over the distinct rearrangements of its free (non-cleavage-site) positions.
+    /// </summary>
+    /// <param name="swappedPositionArray">Maps the previous position (index) to the new position
+    /// (value), the same contract as <see cref="ScrambleSequence"/>, so modification remapping is
+    /// shared between the two.</param>
+    /// <remarks>
+    /// The result is composition-preserving, hence isomeric with the input: same residues, same
+    /// mass, different order. Unlike <see cref="ScrambleSequence"/> this consumes no random state,
+    /// so a given (sequence, index) always yields the same string -- across runs, threads, machines
+    /// and framework versions. Callers that need an unpredictable-but-reproducible choice derive
+    /// the index from a seed and the sequence rather than from a random number generator.
+    /// </remarks>
+    /// <exception cref="MzLibException"><paramref name="index"/> lies outside the space.</exception>
+    public static string UnrankPermutation(string sequence, List<DigestionMotif> motifs, BigInteger index,
+        out int[] swappedPositionArray)
+    {
+        swappedPositionArray = Enumerable.Range(0, sequence?.Length ?? 0).ToArray();
+        if (string.IsNullOrEmpty(sequence))
+        {
+            return sequence;
+        }
+
+        HashSet<int> pinned = CleavageSitePositions(sequence, motifs);
+        List<int> freePositions = new();
+        for (int i = 0; i < sequence.Length; i++)
+        {
+            if (!pinned.Contains(i))
+            {
+                freePositions.Add(i);
+            }
+        }
+
+        SortedDictionary<char, int> counts = new();
+        Dictionary<char, Queue<int>> origins = new();
+        foreach (int position in freePositions)
+        {
+            char residue = sequence[position];
+            counts.TryGetValue(residue, out int seen);
+            counts[residue] = seen + 1;
+
+            if (!origins.TryGetValue(residue, out Queue<int>? queue))
+            {
+                queue = new Queue<int>();
+                origins[residue] = queue;
+            }
+            queue.Enqueue(position);
+        }
+
+        BigInteger size = Multinomial(counts, freePositions.Count);
+        if (index < BigInteger.Zero || index >= size)
+        {
+            throw new MzLibException(
+                $"Permutation index {index} is outside the {size} distinct permutations of '{sequence}'.");
+        }
+
+        char[] rearranged = sequence.ToCharArray();
+        List<char> residues = counts.Keys.ToList();
+        BigInteger remainingPermutations = size;
+        int remainingPositions = freePositions.Count;
+        BigInteger rank = index;
+
+        foreach (int slot in freePositions)
+        {
+            foreach (char residue in residues)
+            {
+                if (counts[residue] == 0)
+                {
+                    continue;
+                }
+
+                // Permutations whose next residue is this one. Exact: the division cancels.
+                BigInteger branch = remainingPermutations * counts[residue] / remainingPositions;
+                if (rank < branch)
+                {
+                    rearranged[slot] = residue;
+                    swappedPositionArray[origins[residue].Dequeue()] = slot;
+                    counts[residue]--;
+                    remainingPermutations = branch;
+                    remainingPositions--;
+                    break;
+                }
+
+                rank -= branch;
+            }
+        }
+
+        return new string(rearranged);
+    }
+
+    /// <summary>Residue counts over the positions no cleavage motif holds in place.</summary>
+    private static SortedDictionary<char, int> FreeResidueCounts(string sequence, List<DigestionMotif> motifs,
+        out int freeCount)
+    {
+        HashSet<int> pinned = CleavageSitePositions(sequence, motifs);
+        SortedDictionary<char, int> counts = new();
+        freeCount = 0;
+
+        for (int i = 0; i < sequence.Length; i++)
+        {
+            if (pinned.Contains(i))
+            {
+                continue;
+            }
+
+            counts.TryGetValue(sequence[i], out int seen);
+            counts[sequence[i]] = seen + 1;
+            freeCount++;
+        }
+
+        return counts;
+    }
+
+    /// <summary>
+    /// n! / (m1! * m2! * ...), built from successive binomials so no factorial is ever materialised.
+    /// </summary>
+    private static BigInteger Multinomial(SortedDictionary<char, int> counts, int total)
+    {
+        BigInteger permutations = BigInteger.One;
+        int placed = 0;
+
+        foreach (int count in counts.Values)
+        {
+            placed += count;
+            permutations *= Binomial(placed, count);
+        }
+
+        return total == 0 ? BigInteger.One : permutations;
+    }
+
+    /// <summary>Binomial coefficient, computed incrementally so every intermediate stays exact.</summary>
+    private static BigInteger Binomial(int n, int k)
+    {
+        if (k < 0 || k > n)
+        {
+            return BigInteger.Zero;
+        }
+
+        k = Math.Min(k, n - k);
+        BigInteger result = BigInteger.One;
+        for (int i = 1; i <= k; i++)
+        {
+            result = result * (n - k + i) / i;
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentAssembler.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentAssembler.cs
@@ -1,0 +1,221 @@
+#nullable enable
+using MzLibUtil;
+using Omics.Digestion;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace UsefulProteomicsDatabases.EntrapmentGeneration;
+
+/// <summary>What became of one base piece of a target sequence.</summary>
+public enum PieceOutcome
+{
+    /// <summary>Rearranged into an isomeric partner.</summary>
+    Permuted,
+
+    /// <summary>
+    /// Has no rearrangement, but is shorter than the minimum peptide length, so it is never
+    /// identified on its own. Kept exactly as it was: no real peptide enters the entrapment
+    /// database, and identity is a rearrangement, so isomerism survives.
+    /// </summary>
+    KeptVerbatimTooShort,
+
+    /// <summary>
+    /// Has no usable rearrangement and *is* long enough to be identified, so it is dropped from the
+    /// entrapment sequence. Emitting it unchanged would place a genuine target peptide inside the
+    /// entrapment database, where every hit is supposed to be false.
+    /// </summary>
+    Excised
+}
+
+/// <summary>One base piece of the target and what happened to it.</summary>
+public sealed class EntrapmentPiece
+{
+    internal EntrapmentPiece(int index, string targetPiece, string? entrapmentPiece,
+        PieceOutcome outcome, EntrapmentFailure failure)
+    {
+        Index = index;
+        TargetPiece = targetPiece;
+        EntrapmentPiece_ = entrapmentPiece;
+        Outcome = outcome;
+        Failure = failure;
+    }
+
+    /// <summary>Ordinal of this piece within the target, counted before anything was excised.</summary>
+    public int Index { get; }
+
+    public string TargetPiece { get; }
+
+    /// <summary>The piece as it appears in the entrapment sequence, or null when excised.</summary>
+    public string? EntrapmentPiece_ { get; }
+
+    public PieceOutcome Outcome { get; }
+
+    /// <summary>Why no partner was found, when <see cref="Outcome"/> is not <see cref="PieceOutcome.Permuted"/>.</summary>
+    public EntrapmentFailure Failure { get; }
+}
+
+/// <summary>An entrapment sequence, and the record of how it was built.</summary>
+public sealed class EntrapmentAssembly
+{
+    internal EntrapmentAssembly(string targetSequence, string entrapmentSequence,
+        int[] targetToEntrapmentPosition, IReadOnlyList<EntrapmentPiece> pieces,
+        int missedCleavagePeptidesSpanningAnExcision)
+    {
+        TargetSequence = targetSequence;
+        EntrapmentSequence = entrapmentSequence;
+        TargetToEntrapmentPosition = targetToEntrapmentPosition;
+        Pieces = pieces;
+        MissedCleavagePeptidesSpanningAnExcision = missedCleavagePeptidesSpanningAnExcision;
+    }
+
+    public string TargetSequence { get; }
+
+    public string EntrapmentSequence { get; }
+
+    /// <summary>
+    /// Position in the entrapment sequence holding each target position's residue, or -1 where the
+    /// piece was excised. Modifications ride across on this.
+    /// </summary>
+    public int[] TargetToEntrapmentPosition { get; }
+
+    public IReadOnlyList<EntrapmentPiece> Pieces { get; }
+
+    /// <summary>
+    /// Missed-cleavage peptides of the entrapment sequence whose constituent pieces were not
+    /// adjacent in the target, so they have no isomeric counterpart there.
+    /// </summary>
+    /// <remarks>
+    /// Every other missed-cleavage peptide is isomeric for free, because base-piece compositions
+    /// add. That is true but not obvious, and these exceptions are counted rather than left
+    /// implicit, because anyone computing mass statistics over the entrapment set will assume the
+    /// invariant holds everywhere.
+    /// </remarks>
+    public int MissedCleavagePeptidesSpanningAnExcision { get; }
+
+    public int ExcisedCount => Pieces.Count(p => p.Outcome == PieceOutcome.Excised);
+
+    public int KeptVerbatimCount => Pieces.Count(p => p.Outcome == PieceOutcome.KeptVerbatimTooShort);
+}
+
+/// <summary>
+/// Builds an entrapment sequence from a target one, by rearranging each of its base pieces in place.
+/// </summary>
+/// <remarks>
+/// <para>The sequence is split at the digestion agent's own cleavage sites
+/// (<see cref="DigestionAgent.GetDigestionSiteIndices"/>), each piece is given an isomeric partner
+/// by <see cref="EntrapmentPeptideGenerator"/>, and the partners are concatenated back together.
+/// Because cleavage sites stay where they were, the entrapment sequence digests into the same
+/// pieces, each isomeric with the target's.</para>
+/// <para>Rearranging the <b>zero-missed-cleavage</b> pieces is enough to cover missed cleavages
+/// too: a missed-cleavage peptide is a run of adjacent pieces, and composition adds, so it is
+/// isomeric with its target counterpart without being handled separately. The exception is a run
+/// spanning an excision, which has no counterpart -- those are counted.</para>
+/// </remarks>
+public static class EntrapmentAssembler
+{
+    /// <summary>
+    /// Builds the entrapment sequence for one fold.
+    /// </summary>
+    /// <param name="targetSequence">The target sequence, typically a protein.</param>
+    /// <param name="digestionParams">Supplies the cleavage sites and the minimum peptide length
+    /// below which a piece is not identifiable on its own.</param>
+    /// <param name="forbiddenSequences">Sequences no partner may equal, normally every target peptide.</param>
+    /// <param name="fold">Zero-based fold, in <c>[0, foldCount)</c>.</param>
+    /// <param name="foldCount">Partners per target -- the <c>r</c> of an r-fold database.</param>
+    /// <param name="seed">Changes every choice reproducibly.</param>
+    public static EntrapmentAssembly Assemble(string targetSequence, IDigestionParams digestionParams,
+        IReadOnlySet<string> forbiddenSequences, int fold = 0, int foldCount = 1, int seed = 1)
+    {
+        if (string.IsNullOrEmpty(targetSequence))
+        {
+            throw new MzLibException("Cannot assemble an entrapment sequence from an empty sequence.");
+        }
+
+        List<DigestionMotif> motifs = digestionParams.DigestionAgent.DigestionMotifs;
+
+        // GetDigestionSiteIndices returns 0, every internal cleavage site, and the length -- a
+        // complete partition. It comes back from a hash set, so it needs ordering.
+        List<int> sites = digestionParams.DigestionAgent.GetDigestionSiteIndices(targetSequence);
+        sites.Sort();
+
+        var pieces = new List<EntrapmentPiece>(sites.Count - 1);
+        var entrapment = new StringBuilder(targetSequence.Length);
+        int[] map = Enumerable.Repeat(-1, targetSequence.Length).ToArray();
+        var retainedTargetIndices = new List<int>(sites.Count - 1);
+
+        for (int index = 0; index < sites.Count - 1; index++)
+        {
+            int start = sites[index];
+            int length = sites[index + 1] - start;
+            string piece = targetSequence.Substring(start, length);
+
+            EntrapmentPeptide partner = EntrapmentPeptideGenerator.Create(piece, motifs, forbiddenSequences,
+                fold, foldCount, seed);
+
+            if (partner.Succeeded)
+            {
+                AppendPiece(entrapment, map, start, partner.EntrapmentSequence!, partner.SwappedPositions!);
+                pieces.Add(new EntrapmentPiece(index, piece, partner.EntrapmentSequence,
+                    PieceOutcome.Permuted, EntrapmentFailure.None));
+                retainedTargetIndices.Add(index);
+                continue;
+            }
+
+            // Too short to be identified on its own: keep it, unchanged, rather than tearing a hole
+            // in the protein for a piece nobody could have matched anyway.
+            if (piece.Length < digestionParams.MinLength)
+            {
+                AppendPiece(entrapment, map, start, piece, Identity(piece.Length));
+                pieces.Add(new EntrapmentPiece(index, piece, piece,
+                    PieceOutcome.KeptVerbatimTooShort, partner.Failure));
+                retainedTargetIndices.Add(index);
+                continue;
+            }
+
+            // Long enough to be identified, and no partner exists: drop it. Its positions stay
+            // unmapped, which is what marks them excised.
+            pieces.Add(new EntrapmentPiece(index, piece, null, PieceOutcome.Excised, partner.Failure));
+        }
+
+        int broken = CountRunsSpanningAGap(retainedTargetIndices, digestionParams.MaxMissedCleavages);
+
+        return new EntrapmentAssembly(targetSequence, entrapment.ToString(), map, pieces, broken);
+    }
+
+    private static void AppendPiece(StringBuilder entrapment, int[] map, int targetStart,
+        string entrapmentPiece, int[] swappedWithinPiece)
+    {
+        int entrapmentStart = entrapment.Length;
+        entrapment.Append(entrapmentPiece);
+
+        for (int offset = 0; offset < swappedWithinPiece.Length; offset++)
+        {
+            map[targetStart + offset] = entrapmentStart + swappedWithinPiece[offset];
+        }
+    }
+
+    private static int[] Identity(int length) => Enumerable.Range(0, length).ToArray();
+
+    /// <summary>
+    /// How many runs of up to <paramref name="maxMissedCleavages"/>+1 retained pieces are not
+    /// contiguous in the target -- i.e. how many missed-cleavage peptides straddle an excision.
+    /// </summary>
+    private static int CountRunsSpanningAGap(List<int> retainedTargetIndices, int maxMissedCleavages)
+    {
+        int broken = 0;
+
+        for (int i = 0; i < retainedTargetIndices.Count; i++)
+        {
+            for (int span = 2; span <= maxMissedCleavages + 1 && i + span - 1 < retainedTargetIndices.Count; span++)
+            {
+                if (retainedTargetIndices[i + span - 1] - retainedTargetIndices[i] != span - 1)
+                {
+                    broken++;
+                }
+            }
+        }
+
+        return broken;
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentPeptideGenerator.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentPeptideGenerator.cs
@@ -1,0 +1,195 @@
+#nullable enable
+using MzLibUtil;
+using Omics.Digestion;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace UsefulProteomicsDatabases.EntrapmentGeneration;
+
+/// <summary>
+/// Why an entrapment peptide could not be produced. These are kept apart because the caller's
+/// remedy differs for each, and merging them into a single "failed" hides that.
+/// </summary>
+public enum EntrapmentFailure
+{
+    /// <summary>A partner was produced.</summary>
+    None,
+
+    /// <summary>
+    /// The sequence has exactly one arrangement once its cleavage sites are held in place -- a
+    /// homopolymeric tract such as "SSSSSSR". Arithmetic, not competition: no seed, no extra
+    /// searching and no smaller fold count can produce a partner for this peptide.
+    /// </summary>
+    NoPermutationExists,
+
+    /// <summary>
+    /// Arrangements exist, but every one this fold may draw on is already spoken for -- it is a
+    /// target peptide, or it has already been issued. Depends on the database, so a different
+    /// target set may succeed where this one did not.
+    /// </summary>
+    AllPermutationsTaken,
+
+    /// <summary>
+    /// The space is real but too small to give every fold its own partner. The remedy is a smaller
+    /// fold count, which distinguishes this from <see cref="AllPermutationsTaken"/>.
+    /// </summary>
+    SpaceTooSmallForFoldCount
+}
+
+/// <summary>
+/// One target peptide's entrapment partner, or the reason it has none.
+/// </summary>
+public sealed class EntrapmentPeptide
+{
+    internal EntrapmentPeptide(string targetSequence, string? entrapmentSequence, int[]? swappedPositions,
+        int fold, BigInteger permutationSpaceSize, int probesUsed, EntrapmentFailure failure)
+    {
+        TargetSequence = targetSequence;
+        EntrapmentSequence = entrapmentSequence;
+        SwappedPositions = swappedPositions;
+        Fold = fold;
+        PermutationSpaceSize = permutationSpaceSize;
+        ProbesUsed = probesUsed;
+        Failure = failure;
+    }
+
+    public string TargetSequence { get; }
+
+    /// <summary>The partner, isomeric with the target. Null when <see cref="Succeeded"/> is false.</summary>
+    public string? EntrapmentSequence { get; }
+
+    /// <summary>
+    /// Maps each position in the target to its position in the partner, the same contract as
+    /// <see cref="DecoySequenceValidator.ScrambleSequence"/>, so modifications ride across unchanged.
+    /// </summary>
+    public int[]? SwappedPositions { get; }
+
+    /// <summary>Zero-based fold this partner belongs to.</summary>
+    public int Fold { get; }
+
+    /// <summary>How many distinct arrangements exist. Reported even on failure, because the value
+    /// is what distinguishes an impossible peptide from a merely crowded one.</summary>
+    public BigInteger PermutationSpaceSize { get; }
+
+    /// <summary>Candidates examined, including the one returned. One means the first choice was free.</summary>
+    public int ProbesUsed { get; }
+
+    public EntrapmentFailure Failure { get; }
+
+    public bool Succeeded => Failure == EntrapmentFailure.None;
+}
+
+/// <summary>
+/// Produces the entrapment partner of a target peptide: the same residues in a different order,
+/// with every cleavage site left where it was.
+/// </summary>
+/// <remarks>
+/// <para>The partner is <b>isomeric</b> with its target -- same composition, so same mass and the
+/// same count of any residue of interest. For localization work that last property is the point:
+/// the number of candidate sites in a peptide sets the difficulty of placing a modification on it,
+/// so a partner carrying a different count would be compared at a difficulty its target never had.
+/// It also makes target and partner the hardest possible pair to tell apart, which is the
+/// discrimination an entrapment experiment is trying to measure.</para>
+/// <para>Selection is by <b>index, not by chance</b>. The starting point is derived from the
+/// sequence and the seed, and search walks forward from there, so the answer is a pure function of
+/// its inputs: unchanged by processing order, by the protein the peptide came from, by threading,
+/// and by framework version. Nothing here consumes random state, and folds never consult one
+/// another, so a database can be regenerated in pieces without invalidating what already exists.
+/// </para>
+/// <para>Because the search enumerates rather than samples, "no partner exists" is a
+/// <b>proven</b> statement rather than a search that gave up, and the three ways it can fail are
+/// reported apart (<see cref="EntrapmentFailure"/>).</para>
+/// </remarks>
+public static class EntrapmentPeptideGenerator
+{
+    /// <summary>
+    /// The entrapment partner of <paramref name="targetSequence"/> for one fold.
+    /// </summary>
+    /// <param name="targetSequence">The target peptide.</param>
+    /// <param name="motifs">Cleavage motifs whose residues must stay in place, so that the partner
+    /// still digests the same way. Typically <c>DigestionAgent.DigestionMotifs</c>.</param>
+    /// <param name="forbiddenSequences">Sequences the partner may not equal -- normally every target
+    /// peptide in the database.</param>
+    /// <param name="fold">Zero-based fold, in <c>[0, foldCount)</c>.</param>
+    /// <param name="foldCount">How many partners each target is to receive (the <c>r</c> of an
+    /// r-fold entrapment database).</param>
+    /// <param name="seed">Changes every choice reproducibly.</param>
+    public static EntrapmentPeptide Create(string targetSequence, List<DigestionMotif> motifs,
+        IReadOnlySet<string> forbiddenSequences, int fold = 0, int foldCount = 1, int seed = 1)
+    {
+        if (string.IsNullOrEmpty(targetSequence))
+        {
+            throw new MzLibException("Cannot build an entrapment peptide from an empty sequence.");
+        }
+        if (foldCount < 1)
+        {
+            throw new MzLibException($"Fold count must be at least 1, but was {foldCount}.");
+        }
+        if (fold < 0 || fold >= foldCount)
+        {
+            throw new MzLibException($"Fold {fold} is outside the {foldCount} requested folds.");
+        }
+
+        BigInteger size = DecoySequenceValidator.PermutationSpaceSize(targetSequence, motifs);
+
+        // One arrangement means the identity and nothing else. No fold count and no seed can help.
+        if (size <= BigInteger.One)
+        {
+            return Failed(targetSequence, fold, size, EntrapmentFailure.NoPermutationExists);
+        }
+
+        // Give each fold its own contiguous stretch of the space. Disjoint stretches make the folds
+        // distinct by construction and independent of one another -- neither has to know what the
+        // others chose, so they can be produced in any order, in parallel, or years apart.
+        BigInteger stretch = size / foldCount;
+        if (stretch.IsZero)
+        {
+            return Failed(targetSequence, fold, size, EntrapmentFailure.SpaceTooSmallForFoldCount);
+        }
+
+        BigInteger start = fold * stretch;
+        BigInteger offset = DeriveOffset(targetSequence, seed, stretch);
+
+        for (BigInteger step = BigInteger.Zero; step < stretch; step++)
+        {
+            BigInteger index = start + (offset + step) % stretch;
+            string candidate = DecoySequenceValidator.UnrankPermutation(targetSequence, motifs, index,
+                out int[] swapped);
+
+            if (candidate != targetSequence && !forbiddenSequences.Contains(candidate))
+            {
+                return new EntrapmentPeptide(targetSequence, candidate, swapped, fold, size,
+                    (int)(step + BigInteger.One), EntrapmentFailure.None);
+            }
+        }
+
+        // The stretch was walked end to end, so this is a proof rather than an abandoned search.
+        return Failed(targetSequence, fold, size, EntrapmentFailure.AllPermutationsTaken);
+    }
+
+    private static EntrapmentPeptide Failed(string targetSequence, int fold, BigInteger size,
+        EntrapmentFailure failure) =>
+        new(targetSequence, null, null, fold, size, 0, failure);
+
+    /// <summary>
+    /// Where in a fold's stretch to start looking, derived from the sequence and the seed.
+    /// </summary>
+    /// <remarks>
+    /// SHA-256 rather than <see cref="string.GetHashCode()"/> or a home-made hash: its output is
+    /// fixed by specification, so a database regenerated on another machine, another runtime or in
+    /// another decade is byte-identical. String hash codes are explicitly not stable across runs.
+    /// </remarks>
+    private static BigInteger DeriveOffset(string sequence, int seed, BigInteger stretch)
+    {
+        byte[] digest = SHA256.HashData(Encoding.UTF8.GetBytes($"{seed}:{sequence}"));
+
+        // Leading zero byte keeps BigInteger's two's-complement reading non-negative.
+        byte[] unsigned = new byte[digest.Length + 1];
+        Array.Copy(digest, unsigned, digest.Length);
+
+        return new BigInteger(unsigned) % stretch;
+    }
+}


### PR DESCRIPTION
# Assemble an entrapment sequence from a target one

> **Stacks on #1253, which stacks on #1250.** This branch carries their commits too; its own are
> the last three (`62692baa`, `7ff...` tightening one assertion). Merge #1250 then #1253 and this
> diff reduces to the two files below.

Adds `EntrapmentAssembler` to `UsefulProteomicsDatabases/EntrapmentGeneration/`. Two files, nothing
existing touched.

## What it does

Splits a target sequence at its digestion agent's own cleavage sites, gives each base piece an
isomeric partner via #1253, and concatenates the partners back into a sequence.

```csharp
EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(
    protein.BaseSequence, digestionParams, everyTargetPeptide, fold: k, foldCount: r);
```

Because the cleavage sites stay where they were, the entrapment sequence **digests into the same
pieces**, each isomeric with its target counterpart -- same residues, same mass, same count of any
residue of interest.

## Missed cleavages come along for free

Rearranging only the zero-missed-cleavage pieces is enough. A missed-cleavage peptide is a run of
adjacent base pieces, and composition adds, so it is isomeric with its target counterpart without
being handled separately.

The exception is a run that **spans an excision**: it has no counterpart at all. Those are counted
(`MissedCleavagePeptidesSpanningAnExcision`) rather than left implicit, because anyone computing
mass statistics over the entrapment set will otherwise assume the invariant holds everywhere.

## Excision is length-aware, and that is not a detail

A piece with no possible partner is **excised only when it is long enough to be identified on its
own**. A shorter one (`K`, `AK`, `SR`) is kept verbatim: it puts no real peptide into the entrapment
database, and identity is a rearrangement, so isomerism survives.

The naive rule -- excise whenever no partner exists -- looks equivalent and is not. Applied to the
human reviewed proteome it excised every short piece and removed **17.7%** of the peptide
population, stratified from -33.5% at zero candidate sites to -0.6% at six to nine. Per-piece
equality could not see it, because equality is pointwise over pieces present in both sequences and
a removed piece satisfies it vacuously. See the distribution test below.

## Reuse

`DigestionAgent.GetDigestionSiteIndices` already returns the complete partition -- 0, every internal
cleavage site, and the length -- so no cleavage logic is reimplemented here. One wrinkle: it is
built from a `HashSet`, so the returned list needs sorting before use as a partition.

## Tests

Ten, in `Test/DatabaseTests/TestEntrapmentAssembly.cs`:

- one partner per target piece, each isomeric, in order;
- the whole sequence isomeric, with the candidate-site count preserved;
- a sub-length piece kept verbatim rather than excised;
- a searchable piece with no partner excised, leaving its neighbours' digestion untouched;
- no target peptide ever left in the entrapment sequence;
- the exact count of missed-cleavage peptides broken by an excision;
- every retained position mapped to a position holding the same residue, excised ones marked;
- determinism, and a different sequence per fold;
- **the candidate-site distribution reproduced, with excision as the only permitted difference.**

That last one is the assertion that matters, and it earned its place immediately: written first as
"the distributions are identical" it failed, correctly -- identical was never the right invariant
once a peptide can be legitimately removed. It now also asserts the fixture actually exercises
excision, so it cannot pass vacuously.

856 passed / 0 failed across the database, decoy and entrapment suites.

## Notes for review

- `MzLibException` for the empty-sequence guard, matching the neighbours.
- `#nullable enable`; builds with zero warnings.
- Sequence-level only. Turning an assembly into a database entry -- accession scheme, pairing by
  composition, and modification transfer along `TargetToEntrapmentPosition` -- is the next PR.
