### PR TITLE
Add a managed entrapment database generator

### DIFF
--- a/mzLib/Test/DatabaseTests/TestEntrapmentAssembly.cs
+++ b/mzLib/Test/DatabaseTests/TestEntrapmentAssembly.cs
@@ -1,0 +1,370 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using NUnit.Framework;
+using Omics.Digestion;
+using Proteomics.ProteolyticDigestion;
+using UsefulProteomicsDatabases.EntrapmentGeneration;
+
+namespace Test.DatabaseTests;
+
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class EntrapmentAssemblyTests
+{
+    private static readonly HashSet<string> NothingForbidden = new();
+
+    private static IDigestionParams Tryptic(int minLength = 7) =>
+        new DigestionParams("trypsin", minPeptideLength: minLength, maxMissedCleavages: 2);
+
+    /// <summary>Base pieces of a sequence under the same partition the assembler uses.</summary>
+    private static List<string> BasePieces(string sequence, IDigestionParams digestionParams)
+    {
+        List<int> sites = digestionParams.DigestionAgent.GetDigestionSiteIndices(sequence);
+        sites.Sort();
+        return Enumerable.Range(0, sites.Count - 1)
+            .Select(i => sequence.Substring(sites[i], sites[i + 1] - sites[i]))
+            .ToList();
+    }
+
+    private static string Sorted(string s) => string.Concat(s.OrderBy(c => c));
+
+    [Test]
+    public void Assemble_ProducesOnePermutedPieceForEachTargetPiece()
+    {
+        const string target = "SYKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK";
+        IDigestionParams digestion = Tryptic();
+
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, digestion, NothingForbidden);
+
+        List<string> targetPieces = BasePieces(target, digestion);
+        List<string> entrapmentPieces = BasePieces(assembly.EntrapmentSequence, digestion);
+
+        Assert.That(assembly.ExcisedCount, Is.Zero);
+        Assert.That(entrapmentPieces.Count, Is.EqualTo(targetPieces.Count),
+            "the entrapment protein must digest into the same number of pieces");
+        for (int i = 0; i < targetPieces.Count; i++)
+        {
+            Assert.That(Sorted(entrapmentPieces[i]), Is.EqualTo(Sorted(targetPieces[i])),
+                "piece " + i + " must be isomeric with its target counterpart");
+        }
+    }
+
+    [Test]
+    public void Assemble_KeepsTheWholeProteinIsomeric()
+    {
+        const string target = "SYKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK";
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden);
+
+        Assert.That(assembly.EntrapmentSequence, Is.Not.EqualTo(target));
+        Assert.That(Sorted(assembly.EntrapmentSequence), Is.EqualTo(Sorted(target)));
+        Assert.That(assembly.EntrapmentSequence.Count(c => c is 'S' or 'T'),
+            Is.EqualTo(target.Count(c => c is 'S' or 'T')));
+    }
+
+    [Test]
+    public void Assemble_KeepsASubLengthPieceVerbatimRatherThanExcisingIt()
+    {
+        // "AK" has no permutation once K is pinned, but it is below the minimum peptide length, so
+        // it is never identifiable on its own. Keeping it verbatim puts no real target peptide into
+        // the entrapment search space, and identity is a permutation, so isomerism still holds.
+        // Excising every such piece instead would gut the database.
+        const string target = "AKSYKALADQMNLLLSKGGVDTTPFAWENDR";
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden);
+
+        Assert.That(assembly.ExcisedCount, Is.Zero, "a sub-length piece must not be excised");
+        Assert.That(assembly.KeptVerbatimCount, Is.EqualTo(1), "exactly the \"AK\" piece");
+        Assert.That(assembly.EntrapmentSequence, Does.StartWith("AK"));
+        Assert.That(assembly.EntrapmentSequence.Length, Is.EqualTo(target.Length));
+    }
+
+    [Test]
+    public void Assemble_ExcisesASearchablePieceThatHasNoPermutation()
+    {
+        // "SSSSSSR" is long enough to be identified and has exactly one arrangement, so there is no
+        // honest partner for it. It is removed rather than emitted unchanged, because emitting it
+        // would place a genuine target peptide inside the entrapment database.
+        const string target = "SYKALADQMNLLLSKSSSSSSRGGVDTTPFAWENDR";
+        IDigestionParams digestion = Tryptic();
+
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, digestion, NothingForbidden);
+
+        Assert.That(assembly.ExcisedCount, Is.EqualTo(1));
+        Assert.That(assembly.EntrapmentSequence, Does.Not.Contain("SSSSSSR"));
+        Assert.That(assembly.EntrapmentSequence.Length, Is.EqualTo(target.Length - 7));
+
+        // Every other piece digests exactly as it would have without the excision.
+        List<string> targetPieces = BasePieces(target, digestion);
+        List<string> entrapmentPieces = BasePieces(assembly.EntrapmentSequence, digestion);
+        Assert.That(entrapmentPieces.Count, Is.EqualTo(targetPieces.Count - 1));
+    }
+
+    [Test]
+    public void Assemble_NeverLeavesATargetPeptideInTheEntrapmentSequence()
+    {
+        const string target = "SYKALADQMNLLLSKSSSSSSRGGVDTTPFAWENDR";
+        IDigestionParams digestion = Tryptic();
+        var targetPeptides = BasePieces(target, digestion).ToHashSet();
+
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, digestion, targetPeptides);
+
+        foreach (string piece in BasePieces(assembly.EntrapmentSequence, digestion))
+        {
+            if (piece.Length >= digestion.MinLength)
+            {
+                Assert.That(targetPeptides, Does.Not.Contain(piece),
+                    "'" + piece + "' is a real target peptide and must not appear as entrapment");
+            }
+        }
+    }
+
+    [Test]
+    public void Assemble_CountsMissedCleavagePeptidesThatSpanAnExcision()
+    {
+        // Base-peptide compositions add, so a missed-cleavage peptide is normally isomeric with its
+        // target counterpart for free. One that spans an excision is not -- it has no counterpart at
+        // all. Those are counted rather than passed off as isomeric, because someone will compute
+        // mass statistics over the entrapment set assuming the invariant holds everywhere.
+        const string target = "SYKALADQMNLLLSKSSSSSSRGGVDTTPFAWENDR";
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden);
+
+        // Pieces are SYK | ALADQMNLLLSK | SSSSSSR | GGVDTTPFAWENDR, and the third is excised, so the
+        // retained ordinals are 0, 1, 3. At two missed cleavages the runs that straddle that gap are
+        // {0,1,3} and {1,3} -- exactly two. An exact count, not "more than none": the arithmetic here
+        // is nested and off-by-one prone, and a loose assertion would not notice it drifting.
+        Assert.That(assembly.ExcisedCount, Is.EqualTo(1));
+        Assert.That(assembly.MissedCleavagePeptidesSpanningAnExcision, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Assemble_MapsEveryRetainedPositionAndMarksExcisedOnes()
+    {
+        const string target = "SYKALADQMNLLLSKSSSSSSRGGVDTTPFAWENDR";
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden);
+
+        Assert.That(assembly.TargetToEntrapmentPosition.Length, Is.EqualTo(target.Length));
+
+        for (int i = 0; i < target.Length; i++)
+        {
+            int mapped = assembly.TargetToEntrapmentPosition[i];
+            if (mapped < 0)
+            {
+                continue;   // excised
+            }
+
+            Assert.That(assembly.EntrapmentSequence[mapped], Is.EqualTo(target[i]),
+                "position " + i + " must map to a position holding the same residue");
+        }
+
+        // The excised stretch, and only it, is unmapped.
+        Assert.That(assembly.TargetToEntrapmentPosition.Count(p => p < 0), Is.EqualTo(7));
+    }
+
+    [Test]
+    public void Assemble_RejectsAnEmptySequence()
+    {
+        var thrown = Assert.Throws<MzLibUtil.MzLibException>(() =>
+            EntrapmentAssembler.Assemble("", Tryptic(), NothingForbidden));
+        Assert.That(thrown!.Message, Does.Contain("empty"));
+    }
+
+    [Test]
+    public void Assemble_CountsBrokenRunsFromTheGapItself()
+    {
+        // Retained ordinals here are 0, 2, 3 -- the excised piece sits second rather than last.
+        // The run {2,3} is contiguous and must NOT count, which is what distinguishes a real
+        // difference of ordinals from any other arithmetic that happens to agree on [0,1,3].
+        const string target = "ALADQMNLLLSKSSSSSSRGGVDTTPFAWENDRQISTLGGYK";
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden);
+
+        Assert.That(assembly.ExcisedCount, Is.EqualTo(1));
+        Assert.That(assembly.MissedCleavagePeptidesSpanningAnExcision, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Assemble_IsDeterministic()
+    {
+        const string target = "SYKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK";
+
+        string first = EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden).EntrapmentSequence;
+        EntrapmentAssembler.Assemble("ACDEFGHIKLMNPQR", Tryptic(), NothingForbidden);  // unrelated work
+
+        Assert.That(EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden).EntrapmentSequence,
+            Is.EqualTo(first));
+        Assert.That(EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden, seed: 2).EntrapmentSequence,
+            Is.Not.EqualTo(first));
+    }
+
+    [Test]
+    public void Assemble_ReproducesTheCandidateSiteDistributionOfTheTarget()
+    {
+        // The check per-peptide equality structurally cannot make. Equality is pointwise over
+        // peptides present in both databases, so a peptide that was dropped satisfies it vacuously;
+        // only the distribution notices an assembly bug. This is the assertion that caught the
+        // rule which excised every short piece.
+        string[] proteins =
+        {
+            "SYKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK",
+            "AKMTTSTTPAPTTTKQEEEKKKGGVDTTPFAWENDRSSSSSSR",
+            "MPSSTSRLLGVDKAAATPTGGGSQSCCCKYPERDNRSTTTK",
+            "QLQGASWELQSLRPSLDQLAAHPWMLGADGGVPESCDLRTTK"
+        };
+        IDigestionParams digestion = Tryptic();
+
+        var expectedSites = new List<int>();
+        var entrapmentSites = new List<int>();
+        int excised = 0;
+
+        foreach (string protein in proteins)
+        {
+            EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(protein, digestion, NothingForbidden);
+
+            // Excision is the ONLY thing allowed to change the distribution, so the target's
+            // contribution is its searchable pieces minus the ones that had no partner.
+            expectedSites.AddRange(assembly.Pieces
+                .Where(p => p.Outcome != PieceOutcome.Excised)
+                .Select(p => p.TargetPiece)
+                .Where(p => p.Length >= digestion.MinLength)
+                .Select(p => p.Count(c => c is 'S' or 'T')));
+            excised += assembly.ExcisedCount;
+
+            entrapmentSites.AddRange(BasePieces(assembly.EntrapmentSequence, digestion)
+                .Where(p => p.Length >= digestion.MinLength)
+                .Select(p => p.Count(c => c is 'S' or 'T')));
+        }
+
+        Assert.That(excised, Is.GreaterThan(0),
+            "this fixture must actually exercise excision, or the assertion below proves nothing");
+        Assert.That(entrapmentSites.OrderBy(n => n).ToList(), Is.EqualTo(expectedSites.OrderBy(n => n).ToList()),
+            "apart from peptides with no possible partner, the entrapment database must present the "
+            + "same distribution of candidate sites as the target");
+    }
+
+    [Test]
+    public void Assemble_GivesEachFoldADifferentProtein()
+    {
+        const string target = "SYKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK";
+
+        var sequences = Enumerable.Range(0, 5)
+            .Select(k => EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden, fold: k, foldCount: 5)
+                .EntrapmentSequence)
+            .ToList();
+
+        Assert.That(sequences.Distinct().Count(), Is.EqualTo(5));
+        Assert.That(sequences.All(s => Sorted(s) == Sorted(target)), Is.True,
+            "every fold stays isomeric with the target");
+    }
+
+    // The first piece must be long enough that anchoring the protein's first two positions still
+    // leaves a permutation space -- "SYK" has none once positions 0, 1 and the cleavage K are all
+    // held, and the assembler then keeps it verbatim instead of permuting it.
+    private const string FourPieces = "MSTQAEVDLNSGWKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK";
+
+    /// <summary>
+    /// The concatenation of the first two entrapment pieces, built with nothing forbidden. Deriving
+    /// the fixture this way rather than hand-writing a sequence guarantees the collision case is
+    /// actually reached: whatever the generator produces, that exact run is what gets forbidden.
+    /// </summary>
+    private static (EntrapmentAssembly Free, string Run) FirstRun(IDigestionParams digestion)
+    {
+        EntrapmentAssembly free = EntrapmentAssembler.Assemble(FourPieces, digestion, NothingForbidden);
+        Assert.That(free.Pieces.Count, Is.GreaterThan(2), "fixture must have several base pieces");
+        Assert.That(free.Pieces[0].Outcome, Is.EqualTo(PieceOutcome.Permuted));
+        Assert.That(free.Pieces[1].Outcome, Is.EqualTo(PieceOutcome.Permuted));
+        return (free, free.Pieces[0].EntrapmentPiece_ + free.Pieces[1].EntrapmentPiece_);
+    }
+
+    [Test]
+    public void ARunThatWouldEqualARealPeptideIsRejected()
+    {
+        IDigestionParams digestion = Tryptic();
+        (EntrapmentAssembly free, string run) = FirstRun(digestion);
+
+        // Forbid exactly the missed-cleavage peptide the free build would have produced. Neither
+        // piece is forbidden on its own, so only a run-aware check can avoid it.
+        var forbidden = new HashSet<string> { run };
+        EntrapmentAssembly guarded = EntrapmentAssembler.Assemble(FourPieces, digestion, forbidden);
+
+        string guardedRun = guarded.Pieces[0].EntrapmentPiece_ + guarded.Pieces[1].EntrapmentPiece_;
+        Assert.That(guardedRun, Is.Not.EqualTo(run), "the forbidden run must not be emitted");
+        Assert.That(guarded.EntrapmentSequence, Does.Not.Contain(run));
+
+        // The first piece has nothing before it, so no run ends at it and it is free to stay put.
+        Assert.That(guarded.Pieces[0].EntrapmentPiece_, Is.EqualTo(free.Pieces[0].EntrapmentPiece_));
+
+        // Avoiding the collision must not cost isomerism: the replacement is still a rearrangement.
+        Assert.That(Sorted(guarded.Pieces[1].EntrapmentPiece_),
+            Is.EqualTo(Sorted(free.Pieces[1].EntrapmentPiece_)));
+        Assert.That(Sorted(guardedRun), Is.EqualTo(Sorted(run)));
+    }
+
+    [Test]
+    public void RunCheckingIsOffWhenTheDigestionAllowsNoMissedCleavages()
+    {
+        // With no missed cleavages there are no runs to collide, so forbidding a concatenation must
+        // change nothing -- otherwise the check is firing where it has no business.
+        IDigestionParams noMissed = new DigestionParams("trypsin", minPeptideLength: 7, maxMissedCleavages: 0);
+        EntrapmentAssembly free = EntrapmentAssembler.Assemble(FourPieces, noMissed, NothingForbidden);
+        string run = free.Pieces[0].EntrapmentPiece_ + free.Pieces[1].EntrapmentPiece_;
+
+        EntrapmentAssembly guarded = EntrapmentAssembler.Assemble(FourPieces, noMissed,
+            new HashSet<string> { run });
+
+        Assert.That(guarded.EntrapmentSequence, Is.EqualTo(free.EntrapmentSequence));
+    }
+
+    [Test]
+    public void RunCheckingKeepsTheConstructionDeterministic()
+    {
+        IDigestionParams digestion = Tryptic();
+        (_, string run) = FirstRun(digestion);
+        var forbidden = new HashSet<string> { run };
+
+        EntrapmentAssembly first = EntrapmentAssembler.Assemble(FourPieces, digestion, forbidden);
+        EntrapmentAssembly second = EntrapmentAssembler.Assemble(FourPieces, digestion, forbidden);
+
+        Assert.That(second.EntrapmentSequence, Is.EqualTo(first.EntrapmentSequence));
+    }
+
+    [Test]
+    public void ACollisionOnAPieceWithNoAlternativeIsCountedNotRepaired()
+    {
+        // "AAR" holds its R as a cleavage site and has two identical A's left, so it has exactly one
+        // arrangement. When a run ending there equals a real peptide there is no candidate to move
+        // to, and the project's rule is to count such a collision rather than repair it by
+        // backtracking or excising a good piece.
+        IDigestionParams digestion = Tryptic();
+        const string target = "MSTQAEVDLNSGWKAAR";
+
+        EntrapmentAssembly free = EntrapmentAssembler.Assemble(target, digestion, NothingForbidden);
+        Assert.That(free.Pieces[1].Outcome, Is.EqualTo(PieceOutcome.KeptVerbatimTooShort),
+            "fixture must end in a piece with no alternative arrangement");
+        Assert.That(free.UnrepairableRunCollisions, Is.Zero);
+
+        string run = free.Pieces[0].EntrapmentPiece_ + free.Pieces[1].EntrapmentPiece_;
+        EntrapmentAssembly guarded = EntrapmentAssembler.Assemble(target, digestion,
+            new HashSet<string> { run });
+
+        Assert.That(guarded.UnrepairableRunCollisions, Is.EqualTo(1));
+        Assert.That(guarded.EntrapmentSequence, Is.EqualTo(free.EntrapmentSequence),
+            "nothing is silently repaired -- the sequence is unchanged and the collision is reported");
+    }
+
+    [Test]
+    public void ARunSpanningThreePiecesIsCheckedToo()
+    {
+        // maxMissedCleavages = 2 means a peptide can span three base pieces, so the check must look
+        // back two, not one. Forbidding the three-piece run exercises the deeper lookback.
+        IDigestionParams digestion = Tryptic();
+        EntrapmentAssembly free = EntrapmentAssembler.Assemble(FourPieces, digestion, NothingForbidden);
+        string longRun = free.Pieces[0].EntrapmentPiece_ + free.Pieces[1].EntrapmentPiece_
+                         + free.Pieces[2].EntrapmentPiece_;
+
+        EntrapmentAssembly guarded = EntrapmentAssembler.Assemble(FourPieces, digestion,
+            new HashSet<string> { longRun });
+
+        Assert.That(guarded.EntrapmentSequence, Does.Not.Contain(longRun));
+        Assert.That(Sorted(guarded.Pieces[2].EntrapmentPiece_),
+            Is.EqualTo(Sorted(free.Pieces[2].EntrapmentPiece_)));
+    }
+}

--- a/mzLib/Test/DatabaseTests/TestEntrapmentAssembly.cs
+++ b/mzLib/Test/DatabaseTests/TestEntrapmentAssembly.cs
@@ -73,9 +73,19 @@ public class EntrapmentAssemblyTests
         EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, Tryptic(), NothingForbidden);
 
         Assert.That(assembly.ExcisedCount, Is.Zero, "a sub-length piece must not be excised");
-        Assert.That(assembly.KeptVerbatimCount, Is.EqualTo(1), "exactly the \"AK\" piece");
+        Assert.That(assembly.Pieces[0].TargetPiece, Is.EqualTo("AK"), "fixture must open with \"AK\"");
+        Assert.That(assembly.Pieces[0].Outcome, Is.EqualTo(PieceOutcome.KeptVerbatimTooShort));
         Assert.That(assembly.EntrapmentSequence, Does.StartWith("AK"));
         Assert.That(assembly.EntrapmentSequence.Length, Is.EqualTo(target.Length));
+
+        // Named per piece rather than as a count, because "SYK" reaches the same outcome by a
+        // different route once a piece's own termini are anchored: S at position 0 and K at position
+        // 2 are both held, so a single free residue is left and there is no second arrangement.
+        // Asserting a count of one hid which pieces were meant, and would have been satisfied by the
+        // wrong piece being kept.
+        Assert.That(assembly.Pieces[1].TargetPiece, Is.EqualTo("SYK"));
+        Assert.That(assembly.Pieces[1].Outcome, Is.EqualTo(PieceOutcome.KeptVerbatimTooShort));
+        Assert.That(assembly.KeptVerbatimCount, Is.EqualTo(2));
     }
 
     [Test]
@@ -366,5 +376,97 @@ public class EntrapmentAssemblyTests
         Assert.That(guarded.EntrapmentSequence, Does.Not.Contain(longRun));
         Assert.That(Sorted(guarded.Pieces[2].EntrapmentPiece_),
             Is.EqualTo(Sorted(free.Pieces[2].EntrapmentPiece_)));
+    }
+
+    // ---- piece termini and the initiator methionine -------------------------
+
+    [Test]
+    public void Assemble_HoldsEachPiecesOwnTerminiNotOnlyTheProteins()
+    {
+        // The structural form of the two peptide-terminal tests in TestEntrapmentProtein: whatever
+        // the annotations are, a piece's first and last residues must land on its first and last
+        // positions, because that is what makes a peptide-level location restriction survive.
+        const string target = "MAAALGGDRSGGVDTTPFAWENDRQITTLGGYKELMNPQWVR";
+        IDigestionParams digestion = Tryptic();
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(target, digestion, NothingForbidden);
+
+        List<int> sites = digestion.DigestionAgent.GetDigestionSiteIndices(target);
+        sites.Sort();
+        int cursor = 0;
+        foreach (EntrapmentPiece piece in assembly.Pieces)
+        {
+            Assert.That(piece.Outcome, Is.Not.EqualTo(PieceOutcome.Excised),
+                "fixture must not need excision, or the position map has gaps");
+            int start = sites[piece.Index];
+            int end = start + piece.TargetPiece.Length - 1;
+            Assert.That(assembly.TargetToEntrapmentPosition[start], Is.EqualTo(cursor),
+                "piece " + piece.Index + " must keep its first residue first");
+            Assert.That(assembly.TargetToEntrapmentPosition[end],
+                Is.EqualTo(cursor + piece.EntrapmentPiece_.Length - 1),
+                "piece " + piece.Index + " must keep its last residue last");
+            cursor += piece.EntrapmentPiece_.Length;
+        }
+
+        Assert.That(assembly.Pieces.Count, Is.GreaterThan(2),
+            "fixture must contain an interior piece, which is where the protein anchors do not reach");
+    }
+
+    [Test]
+    public void Assemble_RefusesACandidateWhoseInitiatorMethionineStrippedFormIsATargetPeptide()
+    {
+        // A search digests the opening piece twice, with and without the initiator methionine, so a
+        // piece distinct from every target peptide can still have an M-stripped form that is not.
+        // This is the only route left at MaxMissedCleavages = 0, and before the check existed it put
+        // four real target peptides into the human entrapment set -- in no exclusion list, because a
+        // run collision was the only reason the sidecar could name.
+        const string target = "MSTQAEVDLNSGWKGGVDTTPFAWENDR";
+        IDigestionParams digestion = Tryptic();
+
+        EntrapmentAssembly free = EntrapmentAssembler.Assemble(target, digestion, NothingForbidden);
+        string opening = free.Pieces[0].EntrapmentPiece_;
+        Assert.That(opening, Does.StartWith("M"), "fixture must open with the initiator methionine");
+
+        EntrapmentAssembly guarded = EntrapmentAssembler.Assemble(target, digestion,
+            new HashSet<string> { opening.Substring(1) });
+
+        Assert.That(guarded.Pieces[0].EntrapmentPiece_, Is.Not.EqualTo(opening),
+            "the candidate whose stripped form is a target peptide must be refused");
+        Assert.That(Sorted(guarded.Pieces[0].EntrapmentPiece_), Is.EqualTo(Sorted(free.Pieces[0].TargetPiece)),
+            "refusing one candidate must not cost isomerism");
+        Assert.That(guarded.InitiatorMethionineCollisions, Is.Zero,
+            "another arrangement existed, so nothing is left to report");
+    }
+
+    [Test]
+    public void Assemble_ChecksTheStrippedFormOnlyForThePieceThatOpensTheProtein()
+    {
+        // Every other piece is fully covered by testing the candidate itself, and testing them all
+        // would reject arrangements over sequences no search ever emits. Forbidding an interior
+        // piece's own M-stripped form must therefore change nothing.
+        const string target = "GGVDTTPFAWENDRMSTQAEVDLNSGWKQITTLGGYK";
+        IDigestionParams digestion = Tryptic();
+
+        EntrapmentAssembly free = EntrapmentAssembler.Assemble(target, digestion, NothingForbidden);
+        string interior = free.Pieces[1].EntrapmentPiece_;
+        Assert.That(free.Pieces[1].TargetPiece, Does.StartWith("M"),
+            "fixture needs an interior piece beginning with methionine");
+
+        EntrapmentAssembly guarded = EntrapmentAssembler.Assemble(target, digestion,
+            new HashSet<string> { interior.Substring(1) });
+
+        Assert.That(guarded.EntrapmentSequence, Is.EqualTo(free.EntrapmentSequence));
+        Assert.That(guarded.InitiatorMethionineCollisions, Is.Zero);
+    }
+
+    [Test]
+    public void Assemble_ReportsNoInitiatorMethionineCollisionWhenThereIsNothingToReport()
+    {
+        // Zero because the check ran, not because there is no column. The distinction is the whole
+        // reason this is counted separately from the run collisions, which at MC = 0 are zero
+        // because the machinery producing them is switched off.
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble(FourPieces, Tryptic(), NothingForbidden);
+
+        Assert.That(assembly.InitiatorMethionineCollisions, Is.Zero);
+        Assert.That(assembly.InitiatorMethionineCollisionPeptides, Is.Empty);
     }
 }

--- a/mzLib/Test/DatabaseTests/TestEntrapmentMassGroups.cs
+++ b/mzLib/Test/DatabaseTests/TestEntrapmentMassGroups.cs
@@ -1,0 +1,233 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using MzLibUtil;
+using NUnit.Framework;
+using Omics.Digestion;
+using Omics.Modifications;
+using Proteomics;
+using Proteomics.ProteolyticDigestion;
+using UsefulProteomicsDatabases.EntrapmentGeneration;
+
+namespace Test.DatabaseTests;
+
+/// <summary>
+/// The invariant in the units a search engine actually sees: per (peptide, MASS GROUP), not per
+/// (peptide, modification name). The distinction is the whole point -- "the companion carries the
+/// same modifications" and "the companion has the same mass groups" are different sentences, and
+/// only the second is what the engine explores.
+/// </summary>
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class EntrapmentMassGroupTests
+{
+    private static readonly HashSet<string> NothingForbidden = new();
+
+    private static IDigestionParams Tryptic =>
+        new DigestionParams("trypsin", minPeptideLength: 7, maxMissedCleavages: 0);
+
+    private static Modification Mod(string motifResidue, string id, double mass,
+        string restriction = "Anywhere.")
+    {
+        ModificationMotif.TryGetMotif(motifResidue, out ModificationMotif motif);
+        return new Modification(_originalId: id, _modificationType: "Common Biological",
+            _target: motif, _locationRestriction: restriction, _monoisotopicMass: mass);
+    }
+
+    // +15.994915 on three different residues. A search sees one mass and three candidate residues;
+    // a name-based grouping would see three unrelated modifications.
+    private static Modification OxidationOnM() => Mod("M", "Oxidation", 15.994915);
+    private static Modification OxidationOnW() => Mod("W", "Oxidation", 15.994915);
+    private static Modification HydroxylationOnP() => Mod("P", "Hydroxylation", 15.994915);
+
+    [Test]
+    public void OneMassGathersEveryModificationOfThatMassAndAllTheirResidues()
+    {
+        var index = new MassGroupIndex(new[] { OxidationOnM(), OxidationOnW(), HydroxylationOnP() });
+
+        Assert.That(index.Groups.Count, Is.EqualTo(1),
+            "one mass is one group however many names carry it");
+        MassGroup group = index.Groups[0];
+        Assert.That(group.Residues.OrderBy(c => c), Is.EqualTo(new[] { 'M', 'P', 'W' }));
+        Assert.That(group.Modifications.Count, Is.EqualTo(3),
+            "three distinct IdWithMotif values -- the names differ, the mass does not, and it is the "
+            + "mass a search competes on");
+        Assert.That(group.Modifications,
+            Is.EquivalentTo(new[] { "Oxidation on M", "Oxidation on W", "Hydroxylation on P" }));
+        Assert.That(group.Span, Is.Zero);
+    }
+
+    [Test]
+    public void TheToleranceDecidesWhetherNearIsobarsAreOneCandidateSetOrTwo()
+    {
+        // Phospho and sulfo are 9.5 mDa apart -- one candidate set or two depending on what the
+        // instrument and the search can separate, which is the consumer's call and not ours.
+        var phospho = Mod("S", "Phosphorylation", 79.966331);
+        var sulfo = Mod("Y", "Sulfonation", 79.956815);
+
+        Assert.That(new MassGroupIndex(new[] { phospho, sulfo }, 0.0).Groups.Count, Is.EqualTo(2));
+        Assert.That(new MassGroupIndex(new[] { phospho, sulfo }, 0.001).Groups.Count, Is.EqualTo(2));
+        Assert.That(new MassGroupIndex(new[] { phospho, sulfo }, 0.010).Groups.Count, Is.EqualTo(1),
+            "at 10 mDa the two become one candidate set");
+    }
+
+    [Test]
+    public void AWildcardMotifCanCarryItsMassAnywhere()
+    {
+        // "Acetylation on X" is kept in real configurations because the dictionary has no
+        // residue-specific N-terminal acetyl record. Treating X as a literal residue would make
+        // every peptide's capacity for it zero.
+        var index = new MassGroupIndex(new[] { Mod("X", "Carbamyl", 43.005814) });
+
+        Assert.That(MassGroupIndex.Capacity("PEPTIDEK", index.Groups[0]), Is.EqualTo(8));
+    }
+
+    [Test]
+    public void AModificationWithoutAMassDefinesNoGroup()
+    {
+        ModificationMotif.TryGetMotif("S", out ModificationMotif motif);
+        var massless = new Modification(_originalId: "Unknown", _modificationType: "Common Biological",
+            _target: motif, _locationRestriction: "Anywhere.");
+
+        // Dropped rather than treated as zero: a zero-mass group would swallow every other
+        // unmassed modification and read as a real candidate set.
+        Assert.That(new MassGroupIndex(new[] { massless }).Groups, Is.Empty);
+    }
+
+    [Test]
+    public void ANegativeToleranceIsRefused()
+    {
+        Assert.Throws<MzLibException>(() => new MassGroupIndex(new[] { OxidationOnM() }, -0.001));
+    }
+
+    [Test]
+    public void CapacityAndAnnotatedSitesBothSurviveTheRearrangement()
+    {
+        // The invariant, both clauses, on a protein whose annotations are ordinary "Anywhere." ones.
+        const string sequence = "MAAALGGDRSMGVDTTPFAWENDRQITTLGGYK";
+        var index = new MassGroupIndex(new[] { OxidationOnM(), OxidationOnW(), HydroxylationOnP() });
+        var target = new Protein(sequence, "P12345",
+            oneBasedModifications: new Dictionary<int, List<Modification>>
+            {
+                { 11, new List<Modification> { OxidationOnM() } },   // the M in the middle piece
+                { 20, new List<Modification> { OxidationOnW() } },   // the W in the middle piece
+            });
+        Assert.That(sequence[10], Is.EqualTo('M'), "fixture: annotation 1 must sit on the M");
+        Assert.That(sequence[19], Is.EqualTo('W'), "fixture: annotation 2 must sit on the W");
+
+        Protein companion = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden,
+            out EntrapmentAssembly assembly);
+
+        var comparison = new MassGroupComparison(index);
+        comparison.Add(target, companion, assembly, Tryptic.MinLength);
+
+        Assert.That(comparison.PeptidesCompared, Is.GreaterThan(0), "the fixture must compare something");
+        MassGroupTally tally = comparison.Tallies.Single();
+        Assert.That(tally.TargetCapacity, Is.EqualTo(tally.CompanionCapacity));
+        Assert.That(tally.TargetAnnotatedSites, Is.EqualTo(tally.CompanionAnnotatedSites));
+        Assert.That(tally.TargetAnnotatedSites, Is.EqualTo(2), "both annotations must be counted");
+        Assert.That(tally.PeptidesWithCapacityMismatch, Is.Zero);
+        Assert.That(tally.PeptidesWithAnnotatedSiteMismatch, Is.Zero);
+        Assert.That(comparison.Holds, Is.True);
+    }
+
+    [Test]
+    public void APeptideTerminalAnnotationIsCountedOnlyWhereASearchCouldApplyIt()
+    {
+        // The case the whole section exists for, and the one a modification tally cannot see. The
+        // annotation is transported and written either way; what decides whether it is a hypothesis
+        // is whether it still sits at the peptide's first residue.
+        //
+        // With the piece-terminal anchor in place this passes; it is written against the SEARCH's
+        // view rather than the protein's so that it starts failing again the moment that anchor
+        // stops holding, which is the only way this class of defect is ever visible.
+        const string sequence = "MAAALGGDRSGGVDTTPFAWENDRQITTLGGYK";
+        var waterLoss = Mod("S", "Water Loss", -18.010565, "Peptide N-terminal.");
+        var index = new MassGroupIndex(new[] { waterLoss });
+        var target = new Protein(sequence, "P12345",
+            oneBasedModifications: new Dictionary<int, List<Modification>>
+            {
+                { 10, new List<Modification> { waterLoss } }
+            });
+        Assert.That(sequence[9], Is.EqualTo('S'), "fixture: the annotation opens an interior piece");
+
+        Protein companion = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden,
+            out EntrapmentAssembly assembly);
+
+        var comparison = new MassGroupComparison(index);
+        comparison.Add(target, companion, assembly, Tryptic.MinLength);
+
+        MassGroupTally tally = comparison.Tallies.Single();
+        Assert.That(tally.TargetAnnotatedSites, Is.EqualTo(1),
+            "the fixture must produce a usable target site, or it asserts nothing");
+        Assert.That(tally.CompanionAnnotatedSites, Is.EqualTo(1),
+            "the companion must offer the same hypothesis, not merely carry the same annotation");
+        Assert.That(tally.PeptidesWithAnnotatedSiteMismatch, Is.Zero);
+        Assert.That(comparison.Holds, Is.True);
+    }
+
+    [Test]
+    public void AnExcisedPeptideIsNotCountedAsAMatchOrAsAMismatch()
+    {
+        // A per-peptide equality is satisfied vacuously by a peptide that no longer exists, which is
+        // why the totals are published beside it. An excised piece has no companion to compare with,
+        // so it contributes to neither -- the achieved fold ratio is where that loss is reported.
+        const string sequence = "SYKALADQMNLLLSKSSSSSSRGGVDTTPFAWENDR";
+        var index = new MassGroupIndex(new[] { Mod("S", "Phosphorylation", 79.966331) });
+        var target = new Protein(sequence, "P12345");
+
+        Protein companion = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden,
+            out EntrapmentAssembly assembly);
+
+        Assert.That(assembly.ExcisedCount, Is.EqualTo(1), "fixture must actually excise a piece");
+        var comparison = new MassGroupComparison(index);
+        comparison.Add(target, companion, assembly, Tryptic.MinLength);
+
+        int searchable = assembly.Pieces.Count(p => p.Outcome != PieceOutcome.Excised
+                                                    && p.TargetPiece.Length >= Tryptic.MinLength);
+        Assert.That(comparison.PeptidesCompared, Is.EqualTo(searchable));
+        Assert.That(comparison.Holds, Is.True);
+    }
+
+    [Test]
+    public void TheDistributionIsReportedGroupByGroupEvenWhereNothingIsAnnotated()
+    {
+        // "This mass had no annotated site on either side" and "this mass was not looked at" are
+        // different statements, and only a row can tell them apart.
+        var index = new MassGroupIndex(new[]
+        {
+            OxidationOnM(), Mod("S", "Phosphorylation", 79.966331), Mod("K", "Acetylation", 42.010565)
+        });
+        var target = new Protein("MAAALGGDRSGGVDTTPFAWENDRQITTLGGYK", "P12345");
+        Protein companion = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden,
+            out EntrapmentAssembly assembly);
+
+        var comparison = new MassGroupComparison(index);
+        comparison.Add(target, companion, assembly, Tryptic.MinLength);
+        string tsv = comparison.ToTabSeparated();
+
+        Assert.That(comparison.Tallies.Count, Is.EqualTo(3));
+        Assert.That(tsv, Does.Contain("# massGroupToleranceDaltons\t0"));
+        Assert.That(tsv, Does.Contain("# invariantHolds\ttrue"));
+        Assert.That(tsv.Split('\n').Count(l => l.StartsWith("15.99")), Is.EqualTo(1));
+        Assert.That(tsv.Split('\n').Count(l => l.StartsWith("42.01")), Is.EqualTo(1));
+        Assert.That(tsv.Split('\n').Count(l => l.StartsWith("79.96")), Is.EqualTo(1));
+        Assert.That(comparison.Tallies.Select(t => t.Group.RepresentativeMass),
+            Is.Ordered, "rows ascend by mass so two reports can be diffed");
+    }
+
+    [Test]
+    public void TheComparisonRefusesIncompleteInput()
+    {
+        var index = new MassGroupIndex(new[] { OxidationOnM() });
+        var comparison = new MassGroupComparison(index);
+        var target = new Protein("MAAALGGDRSGGVDTTPFAWENDRQITTLGGYK", "P12345");
+        Protein companion = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden,
+            out EntrapmentAssembly assembly);
+
+        Assert.Throws<MzLibException>(() => comparison.Add(null, companion, assembly, 7));
+        Assert.Throws<MzLibException>(() => comparison.Add(target, null, assembly, 7));
+        Assert.Throws<MzLibException>(() => comparison.Add(target, companion, null, 7));
+        Assert.Throws<MzLibException>(() => new MassGroupComparison(null));
+    }
+}

--- a/mzLib/Test/DatabaseTests/TestEntrapmentPeptideGenerator.cs
+++ b/mzLib/Test/DatabaseTests/TestEntrapmentPeptideGenerator.cs
@@ -1,0 +1,197 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Numerics;
+using NUnit.Framework;
+using Omics.Digestion;
+using UsefulProteomicsDatabases.EntrapmentGeneration;
+
+namespace Test.DatabaseTests;
+
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class EntrapmentPeptideGeneratorTests
+{
+    private static List<DigestionMotif> Trypsin => DigestionMotif.ParseDigestionMotifsFromString("K|,R|");
+    private static readonly HashSet<string> NothingForbidden = new();
+
+    [Test]
+    public void Create_ReturnsAnIsomericPeptideThatIsNotTheTarget()
+    {
+        EntrapmentPeptide result = EntrapmentPeptideGenerator.Create("SYKALADQMNLLLSK", Trypsin, NothingForbidden);
+
+        Assert.That(result.Succeeded, Is.True);
+        Assert.That(result.Failure, Is.EqualTo(EntrapmentFailure.None));
+        Assert.That(result.EntrapmentSequence, Is.Not.EqualTo("SYKALADQMNLLLSK"));
+        Assert.That(string.Concat(result.EntrapmentSequence!.OrderBy(c => c)),
+            Is.EqualTo(string.Concat("SYKALADQMNLLLSK".OrderBy(c => c))),
+            "same residues in a different order -- same mass, same composition");
+    }
+
+    [Test]
+    public void Create_PreservesCandidateSiteCountAndCleavageSites()
+    {
+        // The property the glyco localization work depends on: the number of S/T in a peptide is
+        // the number of candidate sites, and comparing site calls at different n compares
+        // different difficulty. Composition preservation gives this for free -- assert it anyway.
+        const string target = "SYKALADQMNLLLSK";
+        EntrapmentPeptide result = EntrapmentPeptideGenerator.Create(target, Trypsin, NothingForbidden);
+
+        Assert.That(result.EntrapmentSequence!.Count(c => c is 'S' or 'T'),
+            Is.EqualTo(target.Count(c => c is 'S' or 'T')));
+        Assert.That(result.EntrapmentSequence[2], Is.EqualTo('K'));
+        Assert.That(result.EntrapmentSequence[14], Is.EqualTo('K'));
+    }
+
+    [Test]
+    public void Create_IsAPureFunctionOfSequenceAndSeed()
+    {
+        // No random state, so the answer cannot depend on how many peptides were processed first,
+        // on which protein this one came from, or on which thread ran it.
+        const string target = "SYKALADQMNLLLSK";
+        string first = EntrapmentPeptideGenerator.Create(target, Trypsin, NothingForbidden).EntrapmentSequence!;
+
+        for (int i = 0; i < 5; i++)
+        {
+            EntrapmentPeptideGenerator.Create("ACDEFGHIK", Trypsin, NothingForbidden);   // unrelated work
+        }
+
+        Assert.That(EntrapmentPeptideGenerator.Create(target, Trypsin, NothingForbidden).EntrapmentSequence,
+            Is.EqualTo(first));
+        Assert.That(EntrapmentPeptideGenerator.Create(target, Trypsin, NothingForbidden, seed: 2).EntrapmentSequence,
+            Is.Not.EqualTo(first), "a different seed must give a different answer");
+    }
+
+    [Test]
+    public void Create_ReportsNoPermutationExistsSeparatelyFromExhaustion()
+    {
+        // Two different failures that must never be merged into one "failed":
+        //   arithmetic -- a homopolymeric tract has exactly one arrangement, so no r helps;
+        //   exhaustion -- the space is real but every member of it is already spoken for.
+        EntrapmentPeptide homopolymer = EntrapmentPeptideGenerator.Create("SSSSSSR", Trypsin, NothingForbidden);
+        Assert.That(homopolymer.Succeeded, Is.False);
+        Assert.That(homopolymer.Failure, Is.EqualTo(EntrapmentFailure.NoPermutationExists));
+        Assert.That(homopolymer.PermutationSpaceSize, Is.EqualTo(BigInteger.One));
+
+        // Forbid the entire space of a small peptide, leaving exhaustion as the only outcome.
+        var everyPermutation = new HashSet<string>();
+        BigInteger size = UsefulProteomicsDatabases.DecoySequenceValidator.PermutationSpaceSize("QEEEKKK", Trypsin);
+        for (BigInteger i = BigInteger.Zero; i < size; i++)
+        {
+            everyPermutation.Add(UsefulProteomicsDatabases.DecoySequenceValidator
+                .UnrankPermutation("QEEEKKK", Trypsin, i, out _));
+        }
+
+        EntrapmentPeptide exhausted = EntrapmentPeptideGenerator.Create("QEEEKKK", Trypsin, everyPermutation);
+        Assert.That(exhausted.Succeeded, Is.False);
+        Assert.That(exhausted.Failure, Is.EqualTo(EntrapmentFailure.AllPermutationsTaken));
+        Assert.That(exhausted.PermutationSpaceSize, Is.GreaterThan(BigInteger.One),
+            "the space exists -- it is simply fully occupied");
+    }
+
+    [Test]
+    public void Create_ReportsWhenTheSpaceCannotSupplyTheRequestedFolds()
+    {
+        // "QEEEKKK" has four arrangements. Asking for nine folds is not exhaustion and not
+        // arithmetic impossibility -- it is a request the database cannot honour, and the caller's
+        // remedy (ask for fewer folds) differs from both.
+        EntrapmentPeptide result = EntrapmentPeptideGenerator.Create("QEEEKKK", Trypsin, NothingForbidden, fold: 8, foldCount: 9);
+
+        Assert.That(result.Succeeded, Is.False);
+        Assert.That(result.Failure, Is.EqualTo(EntrapmentFailure.SpaceTooSmallForFoldCount));
+    }
+
+    [Test]
+    public void Create_GivesMutuallyDistinctPeptidesForEachFold()
+    {
+        const string target = "SYKALADQMNLLLSK";
+        const int folds = 9;
+
+        var sequences = Enumerable.Range(0, folds)
+            .Select(k => EntrapmentPeptideGenerator.Create(target, Trypsin, NothingForbidden, fold: k, foldCount: folds))
+            .ToList();
+
+        Assert.That(sequences.All(s => s.Succeeded), Is.True);
+        Assert.That(sequences.Select(s => s.EntrapmentSequence).Distinct().Count(), Is.EqualTo(folds),
+            "r-fold entrapment needs r distinct partners, not r copies");
+        Assert.That(sequences.All(s => s.EntrapmentSequence != target), Is.True);
+    }
+
+    [Test]
+    public void Create_FoldsAreIndependentOfOneAnother()
+    {
+        // Fold 5 must be the same whether or not folds 0-4 were ever asked for, so a database can
+        // be extended or regenerated in pieces without invalidating what already exists.
+        const string target = "SYKALADQMNLLLSK";
+
+        string alone = EntrapmentPeptideGenerator
+            .Create(target, Trypsin, NothingForbidden, fold: 5, foldCount: 9).EntrapmentSequence!;
+
+        for (int k = 0; k < 5; k++)
+        {
+            EntrapmentPeptideGenerator.Create(target, Trypsin, NothingForbidden, fold: k, foldCount: 9);
+        }
+
+        Assert.That(EntrapmentPeptideGenerator
+            .Create(target, Trypsin, NothingForbidden, fold: 5, foldCount: 9).EntrapmentSequence,
+            Is.EqualTo(alone));
+    }
+
+    [Test]
+    public void Create_NeverReturnsAForbiddenSequence()
+    {
+        const string target = "ACDEFGHIK";
+        var forbidden = new HashSet<string>();
+
+        // Forbid the first few answers and confirm the generator walks past them.
+        for (int i = 0; i < 3; i++)
+        {
+            EntrapmentPeptide step = EntrapmentPeptideGenerator.Create(target, Trypsin, forbidden);
+            Assert.That(step.Succeeded, Is.True);
+            Assert.That(forbidden, Does.Not.Contain(step.EntrapmentSequence));
+            forbidden.Add(step.EntrapmentSequence!);
+        }
+
+        Assert.That(forbidden.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void Create_ReportsTheSpaceSizeAndHowHardItHadToLook()
+    {
+        EntrapmentPeptide easy = EntrapmentPeptideGenerator.Create("TTTPAPTTT", Trypsin, NothingForbidden);
+
+        Assert.That(easy.PermutationSpaceSize, Is.EqualTo(new BigInteger(252)));
+        Assert.That(easy.ProbesUsed, Is.EqualTo(1), "an unforbidden space should answer on the first probe");
+    }
+
+    // Each guard is asserted through its MESSAGE, not merely through the exception type. Several of
+    // these arguments are rejected by more than one guard, so a type-only assertion still passes
+    // when the guard under test is removed -- the message is what pins which one actually fired.
+    [Test]
+    public void Create_RejectsAnEmptySequence()
+    {
+        var thrown = Assert.Throws<MzLibUtil.MzLibException>(() =>
+            EntrapmentPeptideGenerator.Create("", Trypsin, NothingForbidden));
+        Assert.That(thrown!.Message, Does.Contain("empty"));
+    }
+
+    [Test]
+    public void Create_RejectsAFoldCountBelowOne()
+    {
+        var thrown = Assert.Throws<MzLibUtil.MzLibException>(() =>
+            EntrapmentPeptideGenerator.Create("ACDEFGHIK", Trypsin, NothingForbidden, fold: 0, foldCount: 0));
+        Assert.That(thrown!.Message, Does.Contain("Fold count").And.Contain("0"));
+    }
+
+    [Test]
+    public void Create_RejectsAFoldOutsideTheRequestedCount()
+    {
+        var tooHigh = Assert.Throws<MzLibUtil.MzLibException>(() =>
+            EntrapmentPeptideGenerator.Create("ACDEFGHIK", Trypsin, NothingForbidden, fold: 3, foldCount: 3));
+        Assert.That(tooHigh!.Message, Does.Contain("Fold 3").And.Contain("3 requested folds"));
+
+        var negative = Assert.Throws<MzLibUtil.MzLibException>(() =>
+            EntrapmentPeptideGenerator.Create("ACDEFGHIK", Trypsin, NothingForbidden, fold: -1));
+        Assert.That(negative!.Message, Does.Contain("Fold -1"));
+    }
+}

--- a/mzLib/Test/DatabaseTests/TestEntrapmentProtein.cs
+++ b/mzLib/Test/DatabaseTests/TestEntrapmentProtein.cs
@@ -936,4 +936,109 @@ public class EntrapmentProteinTests
         Assert.That(entrapment.UniProtSequenceAttributes.Mass, Is.EqualTo(targetMass));
     }
 
+    // ---- peptide-terminal modifications ------------------------------------
+    //
+    // A restriction that is satisfied per DIGESTION PRODUCT rather than once per entry, and the
+    // reason a piece's own termini are anchored. It is the quietest failure in this class: while a
+    // protein is being built, ModFits is called with the digestion-product index set to zero, so
+    // "Peptide N-terminal." falls through to "fits" and the annotation is transported and written.
+    // It is judged for real only at digestion. So the modification count in equals the count out,
+    // nothing is dropped, no counter moves -- and the entrapment peptide has silently lost a
+    // peptidoform hypothesis its target still has.
+    //
+    // These assert through DIGESTION for that reason. Asserting on the protein object passes
+    // whether or not the anchor exists, which is precisely how this went unnoticed.
+
+    /// <summary>Digestion products of <paramref name="protein"/> carrying <paramref name="id"/>.</summary>
+    private static int PeptidoformsCarrying(Protein protein, IDigestionParams digestion, string id)
+    {
+        var none = new List<Modification>();
+        return protein.Digest(digestion, none, none)
+            .Count(peptide => peptide.AllModsOneIsNterminus.Values.Any(m => m.IdWithMotif == id));
+    }
+
+    [Test]
+    public void Create_KeepsAPeptideNTerminalModificationUsableAfterDigestion()
+    {
+        // The modification sits on the first residue of an INTERIOR piece, which is where the
+        // protein-level anchors do not reach. Under trypsin the last residue of a piece is its
+        // cleavage residue and is pinned already, so the first is the exposed one -- measured at
+        // 69.00% of Arg-C pieces and 65.42% of Glu-C pieces moving it.
+        //
+        // The S is the only one in its piece on purpose. If the piece held several, the unranking
+        // could return an S to position 1 regardless and the test would pass without the anchor.
+        const string sequence = "MAAALGGDRSGGVDTTPFAWENDRQITTLGGYK";
+        var mod = TerminalMod("S", "Peptide N-terminal.", "Water Loss");
+        var target = new Protein(sequence, "P12345",
+            oneBasedModifications: new Dictionary<int, List<Modification>>
+            {
+                { 10, new List<Modification> { mod } }
+            });
+        Assert.That(sequence[9], Is.EqualTo('S'), "fixture: the annotation must sit on the S");
+
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        Assert.That(PeptidoformsCarrying(target, Tryptic, mod.IdWithMotif), Is.GreaterThan(0),
+            "fixture must actually produce a modified target peptidoform");
+        Assert.That(PeptidoformsCarrying(entrapment, Tryptic, mod.IdWithMotif),
+            Is.EqualTo(PeptidoformsCarrying(target, Tryptic, mod.IdWithMotif)),
+            "the companion must offer the same modified peptidoforms as its target");
+        Assert.That(entrapment.BaseSequence.Substring(9, 1), Is.EqualTo("S"),
+            "the annotated residue must still open its piece");
+    }
+
+    [Test]
+    public void APeptideCTerminalAnnotationNeverSurvivesProteinConstructionAtAll()
+    {
+        // The mirror case cannot be asserted through digestion, because mzLib never lets it get
+        // that far -- and that is worth pinning rather than working around.
+        //
+        // Protein construction validates annotations with ModFits called as
+        // ModFits(mod, sequence, digestionProductOneBasedIndex: 0, digestionProductLength: length, position),
+        // and the two peptide-level cases are not symmetric in the face of that zero:
+        //
+        //     "Peptide N-terminal." when digestionProductOneBasedIndex > 1    ->  0 > 1 is false, survives
+        //     "Peptide C-terminal." when digestionProductOneBasedIndex < length -> 0 < length is true, dropped
+        //
+        // So an XML "Peptide N-terminal." annotation is carried into the protein and judged later at
+        // digestion -- which is the silent failure the piece anchor exists for -- while a
+        // "Peptide C-terminal." one is discarded at construction and can never reach any peptide,
+        // target or entrapment. Anchoring a piece's last residue therefore buys nothing TODAY; it is
+        // done anyway because it is symmetric, because the measured cost is twenty pieces per
+        // proteome arm, and because the day that asymmetry is fixed the anchor is already right.
+        const string sequence = "MAAAGGKSTPFAWENRQDQISTLGGYKCDLLNGGVTTPWE";
+        var target = new Protein(sequence, "P12345",
+            oneBasedModifications: new Dictionary<int, List<Modification>>
+            {
+                { 28, new List<Modification> { TerminalMod("C", "Peptide C-terminal.", "Amidation") } }
+            });
+        Assert.That(sequence[27], Is.EqualTo('C'), "fixture: the annotation must sit on the C");
+
+        Assert.That(target.OneBasedPossibleLocalizedModifications, Is.Empty,
+            "if this ever holds the annotation, the C-terminal half of the anchor becomes testable "
+            + "through digestion and this test should be replaced by that one");
+    }
+
+    [Test]
+    public void Create_HoldsThePieceTerminiWhateverTheProteaseCutsBefore()
+    {
+        // Asp-N cleaves BEFORE D, so every piece opens on a pinned D and it is the LAST residue that
+        // is free -- the mirror of trypsin, where the last residue is the cleavage residue. Measured
+        // on the reviewed human proteome before this anchor: 72.68% of Asp-N pieces moved their last
+        // residue, against 0.00% of Arg-C and Glu-C pieces. Asserted structurally because the
+        // annotation route above is closed.
+        IDigestionParams aspN = new DigestionParams("Asp-N", minPeptideLength: 7, maxMissedCleavages: 0);
+        const string sequence = "MAAAGGKSTPFAWENRQDQISTLGGYKCDLLNGGVTTPWE";
+        var target = new Protein(sequence, "P12345");
+
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, aspN, NothingForbidden);
+
+        Assert.That(entrapment.BaseSequence, Is.Not.EqualTo(sequence), "it must actually rearrange");
+        Assert.That(entrapment.BaseSequence[27], Is.EqualTo('C'),
+            "the last residue of the middle piece must not move");
+        Assert.That(entrapment.BaseSequence[17], Is.EqualTo('D'),
+            "the cleavage residue opening that piece is pinned as before");
+        Assert.That(entrapment.BaseSequence[39], Is.EqualTo('E'),
+            "the protein's own C-terminus was already anchored and stays so");
+    }
 }

--- a/mzLib/Test/DatabaseTests/TestEntrapmentProtein.cs
+++ b/mzLib/Test/DatabaseTests/TestEntrapmentProtein.cs
@@ -1,0 +1,939 @@
+﻿using System;
+using System.Globalization;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using Omics.Digestion;
+using Omics.BioPolymer;
+using Omics.Modifications;
+using Proteomics;
+using Proteomics.ProteolyticDigestion;
+using UsefulProteomicsDatabases;
+using UsefulProteomicsDatabases.EntrapmentGeneration;
+
+namespace Test.DatabaseTests;
+
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class EntrapmentProteinTests
+{
+    private static readonly HashSet<string> NothingForbidden = new();
+    private const string Sequence = "SYKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK";
+
+    private static IDigestionParams Tryptic => new DigestionParams("trypsin", minPeptideLength: 7, maxMissedCleavages: 2);
+
+    private static Modification Phospho()
+    {
+        ModificationMotif.TryGetMotif("T", out ModificationMotif motif);
+        return new Modification(_originalId: "Phospho", _modificationType: "Common Biological",
+            _target: motif, _locationRestriction: "Anywhere.", _monoisotopicMass: 79.96633);
+    }
+
+    // ---- accession ---------------------------------------------------------
+
+    [Test]
+    public void Accession_PutsTheMarkerFirstSoTheLoaderFindsIt()
+    {
+        string accession = EntrapmentAccession.Format("P12345", fold: 0);
+
+        // Prefix, because ProteinDbLoader detects entrapment by looking for the identifier anywhere
+        // in the accession and prepends it when absent -- matching the convention means a written
+        // database reloads as entrapment with no extra argument, and is never double-prefixed.
+        Assert.That(accession, Does.StartWith(ProteinDbLoader.DefaultEntrapmentIdentifier));
+        Assert.That(accession, Does.Contain("P12345"));
+    }
+
+    [Test]
+    public void Accession_RoundTripsTheTargetAndFold()
+    {
+        for (int fold = 0; fold < 4; fold++)
+        {
+            string accession = EntrapmentAccession.Format("P12345", fold);
+            Assert.That(EntrapmentAccession.TryParse(accession, out string target, out int parsedFold), Is.True);
+            Assert.That(target, Is.EqualTo("P12345"));
+            Assert.That(parsedFold, Is.EqualTo(fold));
+        }
+    }
+
+    [Test]
+    public void Accession_RefusesSomethingThatIsNotAnEntrapmentAccession()
+    {
+        Assert.That(EntrapmentAccession.TryParse("P12345", out _, out _), Is.False);
+        Assert.That(EntrapmentAccession.TryParse("", out _, out _), Is.False);
+        Assert.That(EntrapmentAccession.TryParse(null, out _, out _), Is.False);
+    }
+
+    [Test]
+    public void Accession_SurvivesATargetAccessionContainingUnderscores()
+    {
+        // UniProt entry names always carry one, so splitting naively would lose the fold.
+        string accession = EntrapmentAccession.Format("SP_HUMAN_P12345", fold: 3);
+        Assert.That(EntrapmentAccession.TryParse(accession, out string target, out int fold), Is.True);
+        Assert.That(target, Is.EqualTo("SP_HUMAN_P12345"));
+        Assert.That(fold, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void Accession_RefusesToFormatSomethingUnusable()
+    {
+        var noTarget = Assert.Throws<MzLibUtil.MzLibException>(() => EntrapmentAccession.Format("", 0));
+        Assert.That(noTarget!.Message, Does.Contain("target accession"));
+
+        var negative = Assert.Throws<MzLibUtil.MzLibException>(() => EntrapmentAccession.Format("P12345", -1));
+        Assert.That(negative!.Message, Does.Contain("negative"));
+    }
+
+    [TestCase("Random_P12345", TestName = "Accession parse - no fold marker")]
+    [TestCase("Random_P12345_f", TestName = "Accession parse - fold marker with no digits")]
+    [TestCase("Random_P12345_fX", TestName = "Accession parse - fold that is not a number")]
+    [TestCase("Random_P12345_f-1", TestName = "Accession parse - negative fold")]
+    [TestCase("Random__f1", TestName = "Accession parse - empty target accession")]
+    [TestCase("Random_f1", TestName = "Accession parse - marker but nothing before the fold")]
+    public void Accession_RefusesMalformedInput(string accession)
+    {
+        Assert.That(EntrapmentAccession.TryParse(accession, out _, out _), Is.False);
+    }
+
+    // ---- protein generation ------------------------------------------------
+
+    [Test]
+    public void Create_MakesAnEntrapmentProteinIsomericWithItsTarget()
+    {
+        var target = new Protein(Sequence, "P12345");
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        Assert.That(entrapment.IsEntrapment, Is.True);
+        Assert.That(entrapment.BaseSequence, Is.Not.EqualTo(target.BaseSequence));
+        Assert.That(string.Concat(entrapment.BaseSequence.OrderBy(c => c)),
+            Is.EqualTo(string.Concat(target.BaseSequence.OrderBy(c => c))));
+        Assert.That(EntrapmentAccession.TryParse(entrapment.Accession, out string parsed, out _), Is.True);
+        Assert.That(parsed, Is.EqualTo("P12345"));
+    }
+
+    [Test]
+    public void Create_CarriesModificationsToTheResidueTheyWereOn()
+    {
+        Modification phospho = Phospho();
+        var mods = new Dictionary<int, List<Modification>>();
+        for (int oneBased = 1; oneBased <= Sequence.Length; oneBased++)
+        {
+            if (Sequence[oneBased - 1] == 'T')
+            {
+                mods[oneBased] = new List<Modification> { phospho };
+            }
+        }
+        Assert.That(mods, Is.Not.Empty, "the fixture must actually carry modifications");
+
+        var target = new Protein(Sequence, "P12345", oneBasedModifications: mods);
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        Assert.That(entrapment.OneBasedPossibleLocalizedModifications.Count, Is.EqualTo(mods.Count),
+            "every modification on a retained residue must survive the move");
+        foreach (int position in entrapment.OneBasedPossibleLocalizedModifications.Keys)
+        {
+            Assert.That(entrapment.BaseSequence[position - 1], Is.EqualTo('T'),
+                "a modification must land on the residue its motif requires");
+        }
+    }
+
+    [Test]
+    public void Create_DropsModificationsOnExcisedResidues()
+    {
+        // "SSSSSSR" has no partner and is long enough to be identified, so it is excised -- and any
+        // modification sitting on it goes with it rather than landing somewhere arbitrary.
+        const string withHomopolymer = "SYKALADQMNLLLSKSSSSSSRGGVDTTPFAWENDR";
+        ModificationMotif.TryGetMotif("S", out ModificationMotif motif);
+        var onExcisedTract = new Modification(_originalId: "Phospho", _modificationType: "Common Biological",
+            _target: motif, _locationRestriction: "Anywhere.", _monoisotopicMass: 79.96633);
+
+        var target = new Protein(withHomopolymer, "P12345", oneBasedModifications:
+            new Dictionary<int, List<Modification>> { { 17, new List<Modification> { onExcisedTract } } });
+
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        Assert.That(entrapment.BaseSequence, Does.Not.Contain("SSSSSSR"));
+        Assert.That(entrapment.OneBasedPossibleLocalizedModifications, Is.Empty);
+    }
+
+    [Test]
+    public void Create_GivesEachFoldItsOwnAccessionAndSequence()
+    {
+        var target = new Protein(Sequence, "P12345");
+
+        var entrapments = Enumerable.Range(0, 4)
+            .Select(k => EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden, fold: k, foldCount: 4))
+            .ToList();
+
+        Assert.That(entrapments.Select(p => p.Accession).Distinct().Count(), Is.EqualTo(4));
+        Assert.That(entrapments.Select(p => p.BaseSequence).Distinct().Count(), Is.EqualTo(4));
+    }
+
+    [Test]
+    public void Create_RefusesANullTarget()
+    {
+        var thrown = Assert.Throws<MzLibUtil.MzLibException>(() =>
+            EntrapmentProteinGenerator.Create(null, Tryptic, NothingForbidden));
+        Assert.That(thrown!.Message, Does.Contain("null target"));
+    }
+
+    [Test]
+    public void Create_HandlesAProteinCarryingNoModifications()
+    {
+        var target = new Protein(Sequence, "P12345");
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+        Assert.That(entrapment.OneBasedPossibleLocalizedModifications, Is.Empty);
+    }
+
+    [Test]
+    public void Create_KeepsAModificationThatLandsOnTheVeryFirstResidue()
+    {
+        // Position zero is a real destination, not a "missing" marker -- only a negative means
+        // excised. Conflating them would silently drop a modification whenever its residue moved to
+        // the front. "AK" is below the minimum length and has no rearrangement, so it is kept
+        // verbatim with an identity map: its first residue is GUARANTEED to land at position zero,
+        // which an ordinary rearranged piece would only reach by luck.
+        ModificationMotif.TryGetMotif("A", out ModificationMotif motif);
+        var onFirstResidue = new Modification(_originalId: "Acetyl", _modificationType: "Common Biological",
+            _target: motif, _locationRestriction: "Anywhere.", _monoisotopicMass: 42.010565);
+
+        var target = new Protein("AKGGVDTTPFAWENDRQISTLGGYK", "P12345", oneBasedModifications:
+            new Dictionary<int, List<Modification>> { { 1, new List<Modification> { onFirstResidue } } });
+
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden,
+            out EntrapmentAssembly assembly);
+
+        Assert.That(assembly.TargetToEntrapmentPosition[0], Is.Zero, "the fixture must exercise position zero");
+        Assert.That(entrapment.OneBasedPossibleLocalizedModifications.ContainsKey(1), Is.True,
+            "a modification landing at position zero must survive");
+        Assert.That(entrapment.BaseSequence[0], Is.EqualTo('A'));
+    }
+
+    [Test]
+    public void Create_DropsPositionalAnnotationsThatTheRearrangementInvalidates()
+    {
+        // Sequence variations, truncation products, disulfide bonds and splice sites all describe
+        // the TARGET's sequence. Once the residues move they mean nothing, and once excision
+        // shortens the protein a coordinate can point PAST ITS END -- MetaMorpheus applies sequence
+        // variations while loading a database, indexes with that coordinate and throws. Measured on
+        // the human proteome: 131 entrapment entries carried a feature position beyond their own
+        // length, and every search against that database failed to load it.
+        var target = new Protein("SYKALADQMNLLLSKSSSSSSRGGVDTTPFAWENDR", "P12345",
+            proteolysisProducts: new List<TruncationProduct> { new(1, 36, "full-length") },
+            disulfideBonds: new List<DisulfideBond> { new(3, 30, "bond") },
+            spliceSites: new List<SpliceSite> { new(5, 9, "site") });
+
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        Assert.That(entrapment.TruncationProducts, Is.Empty);
+        Assert.That(entrapment.DisulfideBonds, Is.Empty);
+        Assert.That(entrapment.SpliceSites, Is.Empty);
+        Assert.That(entrapment.SequenceVariations, Is.Empty);
+        Assert.That(entrapment.AppliedSequenceVariations, Is.Empty);
+
+        // The target keeps everything -- we copy, we do not mutate.
+        Assert.That(target.TruncationProducts, Is.Not.Empty);
+        Assert.That(target.DisulfideBonds, Is.Not.Empty);
+    }
+
+    [Test]
+    public void Create_NeverLeavesAnAnnotationPointingPastTheSequence()
+    {
+        // The failure mode directly: the fixture excises SSSSSSR, so the entrapment protein is
+        // seven residues shorter than the annotations that described its target.
+        // Carries a modification so the range assertion at the end has something to bite on. Without
+        // one, every collection feeding `everyPosition` is empty -- the four above are asserted so --
+        // and `Is.All` over nothing passes whatever the fix does.
+        ModificationMotif.TryGetMotif("T", out ModificationMotif tMotif);
+        var onThreonine = new Modification(_originalId: "Phospho", _modificationType: "Common Biological",
+            _target: tMotif, _locationRestriction: "Anywhere.", _monoisotopicMass: 79.96633);
+
+        var target = new Protein("SYKALADQMNLLLSKSSSSSSRGGVDTTPFAWENDR", "P12345",
+            proteolysisProducts: new List<TruncationProduct> { new(30, 36, "C-terminal chunk") },
+            oneBasedModifications: new Dictionary<int, List<Modification>>
+            {
+                { 27, new List<Modification> { onThreonine } },
+                { 28, new List<Modification> { onThreonine } },
+            });
+
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        Assert.That(entrapment.BaseSequence.Length, Is.LessThan(target.BaseSequence.Length));
+
+        // Assert the contract directly rather than looping a collection the fix empties. The old
+        // form iterated TruncationProducts asserting each end position was in range, and this path
+        // clears that collection -- so the loop body never ran and the only live assertion was that
+        // the sequence got shorter. A test named for the fix could not observe it.
+        Assert.That(entrapment.TruncationProducts, Is.Empty,
+            "positional annotations describe the target's coordinates and are dropped, not remapped");
+        Assert.That(entrapment.SequenceVariations, Is.Empty);
+        Assert.That(entrapment.DisulfideBonds, Is.Empty);
+        Assert.That(entrapment.SpliceSites, Is.Empty);
+
+        // And the property that mattered, stated over everything the entry actually carries.
+        List<int> everyPosition = entrapment.TruncationProducts
+            .Where(t => t.OneBasedEndPosition.HasValue).Select(t => t.OneBasedEndPosition.Value)
+            .Concat(entrapment.DisulfideBonds.Select(b => b.OneBasedEndPosition))
+            .Concat(entrapment.SpliceSites.Select(x => x.OneBasedEndPosition))
+            .Concat(entrapment.OneBasedPossibleLocalizedModifications.Keys)
+            .ToList();
+        Assert.That(everyPosition, Is.Not.Empty,
+            "otherwise Is.All below asserts over an empty sequence and cannot fail");
+        Assert.That(everyPosition, Is.All.LessThanOrEqualTo(entrapment.BaseSequence.Length));
+    }
+
+    // ---- terminal modifications --------------------------------------------
+
+    private static Modification TerminalMod(string motifResidue, string restriction, string id) 
+    {
+        ModificationMotif.TryGetMotif(motifResidue, out ModificationMotif motif);
+        return new Modification(_originalId: id, _modificationType: "Common Biological",
+            _target: motif, _locationRestriction: restriction, _monoisotopicMass: 42.010565);
+    }
+
+    [Test]
+    public void Create_KeepsAModificationRestrictedToTheProteinNTerminus()
+    {
+        // A rearrangement that moved this residue off the terminus would make the modification
+        // invalid for its location, and mzLib would drop it -- silently. Measured before anchoring:
+        // 3,946 N-terminal modifications lost across the human proteome, 2.4% of all of them.
+        var target = new Protein("MAAALGGDRKGGVDTTPFAWENDRQISTLGGYK", "P12345",
+            oneBasedModifications: new Dictionary<int, List<Modification>>
+            {
+                { 1, new List<Modification> { TerminalMod("M", "N-terminal.", "N-acetylmethionine") } }
+            });
+
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        Assert.That(entrapment.OneBasedPossibleLocalizedModifications.ContainsKey(1), Is.True,
+            "an N-terminally restricted modification must still be at position 1");
+        Assert.That(entrapment.BaseSequence[0], Is.EqualTo('M'));
+    }
+
+    [Test]
+    public void Create_KeepsAModificationOnTheSecondResidue()
+    {
+        // Position 2 matters as much as position 1: a modification annotated after initiator
+        // methionine cleavage lands on the second residue. Both are anchored.
+        //
+        // The second residue must not be one of a run of identical residues, or the test passes
+        // whether or not anchoring works -- with "MAAA..." the unranking returns an A to slot 1
+        // anyway and the assertion cannot fail. Here the S is the only one in its piece, so it stays
+        // at position 2 only because it is held there.
+        var target = new Protein("MSAALGGDRKGGVDTTPFAWENDRQIATLGGYK", "P12345",
+            oneBasedModifications: new Dictionary<int, List<Modification>>
+            {
+                { 2, new List<Modification> { TerminalMod("S", "N-terminal.", "N-acetylserine") } }
+            });
+
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        Assert.That(entrapment.OneBasedPossibleLocalizedModifications.ContainsKey(2), Is.True);
+        Assert.That(entrapment.BaseSequence[1], Is.EqualTo('S'));
+        Assert.That(entrapment.BaseSequence.Count(c => c == 'S'), Is.EqualTo(1),
+            "the fixture only discriminates while its second residue is unique in the sequence");
+    }
+
+    [Test]
+    public void Create_KeepsAModificationRestrictedToTheProteinCTerminus()
+    {
+        const string sequence = "MAAALGGDRKGGVDTTPFAWENDRQISTLGGYA";
+        var target = new Protein(sequence, "P12345",
+            oneBasedModifications: new Dictionary<int, List<Modification>>
+            {
+                { sequence.Length, new List<Modification> { TerminalMod("A", "C-terminal.", "Amidation") } }
+            });
+
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        Assert.That(entrapment.OneBasedPossibleLocalizedModifications.ContainsKey(entrapment.BaseSequence.Length),
+            Is.True, "a C-terminally restricted modification must still be at the last position");
+        Assert.That(entrapment.BaseSequence[^1], Is.EqualTo('A'));
+    }
+
+    [Test]
+    public void Create_ConservesTheModificationCountWhenTerminalModificationsArePresent()
+    {
+        // The assertion the plan asks for by name: not "the shortfall is reported", but conserved.
+        const string sequence = "MAAALGGDRKGGVDTTPFAWENDRQISTLGGYK";
+        var target = new Protein(sequence, "P12345",
+            oneBasedModifications: new Dictionary<int, List<Modification>>
+            {
+                { 1, new List<Modification> { TerminalMod("M", "N-terminal.", "N-acetylmethionine") } },
+                { 2, new List<Modification> { TerminalMod("A", "N-terminal.", "N-acetylalanine") } },
+                { 18, new List<Modification> { Phospho() } }
+            });
+        int before = target.OneBasedPossibleLocalizedModifications.Sum(kv => kv.Value.Count);
+
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        Assert.That(entrapment.OneBasedPossibleLocalizedModifications.Sum(kv => kv.Value.Count),
+            Is.EqualTo(before), "no modification may be lost when none of them sits on an excised residue");
+    }
+
+    [Test]
+    public void Create_AnchorsTheTerminiWhetherOrNotAnythingIsModified()
+    {
+        // Anchoring is unconditional. Pinning only where a terminal modification happens to sit
+        // would make the entrapment sequence a function of the annotations as well as the residues,
+        // so two databases over the same proteome with different annotations would disagree on
+        // their sequences -- and the determinism the pairing rests on would quietly weaken.
+        const string sequence = "MAAALGGDRKGGVDTTPFAWENDRQISTLGGYK";
+        Protein bare = EntrapmentProteinGenerator.Create(new Protein(sequence, "P1"), Tryptic, NothingForbidden);
+        Protein annotated = EntrapmentProteinGenerator.Create(
+            new Protein(sequence, "P1", oneBasedModifications: new Dictionary<int, List<Modification>>
+            {
+                { 1, new List<Modification> { TerminalMod("M", "N-terminal.", "N-acetylmethionine") } }
+            }), Tryptic, NothingForbidden);
+
+        Assert.That(annotated.BaseSequence, Is.EqualTo(bare.BaseSequence),
+            "the sequence must not depend on whether the protein carried a terminal modification");
+        Assert.That(bare.BaseSequence[0], Is.EqualTo('M'));
+        Assert.That(bare.BaseSequence[1], Is.EqualTo('A'));
+        Assert.That(bare.BaseSequence[^1], Is.EqualTo(sequence[^1]));
+    }
+
+    [Test]
+    public void Create_AnchorsBothEndsOfASingleBasePieceProtein()
+    {
+        // A protein with no internal cleavage site is its own first AND last piece, so both
+        // anchoring branches fire at once. Nothing else in the fixtures exercises that.
+        const string sequence = "MAAALGGDQISTLGGYA";   // no K or R -- one piece
+        var target = new Protein(sequence, "P12345",
+            oneBasedModifications: new Dictionary<int, List<Modification>>
+            {
+                { 1, new List<Modification> { TerminalMod("M", "N-terminal.", "N-acetylmethionine") } },
+                { sequence.Length, new List<Modification> { TerminalMod("A", "C-terminal.", "Amidation") } }
+            });
+
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden,
+            out EntrapmentAssembly assembly);
+
+        Assert.That(assembly.Pieces.Count, Is.EqualTo(1), "the fixture must actually be a single piece");
+        Assert.That(entrapment.BaseSequence[0], Is.EqualTo('M'));
+        Assert.That(entrapment.BaseSequence[1], Is.EqualTo('A'));
+        Assert.That(entrapment.BaseSequence[^1], Is.EqualTo('A'));
+        Assert.That(entrapment.BaseSequence, Is.Not.EqualTo(sequence), "the interior must still move");
+        Assert.That(entrapment.OneBasedPossibleLocalizedModifications.Sum(kv => kv.Value.Count),
+            Is.EqualTo(2), "both terminal modifications must survive");
+    }
+
+    [Test]
+    public void Create_AnchoringActuallyShrinksThePermutationSpace()
+    {
+        // If anchoring silently did nothing, every test above could still pass by luck on a short
+        // fixture. Hold the termini and the space must be strictly smaller.
+        var motifs = global::Omics.Digestion.DigestionMotif.ParseDigestionMotifsFromString("K|,R|");
+        const string piece = "MAAALGGDQISTLGGYA";
+
+        var free = global::UsefulProteomicsDatabases.DecoySequenceValidator.PermutationSpaceSize(piece, motifs);
+        var held = global::UsefulProteomicsDatabases.DecoySequenceValidator.PermutationSpaceSize(piece, motifs,
+            new[] { 0, 1, piece.Length - 1 });
+
+        Assert.That(held, Is.LessThan(free));
+        Assert.That(held, Is.GreaterThan(System.Numerics.BigInteger.One));
+    }
+
+    // ---- pairing -----------------------------------------------------------
+
+    [Test]
+    public void Pairing_RecoversTheTargetPeptideFromCompositionAlone()
+    {
+        var target = new Protein(Sequence, "P12345");
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        var pairing = new EntrapmentPairing(target, Tryptic);
+
+        foreach (var peptide in entrapment.Digest(Tryptic, new List<Modification>(), new List<Modification>()))
+        {
+            string entrapmentPeptide = peptide.BaseSequence;
+            Assert.That(pairing.TryResolve(entrapmentPeptide, out string targetPeptide), Is.True,
+                "'" + entrapmentPeptide + "' should resolve to the target peptide it was built from");
+            Assert.That(string.Concat(targetPeptide.OrderBy(c => c)),
+                Is.EqualTo(string.Concat(entrapmentPeptide.OrderBy(c => c))));
+        }
+    }
+
+    [Test]
+    public void Pairing_NeedsNoSideFileBeyondTheTargetDatabase()
+    {
+        // The whole point of pairing on composition: a search reports a protein accession and a
+        // peptide sequence, and that is enough. Nothing has to be carried alongside the database.
+        var target = new Protein(Sequence, "P12345");
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        Assert.That(EntrapmentAccession.TryParse(entrapment.Accession, out string targetAccession, out _), Is.True);
+        Assert.That(targetAccession, Is.EqualTo(target.Accession));
+
+        var pairing = new EntrapmentPairing(target, Tryptic);
+        string first = entrapment.Digest(Tryptic, new List<Modification>(), new List<Modification>())
+            .First().BaseSequence;
+        Assert.That(pairing.TryResolve(first, out _), Is.True);
+    }
+
+    [Test]
+    public void Pairing_FlagsPeptidesOfIdenticalCompositionAsAmbiguous()
+    {
+        // P57071 really does contain LIHTGVK and LIHTVGK: same residues, same pinned K, different
+        // order. Composition cannot tell them apart, so neither is paired -- they are reported.
+        var target = new Protein("LIHTGVKAAADEFGHIKLIHTVGKMMWWYYPPQQR", "P57071");
+        var pairing = new EntrapmentPairing(target, Tryptic);
+
+        Assert.That(pairing.AmbiguousPeptides, Does.Contain("LIHTGVK"));
+        Assert.That(pairing.AmbiguousPeptides, Does.Contain("LIHTVGK"));
+        Assert.That(pairing.TryResolve("LIHTVGK", out _), Is.False,
+            "an ambiguous key must refuse to guess");
+    }
+
+    [Test]
+    public void Pairing_RefusesANullTarget()
+    {
+        var thrown = Assert.Throws<MzLibUtil.MzLibException>(() => new EntrapmentPairing(null, Tryptic));
+        Assert.That(thrown!.Message, Does.Contain("target protein"));
+    }
+
+    [Test]
+    public void Pairing_RefusesAPeptideItHasNeverSeen()
+    {
+        var pairing = new EntrapmentPairing(new Protein(Sequence, "P12345"), Tryptic);
+        Assert.That(pairing.TryResolve("WWWWWWWW", out _), Is.False);
+        Assert.That(pairing.TryResolve("", out _), Is.False);
+    }
+
+    // ---- round trip --------------------------------------------------------
+
+    [Test]
+    public void EntrapmentProtein_ReloadsAsEntrapmentFromXml()
+    {
+        var target = new Protein(Sequence, "P12345");
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "entrapment_roundtrip.xml");
+        ProteinDbWriter.WriteXmlDatabase(new Dictionary<string, HashSet<Tuple<int, Modification>>>(),
+            new List<Protein> { target, entrapment }, path);
+
+        List<Protein> reloaded = ProteinDbLoader.LoadProteinXML(path, true, DecoyType.None,
+            new List<Modification>(), false, new List<string>(), out _);
+
+        Protein reloadedEntrapment = reloaded.Single(p => p.Accession != "P12345");
+        Assert.That(reloadedEntrapment.IsEntrapment, Is.True,
+            "the accession alone must be enough for the loader to know this is entrapment");
+        Assert.That(reloadedEntrapment.BaseSequence, Is.EqualTo(entrapment.BaseSequence));
+        Assert.That(EntrapmentAccession.TryParse(reloadedEntrapment.Accession, out string parsed, out _), Is.True);
+        Assert.That(parsed, Is.EqualTo("P12345"));
+
+        File.Delete(path);
+    }
+
+    [Test]
+    public void EntrapmentProtein_PairingSurvivesTheRoundTrip()
+    {
+        var target = new Protein(Sequence, "P12345");
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "entrapment_pairing.xml");
+        ProteinDbWriter.WriteXmlDatabase(new Dictionary<string, HashSet<Tuple<int, Modification>>>(),
+            new List<Protein> { target, entrapment }, path);
+        List<Protein> reloaded = ProteinDbLoader.LoadProteinXML(path, true, DecoyType.None,
+            new List<Modification>(), false, new List<string>(), out _);
+
+        Protein reloadedTarget = reloaded.Single(p => p.Accession == "P12345");
+        Protein reloadedEntrapment = reloaded.Single(p => p.Accession != "P12345");
+
+        // Write, read, digest, pair -- with nothing carried alongside the file.
+        var pairing = new EntrapmentPairing(reloadedTarget, Tryptic);
+        foreach (var peptide in reloadedEntrapment.Digest(Tryptic, new List<Modification>(), new List<Modification>()))
+        {
+            Assert.That(pairing.TryResolve(peptide.BaseSequence, out string targetPeptide), Is.True);
+            Assert.That(string.Concat(targetPeptide.OrderBy(c => c)),
+                Is.EqualTo(string.Concat(peptide.BaseSequence.OrderBy(c => c))));
+        }
+
+        File.Delete(path);
+    }
+
+    /// <summary>
+    /// A protein carrying sequence variants, expanded the way LoadProteinXML expands one: several
+    /// proteins sharing a single consensus. This is the shape a real XML database has, and the
+    /// shape a FASTA database never has -- which is why the defect below only ever showed on the
+    /// XML arm.
+    /// </summary>
+    private static List<Protein> ExpandedVariantProteins()
+    {
+        var insertion = new SequenceVariation(5, 5, "A", "AAA", "Insertion at 5");
+        var substitution = new SequenceVariation(10, 10, "G", "R", "Substitution at 10");
+        var consensus = new Protein("MAAAAGAAAAGKPEPTIDESAMPLERTESTPEPTIDEK", "P00001",
+            sequenceVariations: new List<SequenceVariation> { insertion, substitution });
+
+        return VariantApplication
+            .ApplyAllVariantCombinations(consensus, new List<SequenceVariation> { insertion, substitution },
+                maxCombinations: 10)
+            .Cast<Protein>()
+            .ToList();
+    }
+
+    [Test]
+    public void ExpandedVariantsShareOneConsensus()
+    {
+        // Guard on the fixture itself. A fixture that quietly stopped expanding would make every
+        // assertion below pass without exercising anything -- which is how a previous test in this
+        // suite came to cover a case it never reached.
+        List<Protein> targets = ExpandedVariantProteins();
+
+        Assert.That(targets.Count, Is.GreaterThan(1),
+            "fixture must expand into several proteins, or it does not exercise the case");
+        Assert.That(targets.Select(p => p.ConsensusVariant).Distinct().Count(), Is.EqualTo(1),
+            "the expanded proteins must share a single consensus");
+    }
+
+    [Test]
+    public void OneEntrapmentProteinPerEntryNotPerAppliedVariant()
+    {
+        List<Protein> targets = ExpandedVariantProteins();
+
+        List<Protein> entrapment = EntrapmentProteinGenerator.GenerateEntrapment(
+            targets, Tryptic, NothingForbidden);
+
+        // One per database ENTRY. The target list holds several proteins but the database holds one
+        // entry, because variants are annotations on a consensus rather than entries of their own.
+        Assert.That(entrapment.Count, Is.EqualTo(1));
+        Assert.That(entrapment[0].IsEntrapment, Is.True);
+        Assert.That(entrapment[0].Accession, Is.EqualTo("Random_P00001_f0"),
+            "the accession must name the consensus, not an applied variant");
+    }
+
+    [Test]
+    public void EntrapmentEntriesEqualTargetEntriesInTheWrittenDatabase()
+    {
+        // The assertion that matters, and the one no earlier test made: count what survives the
+        // WRITE. Everything the suite asserted about entrapment proteins was true of the in-memory
+        // list and still produced a database with 2.56 entrapment entries per target, because
+        // ProteinDbWriter persists one entry per consensus and entrapment proteins are each their
+        // own consensus.
+        List<Protein> targets = ExpandedVariantProteins();
+        List<Protein> entrapment = EntrapmentProteinGenerator.GenerateEntrapment(
+            targets, Tryptic, NothingForbidden);
+
+        string path = Path.Combine(TestContext.CurrentContext.TestDirectory,
+            "entrapment_entry_parity.xml");
+        ProteinDbWriter.WriteXmlDatabase(null, targets.Concat(entrapment).ToList(), path);
+
+        string written = File.ReadAllText(path);
+        int entries = System.Text.RegularExpressions.Regex.Matches(written, "<entry ").Count;
+        int entrapmentEntries = System.Text.RegularExpressions.Regex
+            .Matches(written, "<accession>Random_").Count;
+
+        Assert.That(entries, Is.EqualTo(2), "one target entry and one entrapment entry");
+        Assert.That(entrapmentEntries, Is.EqualTo(1));
+        Assert.That(entries - entrapmentEntries, Is.EqualTo(entrapmentEntries),
+            "the database must hold one entrapment entry per target entry");
+
+        File.Delete(path);
+    }
+
+    [Test]
+    public void EveryFoldGetsOneEntryPerTarget()
+    {
+        List<Protein> targets = ExpandedVariantProteins();
+
+        List<Protein> entrapment = EntrapmentProteinGenerator.GenerateEntrapment(
+            targets, Tryptic, NothingForbidden, foldCount: 3);
+
+        Assert.That(entrapment.Count, Is.EqualTo(3));
+        Assert.That(entrapment.Select(p => p.Accession).ToList(),
+            Is.EquivalentTo(new[] { "Random_P00001_f0", "Random_P00001_f1", "Random_P00001_f2" }));
+    }
+
+    [Test]
+    public void AFastaStyleListWithNoVariantsIsUnchangedByTheEntryRule()
+    {
+        // The FASTA path was always correct, and must stay that way: no consensus sharing, so every
+        // protein is its own entry and every one gets a partner.
+        var targets = new List<Protein>
+        {
+            new Protein(Sequence, "P00001"),
+            new Protein(Sequence, "P00002"),
+        };
+
+        List<Protein> entrapment = EntrapmentProteinGenerator.GenerateEntrapment(
+            targets, Tryptic, NothingForbidden);
+
+        Assert.That(entrapment.Count, Is.EqualTo(2));
+        Assert.That(entrapment.Select(p => p.Accession).ToList(),
+            Is.EquivalentTo(new[] { "Random_P00001_f0", "Random_P00002_f0" }));
+    }
+
+    private const string ForeignSequence = "MQVLGYTTPDNRAWEDSFLGKQPTMLNDVAHER";
+
+    [Test]
+    public void GenerateEntrapmentCanReportEveryAssemblyAsItGoes()
+    {
+        // One loop rather than two. A caller building a QC report used to walk DatabaseEntries and
+        // call Create itself, and those two loops had to agree about folds and about what an entry
+        // is -- until one compared its partner count against the loaded protein count instead of the
+        // entry count and failed silently for a day.
+        var targets = new List<Protein>
+        {
+            new Protein(Sequence, "P00001"),
+            new Protein("M" + new string('Q', 79), "Q156A1"),   // contributes no partner at all
+        };
+
+        var seen = new List<(string Accession, int Fold, bool Produced)>();
+        List<Protein> entrapment = EntrapmentProteinGenerator.GenerateEntrapment(
+            targets, Tryptic, NothingForbidden,
+            (entry, fold, assembly) => seen.Add((entry.Accession, fold, assembly.EntrapmentSequence.Length > 0)),
+            foldCount: 2);
+
+        Assert.That(seen.Select(x => x.Accession), Is.EquivalentTo(
+            new[] { "P00001", "P00001", "Q156A1", "Q156A1" }), "every entry, every fold");
+        Assert.That(seen.Where(x => x.Accession == "P00001").Select(x => x.Fold),
+            Is.EquivalentTo(new[] { 0, 1 }));
+        Assert.That(seen.Single(x => x.Accession == "Q156A1" && x.Fold == 0).Produced, Is.False,
+            "an entry that contributes nothing is still reported -- that is what a ratio needs");
+        Assert.That(entrapment, Has.Count.EqualTo(2), "and it is still absent from the output");
+    }
+
+    [Test]
+    public void ANegativeSeedGivesTheSameDatabaseWhateverTheCulture()
+    {
+        // Interpolating the seed formats it through the current culture, and a negative one renders
+        // its sign as U+002D under en-US but U+2212 MINUS SIGN under sv-SE, fi-FI and lt-LT --
+        // different bytes into SHA-256, so the same request produced a different database on a
+        // differently-configured machine. The reproducibility this construction exists for has to
+        // survive a culture change, not only a process restart.
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+            string invariant = EntrapmentAssembler
+                .Assemble(Sequence, Tryptic, NothingForbidden, seed: -7).EntrapmentSequence;
+
+            foreach (string culture in new[] { "sv-SE", "fi-FI", "lt-LT" })
+            {
+                CultureInfo.CurrentCulture = new CultureInfo(culture);
+                Assert.That(EntrapmentAssembler.Assemble(Sequence, Tryptic, NothingForbidden, seed: -7)
+                    .EntrapmentSequence, Is.EqualTo(invariant), culture);
+            }
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Test]
+    public void AnAgentWhoseSitesCannotBeHeldIsRefused()
+    {
+        // trypsin|P's K[P]| pins nothing: CleavageSitePositions skips a position where a motif fits
+        // but is prevented, so a rearrangement can move that P away and invent a cleavage site the
+        // target lacked. Five shipped agents carry preventing motifs. Refusing is the honest answer
+        // until pinning works across piece boundaries -- a database that digests differently from
+        // its target produces peptides that fail to pair, and it does so silently.
+        var preventing = new DigestionParams("trypsin|P", minPeptideLength: 7, maxMissedCleavages: 2);
+
+        var ex = Assert.Throws<MzLibUtil.MzLibException>(() =>
+            EntrapmentAssembler.Assemble(Sequence, preventing, NothingForbidden));
+        Assert.That(ex.Message, Does.Contain("preventing-cleavage motif"));
+    }
+
+    [Test]
+    public void AMultiResidueAgentIsRefused()
+    {
+        // StcE's TX|T spans three residues and is cut by the piece boundary, so one piece ends "TX"
+        // and the next begins "T" -- neither fragment matches inside its own piece and nothing is
+        // held at the seam.
+        var multiResidue = new DigestionParams("StcE-trypsin", minPeptideLength: 7, maxMissedCleavages: 2);
+
+        var ex = Assert.Throws<MzLibUtil.MzLibException>(() =>
+            EntrapmentAssembler.Assemble(Sequence, multiResidue, NothingForbidden));
+        Assert.That(ex.Message, Does.Contain("multi-residue motif"));
+    }
+
+    [Test]
+    public void AProteinWhoseEveryPieceIsExcisedIsNotEmitted()
+    {
+        // Q156A1 is the real case: a methionine followed by 79 glutamines. Its single base piece has
+        // exactly one arrangement once the termini are anchored, so it is excised and nothing
+        // remains. Writing an empty-sequence protein makes a loader warn and discard it -- and its
+        // decoy with it -- leaving a database whose entrapment count is quietly short of its target
+        // count, which is exactly how the off-by-one at entry level was noticed.
+        var homopolymer = new Protein("M" + new string('Q', 79), "Q156A1");
+        var ordinary = new Protein(Sequence, "P00001");
+
+        List<Protein> entrapment = EntrapmentProteinGenerator.GenerateEntrapment(
+            new[] { homopolymer, ordinary }, Tryptic, NothingForbidden);
+
+        Assert.That(entrapment.Select(p => p.Accession), Is.EquivalentTo(new[] { "Random_P00001_f0" }),
+            "the homopolymer contributes no entry at all, rather than an empty one");
+        Assert.That(entrapment.All(p => p.BaseSequence.Length > 0), Is.True);
+    }
+
+    [Test]
+    public void TheHomopolymerReallyHasNoArrangement()
+    {
+        // Guard on the premise of the test above: if anchoring ever stopped freezing this sequence,
+        // that test would pass for the wrong reason.
+        EntrapmentAssembly assembly = EntrapmentAssembler.Assemble("M" + new string('Q', 79),
+            Tryptic, NothingForbidden);
+
+        Assert.That(assembly.EntrapmentSequence, Is.Empty);
+        Assert.That(assembly.ExcisedCount, Is.EqualTo(1));
+        Assert.That(assembly.Pieces.Single().Failure,
+            Is.EqualTo(EntrapmentFailure.NoPermutationExists));
+    }
+
+    [Test]
+    public void AForeignAccessionRoundTripsAndNamesNoTarget()
+    {
+        string accession = EntrapmentAccession.FormatForeign("Q9XYZ1");
+
+        Assert.That(accession, Is.EqualTo("Random_foreign_Q9XYZ1"));
+        Assert.That(EntrapmentAccession.TryParseForeign(accession, out string foreign), Is.True);
+        Assert.That(foreign, Is.EqualTo("Q9XYZ1"));
+
+        // It is entrapment, so a consumer scanning for the identifier must still find it -- missing
+        // one would count a foreign entry as a TARGET, which corrupts the estimate in the worst
+        // direction.
+        Assert.That(accession, Does.StartWith("Random_"));
+
+        // But there is no target to name, so the target parser must refuse rather than guess.
+        Assert.That(EntrapmentAccession.TryParse(accession, out _, out _), Is.False);
+    }
+
+    [Test]
+    public void TargetParsingRefusesAForeignAccessionThatLooksLikeAFold()
+    {
+        // The edge case the marker exists for: a foreign protein whose own accession ends in
+        // something shaped like a fold suffix. Refusing on the marker rather than the shape keeps
+        // "foreign_ABC" from ever being reported as a target accession.
+        string accession = EntrapmentAccession.FormatForeign("ABC_f1");
+
+        Assert.That(accession, Is.EqualTo("Random_foreign_ABC_f1"));
+        Assert.That(EntrapmentAccession.TryParse(accession, out string target, out _), Is.False,
+            "a foreign entry has no target, whatever its accession happens to end with");
+        Assert.That(target, Is.Empty);
+        Assert.That(EntrapmentAccession.TryParseForeign(accession, out string foreign), Is.True);
+        Assert.That(foreign, Is.EqualTo("ABC_f1"));
+    }
+
+    [Test]
+    public void AForeignEntryIsRelabelledNotRearranged()
+    {
+        // A foreign protein already is a sequence the sample cannot contain, so permuting it would
+        // buy nothing and lose the annotations that describe it.
+        var foreign = new Protein(ForeignSequence, "Q9XYZ1",
+            sequenceVariations: new List<SequenceVariation>
+            {
+                new SequenceVariation(5, 5, "G", "A", "irrelevant to entrapment"),
+            });
+
+        Protein entry = EntrapmentProteinGenerator.CreateForeign(foreign);
+
+        Assert.That(entry.BaseSequence, Is.EqualTo(ForeignSequence), "the sequence is not touched");
+        Assert.That(entry.IsEntrapment, Is.True);
+        Assert.That(entry.Accession, Is.EqualTo("Random_foreign_Q9XYZ1"));
+        Assert.That(entry.SequenceVariations, Is.Empty,
+            "applying variants would expand one entry into several, and the arm is one entry per entry");
+    }
+
+    [Test]
+    public void ForeignPeptidesSharedWithTheTargetAreReported()
+    {
+        // Homology is the hazard: a conserved protein shares peptides with its ortholog, and a
+        // shared peptide is a REAL target peptide sitting in the entrapment database. Nothing can be
+        // permuted away here, so it is counted.
+        IDigestionParams digestion = Tryptic;
+        var target = new Protein(Sequence, "P00001");
+
+        var targetPeptides = target.Digest(digestion, new List<Modification>(), new List<Modification>())
+            .Select(pep => pep.BaseSequence).ToHashSet();
+        string conserved = targetPeptides.First(pep => pep.Length >= 9);
+
+        // one foreign protein that shares a peptide, and one that does not
+        var foreign = new List<Protein>
+        {
+            new Protein("MQVLGYTTPDNR" + conserved + "AWEDSFLGK", "Q9SHARED"),
+            new Protein(ForeignSequence, "Q9CLEAN"),
+        };
+
+        List<Protein> entrapment = EntrapmentProteinGenerator.GenerateForeignEntrapment(
+            foreign, digestion, targetPeptides, out var shared);
+
+        Assert.That(entrapment.Select(e => e.Accession),
+            Is.EquivalentTo(new[] { "Random_foreign_Q9SHARED", "Random_foreign_Q9CLEAN" }));
+        Assert.That(shared.ContainsKey("Q9SHARED"), Is.True,
+            "fixture must actually share a peptide, or it proves nothing");
+        Assert.That(shared["Q9SHARED"], Does.Contain(conserved));
+        Assert.That(shared.ContainsKey("Q9CLEAN"), Is.False);
+    }
+
+    [Test]
+    public void DisjointForeignProteomeSharesNothing()
+    {
+        IDigestionParams digestion = Tryptic;
+        var target = new Protein(Sequence, "P00001");
+        var targetPeptides = target.Digest(digestion, new List<Modification>(), new List<Modification>())
+            .Select(pep => pep.BaseSequence).ToHashSet();
+
+        List<Protein> entrapment = EntrapmentProteinGenerator.GenerateForeignEntrapment(
+            new[] { new Protein(ForeignSequence, "Q9CLEAN") }, digestion, targetPeptides, out var shared);
+
+        Assert.That(entrapment, Has.Count.EqualTo(1));
+        Assert.That(shared, Is.Empty);
+    }
+
+    private static string Sorted(string s) => string.Concat(s.OrderBy(c => c));
+
+    [Test]
+    public void AForeignMarkerCannotBeMintedAsATargetAccession()
+    {
+        // The two accession forms have to be disjoint and only TryParse was enforcing it: a target
+        // beginning with the marker minted an accession TryParse then refused and TryParseForeign
+        // claimed, so the partner could never be paired back and counted as a foreign entry.
+        Assert.That(() => EntrapmentAccession.Format("foreign_ABC", 0),
+            Throws.TypeOf<MzLibUtil.MzLibException>());
+
+        // The ordinary case is untouched.
+        Assert.That(EntrapmentAccession.Format("P12345", 0), Is.EqualTo("Random_P12345_f0"));
+    }
+
+    [Test]
+    public void APartnerDoesNotInheritItsTargetChecksumOrSequenceVersion()
+    {
+        // The checksum is a CRC64 of the sequence and the partner's sequence is a different one, so
+        // carrying it across wrote every entry with a checksum that both ProteinXmlEntry parses and
+        // ProteinDbWriter writes -- an assertion about a sequence it does not describe.
+        var target = new Protein("MSTQAEVDLNSGWKALADQMNLLLSKGGVDTTPFAWENDR", "P12345");
+        target.UniProtSequenceAttributes.UpdateMassAttribute(4321);
+
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        Assert.That(entrapment.UniProtSequenceAttributes, Is.Not.Null);
+        Assert.That(entrapment.UniProtSequenceAttributes.Checksum, Is.EqualTo("unknown"));
+        Assert.That(entrapment.UniProtSequenceAttributes.SequenceVersion, Is.EqualTo(-1));
+        Assert.That(entrapment.UniProtSequenceAttributes.Length,
+            Is.EqualTo(entrapment.BaseSequence.Length));
+    }
+
+    [Test]
+    public void AnUnknownResidueDoesNotWriteAZeroMass()
+    {
+        // MonoisotopicMass is NaN for a sequence holding X or B, and (int)Math.Round(NaN) is 0, so
+        // an entry whose target carried a real mass was written as mass="0". A rearrangement is
+        // isomeric, so the target's own mass is the right answer here.
+        // The mass is set explicitly, as a UniProt XML supplies it -- Protein's own constructor
+        // computes the same NaN and stores 0, so a target built from the sequence alone would not
+        // have a real mass to lose. That is mzLib core rather than this generator.
+        var target = new Protein("MSTQAEVDLNSGWKXALADQMNLLLSKGGVDTTPFAWENDR", "P12345");
+        target.UniProtSequenceAttributes.UpdateMassAttribute(4321);
+        int targetMass = target.UniProtSequenceAttributes.Mass;
+        Assert.That(targetMass, Is.GreaterThan(0), "the fixture must start from a real mass");
+
+        Protein entrapment = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden);
+
+        Assert.That(entrapment.UniProtSequenceAttributes.Mass, Is.Not.Zero);
+        Assert.That(entrapment.UniProtSequenceAttributes.Mass, Is.EqualTo(targetMass));
+    }
+
+}

--- a/mzLib/Test/DatabaseTests/TestEntrapmentReport.cs
+++ b/mzLib/Test/DatabaseTests/TestEntrapmentReport.cs
@@ -1,0 +1,694 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using NUnit.Framework;
+using Omics.Digestion;
+using Omics.Modifications;
+using Proteomics;
+using Proteomics.ProteolyticDigestion;
+using UsefulProteomicsDatabases.EntrapmentGeneration;
+
+namespace Test.DatabaseTests;
+
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class EntrapmentReportTests
+{
+    private static readonly HashSet<string> NothingForbidden = new();
+
+    private static IDigestionParams Tryptic =>
+        new DigestionParams("trypsin", minPeptideLength: 7, maxMissedCleavages: 2);
+
+    private static readonly string[] Proteins =
+    {
+        "SYKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK",
+        "AKMTTSTTPAPTTTKQEEEKKKSSSSSSRGGVDTTPFAWENDR",
+        "MPSSTSRLLGVDKAAATPTGGGSQSCCCKYPERDNRSTTTK"
+    };
+
+    private static EntrapmentReport BuildReport(int foldCount = 1, Func<string, int> siteCounter = null,
+        IEnumerable<string> sequences = null)
+    {
+        IDigestionParams digestion = Tryptic;
+        var builder = new EntrapmentReportBuilder(digestion, foldCount, seed: 1,
+            siteCounter ?? EntrapmentReport.CountResidues("ST"));
+
+        foreach (string sequence in sequences ?? Proteins)
+        {
+            var target = new Protein(sequence, "P" + sequence.Length + sequence[0]);
+            for (int fold = 0; fold < foldCount; fold++)
+            {
+                EntrapmentProteinGenerator.Create(target, digestion, NothingForbidden,
+                    out EntrapmentAssembly assembly, fold: fold, foldCount: foldCount);
+                builder.Add(target, fold, assembly);
+            }
+        }
+
+        return builder.Build();
+    }
+
+    // ---- the distribution itself -------------------------------------------
+
+    [Test]
+    public void Report_EmitsEveryStratumRatherThanASummary()
+    {
+        EntrapmentReport report = BuildReport();
+
+        Assert.That(report.Strata.Count, Is.GreaterThan(1),
+            "a single number would hide exactly the differences worth looking at");
+        Assert.That(report.Strata.Select(s => s.SiteCount), Is.Ordered,
+            "strata are emitted in ascending order so two reports can be compared line for line");
+        Assert.That(report.Strata.Sum(s => s.TargetPeptides), Is.EqualTo(report.Total.TargetPeptides),
+            "the strata must add up to the total");
+    }
+
+    [Test]
+    public void Report_CountsOnlyPeptidesASearchCouldReport()
+    {
+        IDigestionParams digestion = Tryptic;
+        EntrapmentReport report = BuildReport();
+
+        // "AK" and other sub-length pieces exist in the fixtures but can never be identified alone,
+        // so counting them would flatter every ratio in the report.
+        int searchable = 0;
+        foreach (string sequence in Proteins)
+        {
+            List<int> sites = digestion.DigestionAgent.GetDigestionSiteIndices(sequence);
+            sites.Sort();
+            searchable += Enumerable.Range(0, sites.Count - 1)
+                .Count(i => sites[i + 1] - sites[i] >= digestion.MinLength);
+        }
+
+        Assert.That(report.Total.TargetPeptides, Is.EqualTo(searchable));
+    }
+
+    // ---- failures kept apart -----------------------------------------------
+
+    [Test]
+    public void Report_SeparatesFailuresByCauseAndByStratum()
+    {
+        EntrapmentReport report = BuildReport();
+
+        // "SSSSSSR" carries six candidate sites and has exactly one arrangement, so it lands in the
+        // no-permutation bucket of a high stratum -- not in a single undifferentiated "failed".
+        EntrapmentStratum sixSites = report.Strata.Single(s => s.SiteCount == 6);
+        Assert.That(sixSites.UnpairableNoPermutationExists, Is.EqualTo(1));
+        Assert.That(sixSites.UnpairableAllPermutationsTaken, Is.Zero);
+        Assert.That(sixSites.UnpairableSpaceTooSmallForFoldCount, Is.Zero);
+
+        // Against a literal, not against the same expression the property computes -- restating
+        // the implementation proves only that it equals itself.
+        Assert.That(report.Total.UnpairableNoPermutationExists, Is.EqualTo(1));
+        Assert.That(report.Total.UnpairableAllPermutationsTaken, Is.Zero);
+        Assert.That(report.Total.UnpairableSpaceTooSmallForFoldCount, Is.Zero);
+        Assert.That(report.Total.Unpairable, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Report_CountsMissedCleavagePeptidesThatBreakTheIsomerismInvariant()
+    {
+        EntrapmentReport report = BuildReport();
+
+        // The unpairable tract sits mid-protein on purpose: excising a TERMINAL piece breaks no
+        // runs at all, so a fixture with it at the end would assert nothing.
+        Assert.That(report.Total.MissedCleavagePeptidesSpanningAnExcision, Is.GreaterThan(0),
+            "an excision inside a protein necessarily breaks the runs that spanned it");
+    }
+
+    // ---- achieved r --------------------------------------------------------
+
+    [Test]
+    public void Report_ReportsPartnersDeliveredPerTargetNotAFractionOfWhatWasAsked()
+    {
+        EntrapmentReport oneFold = BuildReport(foldCount: 1);
+        EntrapmentReport fourFolds = BuildReport(foldCount: 4);
+
+        // A target peptide is counted once however many folds run, so the ratio is the achieved r.
+        Assert.That(fourFolds.Total.TargetPeptides, Is.EqualTo(oneFold.Total.TargetPeptides));
+        Assert.That(fourFolds.Total.AchievedFoldRatio,
+            Is.GreaterThan(oneFold.Total.AchievedFoldRatio * 3),
+            "four folds must deliver roughly four partners per target, not one");
+        Assert.That(fourFolds.Total.AchievedFoldRatio, Is.LessThanOrEqualTo(4d));
+    }
+
+    [Test]
+    public void Report_ShowsWhereTheDatabaseFellShortOfWhatWasAsked()
+    {
+        EntrapmentReport report = BuildReport(foldCount: 4);
+
+        // The peptide with one arrangement can never be paired, so its stratum cannot reach 4.
+        EntrapmentStratum sixSites = report.Strata.Single(s => s.SiteCount == 6);
+        Assert.That(sixSites.AchievedFoldRatio, Is.LessThan(4d));
+        Assert.That(sixSites.UnpairableNoPermutationExists, Is.GreaterThan(0));
+    }
+
+    // ---- provenance --------------------------------------------------------
+
+    [Test]
+    public void Report_RecordsHowTheDatabaseWasMade()
+    {
+        EntrapmentReport report = BuildReport(foldCount: 3);
+
+        // Without these the numbers above cannot be interpreted or reproduced: the peptide
+        // population depends on the enzyme and digestion settings as much as on the method.
+        Assert.That(report.Provenance.Enzyme, Is.EqualTo("trypsin"));
+        Assert.That(report.Provenance.Seed, Is.EqualTo(1));
+        Assert.That(report.Provenance.FoldCount, Is.EqualTo(3));
+        Assert.That(report.Provenance.MaxMissedCleavages, Is.EqualTo(2));
+        Assert.That(report.Provenance.MinPeptideLength, Is.EqualTo(7));
+        Assert.That(report.Provenance.Method, Does.Contain("composition-preserving"));
+    }
+
+    // ---- stratifying by something else -------------------------------------
+
+    [Test]
+    public void Report_CanStratifyByAnythingTheCallerCounts()
+    {
+        EntrapmentReport bySites = BuildReport(siteCounter: EntrapmentReport.CountResidues("ST"));
+        EntrapmentReport bySequons = BuildReport(siteCounter: EntrapmentReport.CountNGlycoSequons);
+
+        Assert.That(bySites.Total.TargetPeptides, Is.EqualTo(bySequons.Total.TargetPeptides));
+        Assert.That(bySites.Strata.Select(s => s.SiteCount),
+            Is.Not.EqualTo(bySequons.Strata.Select(s => s.SiteCount)),
+            "counting different things must produce different strata");
+    }
+
+    [Test]
+    public void CountNGlycoSequons_MatchesTheMotifAndExcludesProline()
+    {
+        Assert.That(EntrapmentReport.CountNGlycoSequons("NAS"), Is.EqualTo(1));
+        Assert.That(EntrapmentReport.CountNGlycoSequons("NAT"), Is.EqualTo(1));
+        Assert.That(EntrapmentReport.CountNGlycoSequons("NPS"), Is.Zero, "X must not be proline");
+        Assert.That(EntrapmentReport.CountNGlycoSequons("NAA"), Is.Zero);
+        Assert.That(EntrapmentReport.CountNGlycoSequons("NASNAT"), Is.EqualTo(2));
+        Assert.That(EntrapmentReport.CountNGlycoSequons("NA"), Is.Zero, "too short to hold a sequon");
+    }
+
+    [Test]
+    public void CountResidues_RefusesAnEmptyResidueSet()
+    {
+        Assert.Throws<MzLibUtil.MzLibException>(() => EntrapmentReport.CountResidues(""));
+        Assert.Throws<MzLibUtil.MzLibException>(() => EntrapmentReport.CountResidues(null));
+    }
+
+    // ---- the emitted table --------------------------------------------------
+
+    [Test]
+    public void Report_WritesProvenanceAndOneRowPerStratumPlusATotal()
+    {
+        EntrapmentReport report = BuildReport(foldCount: 2);
+        string[] lines = report.ToTabSeparated()
+            .Split('\n').Select(l => l.TrimEnd('\r')).Where(l => l.Length > 0).ToArray();
+
+        string[] comments = lines.Where(l => l.StartsWith("#")).ToArray();
+        Assert.That(comments.Any(l => l.Contains("trypsin")), Is.True);
+        Assert.That(comments.Any(l => l.StartsWith("# seed")), Is.True);
+
+        string header = lines.First(l => !l.StartsWith("#"));
+        Assert.That(header.Split('\t'), Does.Contain("achievedFoldRatio"));
+
+        string[] rows = lines.Where(l => !l.StartsWith("#")).Skip(1).ToArray();
+        Assert.That(rows.Length, Is.EqualTo(report.Strata.Count + 1), "one row per stratum, plus the total");
+        Assert.That(rows.Last(), Does.StartWith("all"));
+        Assert.That(rows.All(r => r.Split('\t').Length == header.Split('\t').Length), Is.True);
+    }
+
+    [Test]
+    public void Report_NumbersReconcileWithTheDatabaseActuallyWritten()
+    {
+        // The report is only worth reading if it describes the database that came out, so count the
+        // entrapment peptides independently and compare.
+        IDigestionParams digestion = Tryptic;
+        var builder = new EntrapmentReportBuilder(digestion, foldCount: 1, seed: 1,
+            EntrapmentReport.CountResidues("ST"));
+        int actualEntrapmentPeptides = 0;
+
+        foreach (string sequence in Proteins)
+        {
+            var target = new Protein(sequence, "P" + sequence.Length + sequence[0]);
+            Protein entrapment = EntrapmentProteinGenerator.Create(target, digestion, NothingForbidden,
+                out EntrapmentAssembly assembly);
+            builder.Add(target, 0, assembly);
+
+            List<int> sites = digestion.DigestionAgent.GetDigestionSiteIndices(entrapment.BaseSequence);
+            sites.Sort();
+            actualEntrapmentPeptides += Enumerable.Range(0, sites.Count - 1)
+                .Count(i => sites[i + 1] - sites[i] >= digestion.MinLength);
+        }
+
+        Assert.That(builder.Build().Total.EntrapmentPeptides, Is.EqualTo(actualEntrapmentPeptides));
+    }
+
+    [Test]
+    public void Report_SeesTheOtherTwoFailureCauses()
+    {
+        // The fixtures above only ever produce "no permutation exists". These two paths need their
+        // own shapes: a space too small for the folds asked of it, and a space fully occupied.
+        IDigestionParams digestion = Tryptic;
+        // "EEEEEEQK" is one base piece (trypsin cuts after every K, so QEEEKKK would split into
+        // three) and its seven residues before the pinned K admit exactly seven arrangements.
+        const string sequence = "EEEEEEQKGGVDTTPFAWENDR";
+        var target = new Protein(sequence, "P1");
+
+        var tooSmall = new EntrapmentReportBuilder(digestion, foldCount: 9, seed: 1,
+            EntrapmentReport.CountResidues("ST"));
+        EntrapmentProteinGenerator.Create(target, digestion, NothingForbidden,
+            out EntrapmentAssembly smallAssembly, fold: 0, foldCount: 9);
+        tooSmall.Add(target, 0, smallAssembly);
+        Assert.That(tooSmall.Build().Total.UnpairableSpaceTooSmallForFoldCount, Is.EqualTo(1));
+
+        var everyArrangement = new HashSet<string>();
+        System.Numerics.BigInteger size = UsefulProteomicsDatabases.DecoySequenceValidator
+            .PermutationSpaceSize("EEEEEEQK", digestion.DigestionAgent.DigestionMotifs);
+        for (System.Numerics.BigInteger i = 0; i < size; i++)
+        {
+            everyArrangement.Add(UsefulProteomicsDatabases.DecoySequenceValidator
+                .UnrankPermutation("EEEEEEQK", digestion.DigestionAgent.DigestionMotifs, i, out _));
+        }
+
+        var taken = new EntrapmentReportBuilder(digestion, foldCount: 1, seed: 1,
+            EntrapmentReport.CountResidues("ST"));
+        EntrapmentProteinGenerator.Create(target, digestion, everyArrangement,
+            out EntrapmentAssembly takenAssembly);
+        taken.Add(target, 0, takenAssembly);
+        Assert.That(taken.Build().Total.UnpairableAllPermutationsTaken, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Report_TotalsAddUpFieldByField()
+    {
+        EntrapmentReport report = BuildReport(foldCount: 2);
+
+        // Every field, not just the peptide count: the total is accumulated field by field, so a
+        // slip in one of them would otherwise go unseen.
+        Assert.That(report.Total.EntrapmentPeptides, Is.EqualTo(report.Strata.Sum(s => s.EntrapmentPeptides)));
+        Assert.That(report.Total.UnpairableNoPermutationExists,
+            Is.EqualTo(report.Strata.Sum(s => s.UnpairableNoPermutationExists)));
+        Assert.That(report.Total.UnpairableAllPermutationsTaken,
+            Is.EqualTo(report.Strata.Sum(s => s.UnpairableAllPermutationsTaken)));
+        Assert.That(report.Total.UnpairableSpaceTooSmallForFoldCount,
+            Is.EqualTo(report.Strata.Sum(s => s.UnpairableSpaceTooSmallForFoldCount)));
+        Assert.That(report.Total.Ambiguous, Is.EqualTo(report.Strata.Sum(s => s.Ambiguous)));
+        Assert.That(report.Total.EntrapmentPeptides, Is.GreaterThan(0), "the fixture must be non-trivial");
+
+        // Three columns describe the database rather than any candidate-site population, so they
+        // reach the total without passing through a stratum. Asserting the sum is ZERO is the point:
+        // publishing a whole-protein figure in a stratum row would make every other row read 0 for a
+        // column that is not zero, and a reader comparing rows would take it for a property of that
+        // stratum. StratumFor("") used to resolve to the real zero-site stratum, which is exactly
+        // how that happened.
+        Assert.That(report.Strata.Sum(s => s.MissedCleavagePeptidesSpanningAnExcision), Is.Zero);
+        Assert.That(report.Strata.Sum(s => s.SearchSpacePeptides), Is.Zero);
+        Assert.That(report.Strata.Sum(s => s.UnrepairableRunCollisions), Is.Zero);
+        Assert.That(report.Total.SearchSpacePeptides, Is.GreaterThan(0),
+            "and the total must still carry them, or they have simply been lost");
+    }
+
+    [Test]
+    public void Report_CountsAnAmbiguousPeptideOnceHoweverManyFoldsRun()
+    {
+        // Ambiguity is a property of the target protein, not of a fold, so it is worked out once per
+        // accession. Counting it again per fold would inflate it in step with the fold count.
+        var pairing = new EntrapmentPairing(
+            new Protein("LIHTGVKAAADEFGHIKLIHTVGKMMWWYYPPQQR", "P57071"), Tryptic);
+        Assert.That(pairing.AmbiguousPeptides.Count, Is.GreaterThan(0), "the fixture must be ambiguous");
+
+        int[] counts = new[] { 1, 4 }.Select(folds =>
+            BuildReport(foldCount: folds,
+                sequences: new[] { "LIHTGVKAAADEFGHIKLIHTVGKMMWWYYPPQQR" }).Total.Ambiguous).ToArray();
+
+        Assert.That(counts[0], Is.GreaterThan(0));
+        Assert.That(counts[1], Is.EqualTo(counts[0]), "four folds must not quadruple the ambiguity count");
+    }
+
+    [Test]
+    public void Report_HandlesHavingBeenGivenNothing()
+    {
+        EntrapmentReport empty = new EntrapmentReportBuilder(Tryptic, 1, 1).Build();
+
+        Assert.That(empty.Strata, Is.Empty);
+        Assert.That(empty.Total.TargetPeptides, Is.Zero);
+        Assert.That(empty.Total.AchievedFoldRatio, Is.Zero, "no targets means no ratio, not a divide by zero");
+        Assert.That(empty.ToTabSeparated(), Does.Contain("# enzyme"));
+    }
+
+    [Test]
+    public void ReportBuilder_RefusesIncompleteInput()
+    {
+        Assert.Throws<MzLibUtil.MzLibException>(() => new EntrapmentReportBuilder(null, 1, 1));
+
+        var builder = new EntrapmentReportBuilder(Tryptic, 1, 1);
+        var target = new Protein(Proteins[0], "P1");
+        EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden, out EntrapmentAssembly assembly);
+
+        Assert.Throws<MzLibUtil.MzLibException>(() => builder.Add(null, 0, assembly));
+        Assert.Throws<MzLibUtil.MzLibException>(() => builder.Add(target, 0, null));
+    }
+
+    [Test]
+    public void Report_TableCarriesTheNumbersAndNotJustTheShape()
+    {
+        EntrapmentReport report = BuildReport();
+        string[] lines = report.ToTabSeparated()
+            .Split('\n').Select(l => l.TrimEnd('\r')).Where(l => l.Length > 0).ToArray();
+
+        // Provenance values, not merely the presence of a label.
+        Assert.That(lines, Does.Contain("# enzyme\ttrypsin"));
+        Assert.That(lines, Does.Contain("# seed\t1"));
+        Assert.That(lines, Does.Contain("# maxMissedCleavages\t2"));
+        Assert.That(lines, Does.Contain("# minPeptideLength\t7"));
+
+        // And the total row's figures must match the object the table was rendered from.
+        string[] total = lines.Last().Split('\t');
+        Assert.That(total[0], Is.EqualTo("all"));
+        Assert.That(total[1], Is.EqualTo(report.Total.TargetPeptides.ToString()));
+        Assert.That(total[2], Is.EqualTo(report.Total.EntrapmentPeptides.ToString()));
+        Assert.That(total[4], Is.EqualTo(report.Total.UnpairableNoPermutationExists.ToString()));
+        Assert.That(total[7], Is.EqualTo(report.Total.UnpairableRunCollisionsExhausted.ToString()));
+        Assert.That(total[8], Is.EqualTo(report.Total.SearchSpacePeptides.ToString()));
+        Assert.That(total[9], Is.EqualTo(report.Total.EntrapmentSearchSpacePeptides.ToString()));
+        Assert.That(total[10], Is.EqualTo(report.Total.Ambiguous.ToString()));
+        Assert.That(total[12], Is.EqualTo(report.Total.UnrepairableRunCollisions.ToString()));
+
+        // Both halves of a peptide-level r, side by side. entrapmentPeptides counts base pieces, so
+        // a ratio built from that column is a base-piece ratio -- and excision makes the two search
+        // spaces differ by more than the fold factor, so the entrapment side cannot be derived from
+        // the target side and a correction.
+        Assert.That(report.Total.EntrapmentSearchSpacePeptides, Is.GreaterThan(0));
+    }
+
+    /// <summary>
+    /// A protein whose short pieces collide by composition while its searchable peptides do not.
+    /// "AK" and "KA" cannot both occur, but two 2-residue pieces sharing a key are easy to build,
+    /// and before the length bound they were counted as ambiguous despite being unsearchable.
+    /// </summary>
+    private const string ShortPieceCollisions = "AKAKMSTQAEVDLNSGWKALADQMNLLLSK";
+
+    [Test]
+    public void PairingIgnoresPeptidesTooShortToBeReported()
+    {
+        // The index must hold only what a search could report. A key begins with the peptide's
+        // length, so short peptides never collide with long ones and dropping them cannot change
+        // how a searchable peptide resolves -- it only stops them being counted as ambiguous.
+        var lenient = new DigestionParams("trypsin", minPeptideLength: 1, maxMissedCleavages: 2);
+        var realistic = new DigestionParams("trypsin", minPeptideLength: 7, maxMissedCleavages: 2);
+        var protein = new Protein(ShortPieceCollisions, "P00001");
+
+        var withShort = new EntrapmentPairing(protein, lenient);
+        var withoutShort = new EntrapmentPairing(protein, realistic);
+
+        Assert.That(withShort.SearchablePeptideCount, Is.GreaterThan(withoutShort.SearchablePeptideCount),
+            "the lenient bound must admit more peptides, or the fixture proves nothing");
+        Assert.That(withoutShort.AmbiguousPeptides.Any(pep => pep.Length < 7), Is.False,
+            "no peptide below the minimum length may be reported as ambiguous");
+    }
+
+    [Test]
+    public void SearchablePeptideCountSpansMissedCleavagesNotJustBasePieces()
+    {
+        // The denominator an ambiguity rate and an FDP estimator's r both need. It must exceed the
+        // base-piece count, because a run of adjacent pieces is a peptide a search reports too.
+        var digestion = new DigestionParams("trypsin", minPeptideLength: 7, maxMissedCleavages: 2);
+        var protein = new Protein("MSTQAEVDLNSGWKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK", "P00001");
+
+        var pairing = new EntrapmentPairing(protein, digestion);
+
+        // four base pieces, all >= 7, plus runs of two and of three
+        Assert.That(pairing.SearchablePeptideCount, Is.EqualTo(4 + 3 + 2));
+    }
+
+    [Test]
+    public void ReportCarriesTheSearchSpaceDenominatorBesideTheBasePieceCounts()
+    {
+        var digestion = Tryptic;
+        var builder = new EntrapmentReportBuilder(digestion, 1, 1, EntrapmentReport.CountResidues("ST"));
+        var protein = new Protein("MSTQAEVDLNSGWKALADQMNLLLSKGGVDTTPFAWENDRQISTLGGYK", "P00001");
+
+        Protein _ = EntrapmentProteinGenerator.Create(protein, digestion, NothingForbidden,
+            out EntrapmentAssembly assembly);
+        builder.Add(protein, 0, assembly);
+        EntrapmentReport report = builder.Build();
+
+        Assert.That(report.Total.SearchSpacePeptides, Is.EqualTo(9),
+            "runs of one, two and three base pieces");
+        Assert.That(report.Total.SearchSpacePeptides, Is.GreaterThan(report.Total.TargetPeptides),
+            "the search space must exceed the base pieces it is built from");
+
+        string tsv = report.ToTabSeparated();
+        Assert.That(tsv, Does.Contain("searchSpacePeptides"));
+        Assert.That(tsv, Does.Contain("unrepairableRunCollisions"));
+    }
+
+    [Test]
+    public void ReportCountsUnrepairableRunCollisions()
+    {
+        // A run ending in a piece with no alternative arrangement cannot be permuted away from a
+        // real peptide, so it is counted rather than repaired -- and the count has to reach the
+        // report, or a consumer cannot exclude the peptides it describes.
+        var digestion = Tryptic;
+        const string target = "MSTQAEVDLNSGWKAAR";
+
+        EntrapmentAssembly free = EntrapmentAssembler.Assemble(target, digestion, NothingForbidden);
+        string run = free.Pieces[0].EntrapmentPiece_ + free.Pieces[1].EntrapmentPiece_;
+
+        var protein = new Protein(target, "P00001");
+        var builder = new EntrapmentReportBuilder(digestion, 1, 1);
+        Protein _ = EntrapmentProteinGenerator.Create(protein, digestion,
+            new HashSet<string> { run }, out EntrapmentAssembly guarded);
+        builder.Add(protein, 0, guarded);
+
+        Assert.That(guarded.UnrepairableRunCollisions, Is.EqualTo(1));
+        Assert.That(builder.Build().Total.UnrepairableRunCollisions, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void ExclusionTableNamesTheUnrepairableCollisions()
+    {
+        // A count tells a consumer how much to distrust an entrapment total; only the sequences let
+        // it subtract them. This is the form the glyco project asked for.
+        IDigestionParams digestion = Tryptic;
+        const string target = "MSTQAEVDLNSGWKAAR";
+
+        EntrapmentAssembly free = EntrapmentAssembler.Assemble(target, digestion, NothingForbidden);
+        string run = free.Pieces[0].EntrapmentPiece_ + free.Pieces[1].EntrapmentPiece_;
+
+        var protein = new Protein(target, "P00001");
+        var builder = new EntrapmentReportBuilder(digestion, 1, 1);
+        Protein _ = EntrapmentProteinGenerator.Create(protein, digestion,
+            new HashSet<string> { run }, out EntrapmentAssembly guarded);
+        builder.Add(protein, 0, guarded);
+        EntrapmentReport report = builder.Build();
+
+        Assert.That(guarded.UnrepairableRunCollisionPeptides, Is.EqualTo(new[] { run }),
+            "the offending peptide itself, not merely a tally");
+
+        // Filed under the ENTRAPMENT protein's accession, which is what a search reports the peptide
+        // under. Keyed by the target it was rearranged from, `accession` meant one thing on these
+        // rows and another on the ambiguous rows, and a consumer filtering on (accession, peptide)
+        // matched the ambiguous ones and silently missed these.
+        string entrapmentAccession = EntrapmentAccession.Format("P00001", 0);
+        Assert.That(report.UnrepairableRunCollisionsByAccession.ContainsKey("P00001"), Is.False,
+            "the target accession does not name a protein this peptide is in");
+        Assert.That(report.UnrepairableRunCollisionsByAccession[entrapmentAccession], Does.Contain(run));
+
+        string[] lines = report.ExclusionsToTabSeparated()
+            .Split('\n').Select(l => l.TrimEnd('\r')).Where(l => l.Length > 0).ToArray();
+        Assert.That(lines[0], Is.EqualTo("accession\tpeptide\treason"));
+        Assert.That(lines, Does.Contain(entrapmentAccession + "\t" + run + "\tunrepairableRunCollision"));
+
+        // The column and the sidecar are read together, so they count the same thing.
+        Assert.That(report.Total.UnrepairableRunCollisions,
+            Is.EqualTo(lines.Count(l => l.EndsWith("\tunrepairableRunCollision"))),
+            "the stratified column counts peptides, as the sidecar does, not placements");
+    }
+
+    [Test]
+    public void ExclusionTableNamesTheAmbiguousPeptides()
+    {
+        IDigestionParams digestion = Tryptic;
+        // P57071 really does contain LIHTGVK and LIHTVGK -- same composition, same pinned K, so the
+        // pairing key cannot tell them apart and both must be excluded rather than guessed between.
+        var protein = new Protein("MSTQAEVDLNSGWKLIHTGVKLIHTVGKALADQMNLLLSK", "P00002");
+        var builder = new EntrapmentReportBuilder(digestion, 1, 1);
+
+        Protein _ = EntrapmentProteinGenerator.Create(protein, digestion, NothingForbidden,
+            out EntrapmentAssembly assembly);
+        builder.Add(protein, 0, assembly);
+        EntrapmentReport report = builder.Build();
+
+        Assert.That(report.AmbiguousPeptidesByAccession.ContainsKey("P00002"), Is.True,
+            "fixture must actually produce an ambiguous pair, or it proves nothing");
+        Assert.That(report.AmbiguousPeptidesByAccession["P00002"],
+            Is.SupersetOf(new[] { "LIHTGVK", "LIHTVGK" }));
+
+        string table = report.ExclusionsToTabSeparated();
+        Assert.That(table, Does.Contain("P00002\tLIHTGVK\tambiguous"));
+        Assert.That(table, Does.Contain("P00002\tLIHTVGK\tambiguous"));
+    }
+
+    [Test]
+    public void ForeignArmReachesTheReportAndItsExclusionTable()
+    {
+        var builder = new EntrapmentReportBuilder(Tryptic, 1, 1);
+        var shared = new Dictionary<string, IReadOnlyCollection<string>>
+        {
+            ["Q9SHARED"] = new[] { "LIHTGVKPEPTIDER" },
+        };
+
+        builder.AddForeign(2, shared);
+        EntrapmentReport report = builder.Build();
+
+        Assert.That(report.ForeignEntries, Is.EqualTo(2));
+        Assert.That(report.ExclusionsToTabSeparated(),
+            Does.Contain("Q9SHARED	LIHTGVKPEPTIDER	sharedWithTarget"));
+    }
+
+    [Test]
+    public void ForeignEntriesStayOutOfThePermutationRatios()
+    {
+        // A foreign entry was relabelled, not rearranged, so it was never at risk of failing to
+        // permute. Counting it in the achieved-fold ratio would make the arm look like it rescued
+        // peptides it never touched.
+        var builder = new EntrapmentReportBuilder(Tryptic, 1, 1);
+        builder.AddForeign(5, null);
+        EntrapmentReport report = builder.Build();
+
+        Assert.That(report.ForeignEntries, Is.EqualTo(5));
+        Assert.That(report.Total.TargetPeptides, Is.Zero);
+        Assert.That(report.Total.EntrapmentPeptides, Is.Zero);
+    }
+
+    [Test]
+    public void ExclusionTableIsAHeaderWhenNothingIsExcluded()
+    {
+        // An empty answer is a real answer, and must not look like a missing file.
+        var builder = new EntrapmentReportBuilder(Tryptic, 1, 1);
+        string table = builder.Build().ExclusionsToTabSeparated();
+
+        Assert.That(table.Trim(), Is.EqualTo("accession\tpeptide\treason"));
+    }
+
+    [Test]
+    public void ProvenanceRowsDoNotDependOnTheAmbientCulture()
+    {
+        // These rows are what a consumer reads to regenerate a database. sv-SE's negative sign is
+        // U+2212, not ASCII hyphen, so a negative seed was written as a value no parser reading it
+        // back would accept -- while every numeric column further down was already invariant.
+        var previous = System.Threading.Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture =
+                new System.Globalization.CultureInfo("sv-SE");
+            string table = new EntrapmentReportBuilder(Tryptic, foldCount: 1, seed: -7)
+                .Build().ToTabSeparated();
+            string seedRow = table.Split('\n').First(l => l.StartsWith("# seed"));
+
+            Assert.That(seedRow, Does.Contain("-7"));
+            Assert.That(seedRow, Does.Not.Contain("\u2212"));
+        }
+        finally
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = previous;
+        }
+    }
+
+    [Test]
+    public void ForeignArmReachesTheProvenanceItOtherwiseLeavesOut()
+    {
+        // Without these rows the provenance describes only half a database that has a foreign arm,
+        // and the arm's r is not recoverable from the report at all.
+        var builder = new EntrapmentReportBuilder(Tryptic, 1, 1);
+        Assert.That(builder.Build().ToTabSeparated(), Does.Not.Contain("foreignEntries"),
+            "a bottom-up report is unchanged");
+
+        builder.AddForeign(12, new Dictionary<string, IReadOnlyCollection<string>>
+        {
+            ["FOREIGN1"] = new[] { "PEPTIDEK" },
+        });
+        string table = builder.Build().ToTabSeparated();
+
+        Assert.That(table, Does.Contain("# foreignEntries" + "\t" + "12"));
+        Assert.That(table, Does.Contain("# foreignPeptidesSharedWithTarget" + "\t" + "1"));
+    }
+
+    [Test]
+    public void AddForeignMergesPeptidesRatherThanOverwritingThem()
+    {
+        // The entry count accumulates, so assigning the peptides meant two calls naming one
+        // accession counted both entries and kept only the second call's peptides -- the arm
+        // under-reporting exactly the peptides it exists to name.
+        var builder = new EntrapmentReportBuilder(Tryptic, 1, 1);
+        builder.AddForeign(2, new Dictionary<string, IReadOnlyCollection<string>>
+        {
+            ["FOREIGN1"] = new[] { "PEPTIDEK" },
+        });
+        builder.AddForeign(3, new Dictionary<string, IReadOnlyCollection<string>>
+        {
+            ["FOREIGN1"] = new[] { "OTHERAAK" },
+        });
+
+        EntrapmentReport report = builder.Build();
+
+        Assert.That(report.ForeignEntries, Is.EqualTo(5));
+        Assert.That(report.ForeignPeptidesSharedWithTarget["FOREIGN1"],
+            Is.EquivalentTo(new[] { "PEPTIDEK", "OTHERAAK" }));
+    }
+
+    [Test]
+    public void ABuiltReportDoesNotChangeWhenTheBuilderIsUsedAgain()
+    {
+        // Build() handed out the builder's live dictionary where the two beside it were snapshots,
+        // so a later AddForeign mutated a report that had already been built.
+        var builder = new EntrapmentReportBuilder(Tryptic, 1, 1);
+        builder.AddForeign(1, new Dictionary<string, IReadOnlyCollection<string>>
+        {
+            ["FOREIGN1"] = new[] { "PEPTIDEK" },
+        });
+        EntrapmentReport report = builder.Build();
+
+        builder.AddForeign(1, new Dictionary<string, IReadOnlyCollection<string>>
+        {
+            ["FOREIGN2"] = new[] { "LATEADDK" },
+        });
+
+        Assert.That(report.ForeignPeptidesSharedWithTarget.ContainsKey("FOREIGN2"), Is.False,
+            "a built report is a snapshot, not a window onto the builder");
+        Assert.That(report.ForeignEntries, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void AnEntryThatYieldsNoPartnerIsCounted()
+    {
+        // Not writing the empty protein is right -- a loader discarded it anyway -- but it removed
+        // the loader's "N empty entries ignored" warning, which was the only signal the arm was
+        // short. Q156A1 is the real case: a methionine then a run of glutamines, whose only base
+        // piece has one arrangement once the termini are anchored.
+        var target = new Protein("M" + new string('Q', 79), "Q156A1");
+        var builder = new EntrapmentReportBuilder(Tryptic, 1, 1);
+
+        Protein _ = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden,
+            out EntrapmentAssembly assembly);
+        Assert.That(assembly.EntrapmentSequence, Is.Empty, "the fixture must actually yield nothing");
+
+        builder.Add(target, 0, assembly);
+        EntrapmentReport report = builder.Build();
+
+        Assert.That(report.EntriesYieldingNoPartner, Is.EqualTo(1));
+        Assert.That(report.ToTabSeparated(), Does.Contain("# entriesYieldingNoPartner" + "\t" + "1"));
+    }
+
+    [Test]
+    public void ADatabaseWithEveryPartnerDeliveredSaysNothingAboutMissingOnes()
+    {
+        var target = new Protein("MSTQAEVDLNSGWKALADQMNLLLSKGGVDTTPFAWENDR", "P12345");
+        var builder = new EntrapmentReportBuilder(Tryptic, 1, 1);
+        Protein _ = EntrapmentProteinGenerator.Create(target, Tryptic, NothingForbidden,
+            out EntrapmentAssembly assembly);
+        builder.Add(target, 0, assembly);
+        EntrapmentReport report = builder.Build();
+
+        Assert.That(report.EntriesYieldingNoPartner, Is.Zero);
+        Assert.That(report.ToTabSeparated(), Does.Not.Contain("entriesYieldingNoPartner"));
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/DecoyGeneration/DecoySequenceValidator.cs
+++ b/mzLib/UsefulProteomicsDatabases/DecoyGeneration/DecoySequenceValidator.cs
@@ -232,19 +232,28 @@ public static class DecoySequenceValidator
     /// Nothing is enumerated, so this is cheap even when the answer is astronomically large.
     /// </summary>
     /// <remarks>
-    /// Returns <see cref="BigInteger.One"/> when no rearrangement exists -- a homopolymeric tract
-    /// such as "SSSSSSR" has exactly one arrangement once its cleavage sites are pinned. That is
-    /// arithmetic rather than a collision, so no amount of searching or reseeding can improve it.
+    /// Returns <see cref="BigInteger.One"/> when no rearrangement exists. That is arithmetic rather
+    /// than a collision, so no amount of searching or reseeding can improve it, and the only
+    /// available "rearrangement" is the identity -- an entrapment sequence equal to its target.
+    /// <para>Two shapes reach it, and only one of them is exotic. A homopolymeric tract such as
+    /// <c>SSSSSSR</c> is the obvious one. The common one is <b>dense cleavage sites</b>:
+    /// <c>AKAKA</c> also returns 1, pinned by sites at 1 and 3 down to a single arrangement of three
+    /// identical free residues, and short tryptic peptides with several K or R are ordinary rather
+    /// than pathological. A caller will meet size 1 regularly, not only on degenerate input.</para>
     /// Intended for peptide-length sequences; the free-position count drives the cost.
     /// </remarks>
-    public static BigInteger PermutationSpaceSize(string sequence, List<DigestionMotif> motifs)
+    /// <param name="alsoHeldInPlace">Extra zero-based positions to hold still on top of the
+    /// cleavage sites — used to anchor a protein's termini, so a modification restricted to one of
+    /// them stays valid. Null or empty pins nothing extra.</param>
+    public static BigInteger PermutationSpaceSize(string sequence, List<DigestionMotif> motifs,
+        IReadOnlyCollection<int>? alsoHeldInPlace = null)
     {
         if (string.IsNullOrEmpty(sequence))
         {
             return BigInteger.One;
         }
 
-        return Multinomial(FreeResidueCounts(sequence, motifs));
+        return Multinomial(FreeResidueCounts(sequence, motifs, alsoHeldInPlace));
     }
 
     /// <summary>
@@ -262,8 +271,11 @@ public static class DecoySequenceValidator
     /// the index from a seed and the sequence rather than from a random number generator.
     /// </remarks>
     /// <exception cref="MzLibException"><paramref name="index"/> lies outside the space.</exception>
+    /// <param name="alsoHeldInPlace">Extra zero-based positions to hold still on top of the
+    /// cleavage sites. Must match what was passed to <see cref="PermutationSpaceSize"/>, or the
+    /// index will not mean the same thing.</param>
     public static string UnrankPermutation(string sequence, List<DigestionMotif> motifs, BigInteger index,
-        out int[] swappedPositionArray)
+        out int[] swappedPositionArray, IReadOnlyCollection<int>? alsoHeldInPlace = null)
     {
         swappedPositionArray = Enumerable.Range(0, sequence?.Length ?? 0).ToArray();
         if (string.IsNullOrEmpty(sequence))
@@ -271,7 +283,7 @@ public static class DecoySequenceValidator
             return sequence;
         }
 
-        HashSet<int> pinned = CleavageSitePositions(sequence, motifs);
+        HashSet<int> pinned = HeldPositions(sequence, motifs, alsoHeldInPlace);
         List<int> freePositions = new();
         for (int i = 0; i < sequence.Length; i++)
         {
@@ -338,10 +350,32 @@ public static class DecoySequenceValidator
         return new string(rearranged);
     }
 
-    /// <summary>Residue counts over the positions no cleavage motif holds in place.</summary>
-    private static SortedDictionary<char, int> FreeResidueCounts(string sequence, List<DigestionMotif> motifs)
+    /// <summary>Every position held still: the cleavage sites, plus anything the caller anchored.</summary>
+    private static HashSet<int> HeldPositions(string sequence, List<DigestionMotif> motifs,
+        IReadOnlyCollection<int>? alsoHeldInPlace)
     {
-        HashSet<int> pinned = CleavageSitePositions(sequence, motifs);
+        HashSet<int> held = CleavageSitePositions(sequence, motifs);
+        if (alsoHeldInPlace is null)
+        {
+            return held;
+        }
+
+        foreach (int position in alsoHeldInPlace)
+        {
+            if (position >= 0 && position < sequence.Length)
+            {
+                held.Add(position);
+            }
+        }
+
+        return held;
+    }
+
+    /// <summary>Residue counts over the positions nothing holds in place.</summary>
+    private static SortedDictionary<char, int> FreeResidueCounts(string sequence, List<DigestionMotif> motifs,
+        IReadOnlyCollection<int>? alsoHeldInPlace = null)
+    {
+        HashSet<int> pinned = HeldPositions(sequence, motifs, alsoHeldInPlace);
         SortedDictionary<char, int> counts = new();
 
         for (int i = 0; i < sequence.Length; i++)

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentAccession.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentAccession.cs
@@ -1,0 +1,150 @@
+﻿#nullable enable
+using System;
+using System.Globalization;
+
+namespace UsefulProteomicsDatabases.EntrapmentGeneration;
+
+/// <summary>
+/// The accession an entrapment protein wears, and how to read the target and fold back out of it.
+/// </summary>
+/// <remarks>
+/// <para>Two existing conventions are followed rather than a third invented. The entrapment marker
+/// goes <b>first</b>, because <see cref="ProteinDbLoader"/> decides a protein is entrapment by
+/// looking for the identifier anywhere in its accession, and prepends it when absent -- so an
+/// accession shaped this way reloads as entrapment with no extra argument and is never
+/// double-prefixed. The fold goes <b>last</b>, matching
+/// <c>VariantApplication.GetAccession</c>, which appends derived detail as a suffix.</para>
+/// <para>Everything needed to pair a discovery back to its target therefore travels in the
+/// accession, which a search already reports. Nothing has to be carried alongside the database, and
+/// nothing leaks into the sequence -- which matters, because target and partner are deliberately
+/// identical in mass and composition and must stay that way.</para>
+/// </remarks>
+public static class EntrapmentAccession
+{
+    private const string FoldMarker = "_f";
+
+    /// <summary>
+    /// Marks an entry taken from a foreign proteome rather than rearranged from a target.
+    /// </summary>
+    /// <remarks>
+    /// It sits immediately after the identifier, so a foreign entry reads
+    /// <c>Random_foreign_P12345</c>. Two things had to be true at once: a consumer scanning for the
+    /// entrapment identifier must still find it -- miss one and a foreign entry is counted as a
+    /// <i>target</i>, which corrupts the estimate in the worst direction -- and
+    /// <see cref="TryParse"/> must refuse it, because there is no target to name.
+    /// </remarks>
+    private const string ForeignMarker = "foreign_";
+
+    /// <summary>The accession for one fold of one target's entrapment partner.</summary>
+    /// <exception cref="MzLibUtil.MzLibException">The target accession is missing, or the fold is negative.</exception>
+    public static string Format(string targetAccession, int fold,
+        string entrapmentIdentifier = ProteinDbLoader.DefaultEntrapmentIdentifier)
+    {
+        if (string.IsNullOrEmpty(targetAccession))
+        {
+            throw new MzLibUtil.MzLibException("An entrapment accession needs a target accession.");
+        }
+        if (fold < 0)
+        {
+            throw new MzLibUtil.MzLibException($"Fold must not be negative, but was {fold}.");
+        }
+
+        // The two forms have to be disjoint, and only TryParse was enforcing it. A target accession
+        // beginning with the foreign marker minted "Random_foreign_ABC_f0", which TryParse then
+        // refused and TryParseForeign claimed as the foreign entry "ABC_f0" -- a partner that could
+        // never be paired back and would be counted as a foreign entry instead. Refusing here is
+        // what makes the comment on TryParse's own refusal true.
+        if (targetAccession.StartsWith(ForeignMarker, StringComparison.Ordinal))
+        {
+            throw new MzLibUtil.MzLibException(
+                $"A target accession must not begin with \"{ForeignMarker}\", which is reserved for "
+                + $"entries taken from a foreign proteome, but was \"{targetAccession}\".");
+        }
+
+        return $"{entrapmentIdentifier}_{targetAccession}{FoldMarker}{fold.ToString(CultureInfo.InvariantCulture)}";
+    }
+
+    /// <summary>The accession for an entry taken from a foreign proteome.</summary>
+    /// <param name="foreignAccession">The protein's accession in its own database.</param>
+    /// <exception cref="MzLibUtil.MzLibException">The foreign accession is missing.</exception>
+    public static string FormatForeign(string foreignAccession,
+        string entrapmentIdentifier = ProteinDbLoader.DefaultEntrapmentIdentifier)
+    {
+        if (string.IsNullOrEmpty(foreignAccession))
+        {
+            throw new MzLibUtil.MzLibException("A foreign entrapment accession needs an accession.");
+        }
+
+        return $"{entrapmentIdentifier}_{ForeignMarker}{foreignAccession}";
+    }
+
+    /// <summary>Reads a foreign entry's own accession back out.</summary>
+    /// <returns>False when this is not a foreign entrapment accession.</returns>
+    public static bool TryParseForeign(string? accession, out string foreignAccession,
+        string entrapmentIdentifier = ProteinDbLoader.DefaultEntrapmentIdentifier)
+    {
+        foreignAccession = string.Empty;
+        string prefix = entrapmentIdentifier + "_" + ForeignMarker;
+        if (string.IsNullOrEmpty(accession)
+            || !accession.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        foreignAccession = accession.Substring(prefix.Length);
+        return foreignAccession.Length > 0;
+    }
+
+    /// <summary>
+    /// Reads the target accession and fold back out, or reports that this is not one of ours.
+    /// </summary>
+    /// <remarks>
+    /// The fold is taken from the <em>last</em> "_f&lt;digits&gt;" rather than by splitting on
+    /// underscores: UniProt entry names contain them, so a naive split loses the target.
+    /// </remarks>
+    public static bool TryParse(string? accession, out string targetAccession, out int fold,
+        string entrapmentIdentifier = ProteinDbLoader.DefaultEntrapmentIdentifier)
+    {
+        targetAccession = string.Empty;
+        fold = 0;
+
+        // Ordinal throughout, matching what Format writes. Comparing the prefix case-insensitively
+        // while comparing the fold marker case-sensitively let "RANDOM_P12345_F0" pass the first
+        // test and fail the second, so it was neither accepted nor rejected consistently.
+        string prefix = entrapmentIdentifier + "_";
+        if (string.IsNullOrEmpty(accession) || !accession.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // A foreign entry has no target, and its own accession may well end in something that looks
+        // like a fold marker -- "Random_foreign_ABC_f1" would otherwise parse as target "foreign_ABC".
+        // Refusing on the marker rather than on the shape keeps that from ever being a guess.
+        if (accession.StartsWith(prefix + ForeignMarker, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        int marker = accession.LastIndexOf(FoldMarker, StringComparison.Ordinal);
+        if (marker <= prefix.Length - 1)
+        {
+            return false;
+        }
+
+        string digits = accession.Substring(marker + FoldMarker.Length);
+        if (digits.Length == 0
+            || !int.TryParse(digits, NumberStyles.None, CultureInfo.InvariantCulture, out int parsedFold))
+        {
+            return false;
+        }
+
+        targetAccession = accession.Substring(prefix.Length, marker - prefix.Length);
+        if (targetAccession.Length == 0)
+        {
+            return false;
+        }
+
+        fold = parsedFold;
+        return true;
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentAssembler.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentAssembler.cs
@@ -33,13 +33,15 @@ public enum PieceOutcome
 public sealed class EntrapmentPiece
 {
     internal EntrapmentPiece(int index, string targetPiece, string? entrapmentPiece,
-        PieceOutcome outcome, EntrapmentFailure failure)
+        PieceOutcome outcome, EntrapmentFailure failure, int targetStart, int entrapmentStart)
     {
         Index = index;
         TargetPiece = targetPiece;
         EntrapmentPiece_ = entrapmentPiece;
         Outcome = outcome;
         Failure = failure;
+        TargetStart = targetStart;
+        EntrapmentStart = entrapmentStart;
     }
 
     /// <summary>Ordinal of this piece within the target, counted before anything was excised.</summary>
@@ -51,6 +53,21 @@ public sealed class EntrapmentPiece
     public string? EntrapmentPiece_ { get; }
 
     public PieceOutcome Outcome { get; }
+
+    /// <summary>Zero-based offset of this piece in the TARGET sequence.</summary>
+    public int TargetStart { get; }
+
+    /// <summary>
+    /// Zero-based offset of this piece in the ENTRAPMENT sequence, or -1 when it was excised.
+    /// </summary>
+    /// <remarks>
+    /// Not the same as <see cref="TargetStart"/> once anything earlier has been excised, and not
+    /// recoverable from <see cref="Index"/> either. Carried because every caller that wants to look
+    /// at a piece in its protein's coordinates -- to ask whether a modification still fits at its
+    /// position within the peptide, say -- otherwise has to re-derive it by re-running the digestion
+    /// and accumulating lengths, which two separate analysis harnesses did before this existed.
+    /// </remarks>
+    public int EntrapmentStart { get; }
 
     /// <summary>Why no partner was found, when <see cref="Outcome"/> is not <see cref="PieceOutcome.Permuted"/>.</summary>
     public EntrapmentFailure Failure { get; }
@@ -210,6 +227,9 @@ public static class EntrapmentAssembler
             int start = sites[index];
             int length = sites[index + 1] - start;
             string piece = targetSequence.Substring(start, length);
+            // Read before anything is appended, so it is where this piece WILL start rather than
+            // where the next one will.
+            int entrapmentStart = entrapment.Length;
 
             Func<string, IReadOnlyList<string>>? completesAForbiddenRun =
                 RejectRunCollisions(placed, digestionParams.MaxMissedCleavages, forbiddenSequences,
@@ -234,7 +254,7 @@ public static class EntrapmentAssembler
                 // A permuted piece was chosen with the run test applied, so this cannot fire -- it is
                 // asserted rather than assumed only because the count below must mean one thing.
                 pieces.Add(new EntrapmentPiece(index, piece, partner.EntrapmentSequence,
-                    PieceOutcome.Permuted, EntrapmentFailure.None));
+                    PieceOutcome.Permuted, EntrapmentFailure.None, start, entrapmentStart));
                 retainedTargetIndices.Add(index);
                 continue;
             }
@@ -265,14 +285,15 @@ public static class EntrapmentAssembler
                     initiatorMethionineCollisions.Add(strippedCollision);
                 }
                 pieces.Add(new EntrapmentPiece(index, piece, piece,
-                    PieceOutcome.KeptVerbatimTooShort, partner.Failure));
+                    PieceOutcome.KeptVerbatimTooShort, partner.Failure, start, entrapmentStart));
                 retainedTargetIndices.Add(index);
                 continue;
             }
 
             // Long enough to be identified, and no partner exists: drop it. Its positions stay
             // unmapped, which is what marks them excised.
-            pieces.Add(new EntrapmentPiece(index, piece, null, PieceOutcome.Excised, partner.Failure));
+            pieces.Add(new EntrapmentPiece(index, piece, null, PieceOutcome.Excised, partner.Failure,
+                start, -1));
         }
 
         int broken = CountRunsSpanningAGap(retainedTargetIndices, digestionParams.MaxMissedCleavages);

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentAssembler.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentAssembler.cs
@@ -62,7 +62,8 @@ public sealed class EntrapmentAssembly
     internal EntrapmentAssembly(string targetSequence, string entrapmentSequence,
         int[] targetToEntrapmentPosition, IReadOnlyList<EntrapmentPiece> pieces,
         int missedCleavagePeptidesSpanningAnExcision,
-        IReadOnlyList<string> unrepairableRunCollisionPeptides)
+        IReadOnlyList<string> unrepairableRunCollisionPeptides,
+        IReadOnlyList<string> initiatorMethionineCollisionPeptides)
     {
         TargetSequence = targetSequence;
         EntrapmentSequence = entrapmentSequence;
@@ -70,6 +71,7 @@ public sealed class EntrapmentAssembly
         Pieces = pieces;
         MissedCleavagePeptidesSpanningAnExcision = missedCleavagePeptidesSpanningAnExcision;
         UnrepairableRunCollisionPeptides = unrepairableRunCollisionPeptides;
+        InitiatorMethionineCollisionPeptides = initiatorMethionineCollisionPeptides;
     }
 
     public string TargetSequence { get; }
@@ -125,6 +127,27 @@ public sealed class EntrapmentAssembly
     /// </remarks>
     public IReadOnlyList<string> UnrepairableRunCollisionPeptides { get; }
 
+    /// <summary>
+    /// Peptides that are a real target peptide because a search removes the entrapment sequence's
+    /// INITIATOR METHIONINE, and no arrangement of the opening piece avoided it.
+    /// </summary>
+    /// <remarks>
+    /// <para>Digestion emits the opening piece twice, with and without the initiator methionine, so
+    /// a piece that is distinct from every target peptide can still have an M-stripped form that is
+    /// not. Every other piece is checked as itself and that is enough; this one is checked as itself
+    /// and as itself minus a residue.</para>
+    /// <para>The route survives a build at <c>MaxMissedCleavages = 0</c>, which deletes the run
+    /// route entirely, so it is the only way a real target peptide reaches the entrapment set there.
+    /// Measured on the reviewed human proteome before this check existed: two peptides under Arg-C
+    /// and two under Glu-C, none under Asp-N -- 0.0005% -- and, because a run collision was the only
+    /// reason the exclusion sidecar could name, they appeared in no list at all. A count of zero
+    /// here is the statement that the check ran, which an absent column is not.</para>
+    /// </remarks>
+    public IReadOnlyList<string> InitiatorMethionineCollisionPeptides { get; }
+
+    /// <summary>How many of <see cref="InitiatorMethionineCollisionPeptides"/> there are.</summary>
+    public int InitiatorMethionineCollisions => InitiatorMethionineCollisionPeptides.Count;
+
     public int ExcisedCount => Pieces.Count(p => p.Outcome == PieceOutcome.Excised);
 
     public int KeptVerbatimCount => Pieces.Count(p => p.Outcome == PieceOutcome.KeptVerbatimTooShort);
@@ -178,6 +201,7 @@ public static class EntrapmentAssembler
         // sequence, so a candidate can be tested against the runs it would complete.
         var placed = new List<string>(sites.Count - 1);
         var unrepairable = new List<string>();
+        var initiatorMethionineCollisions = new List<string>();
         int[] map = Enumerable.Repeat(-1, targetSequence.Length).ToArray();
         var retainedTargetIndices = new List<int>(sites.Count - 1);
 
@@ -191,9 +215,17 @@ public static class EntrapmentAssembler
                 RejectRunCollisions(placed, digestionParams.MaxMissedCleavages, forbiddenSequences,
                     digestionParams.MinLength, digestionParams.MaxLength);
 
+            // Keyed on what has actually been placed rather than on the piece's ordinal, because an
+            // excised opening piece promotes the next one -- the entrapment protein then begins
+            // wherever the first surviving piece begins, and that is the residue a search would
+            // treat as an initiator methionine.
+            Func<string, string?>? strippedOfInitiatorMethionine =
+                RejectInitiatorMethionineCollisions(entrapment.Length == 0, forbiddenSequences,
+                    digestionParams.MinLength, digestionParams.MaxLength);
+
             EntrapmentPeptide partner = EntrapmentPeptideGenerator.Create(piece, motifs, forbiddenSequences,
                 fold, foldCount, seed, TerminalAnchors(start, length, targetSequence.Length),
-                completesAForbiddenRun is null ? null : c => completesAForbiddenRun(c).Count > 0);
+                Reject(completesAForbiddenRun, strippedOfInitiatorMethionine));
 
             if (partner.Succeeded)
             {
@@ -222,6 +254,16 @@ public static class EntrapmentAssembler
                 {
                     unrepairable.Add(collision);
                 }
+                // Same rule for the initiator-methionine route, and for the same reason: a piece
+                // kept verbatim has no alternative to move to, so the collision is named rather than
+                // repaired. It cannot fire while MinLength is respected -- the stripped form is one
+                // residue shorter than a piece that was already too short -- and it is written
+                // because "cannot fire" is a claim the count is entitled to check.
+                string? strippedCollision = strippedOfInitiatorMethionine?.Invoke(piece);
+                if (strippedCollision is not null)
+                {
+                    initiatorMethionineCollisions.Add(strippedCollision);
+                }
                 pieces.Add(new EntrapmentPiece(index, piece, piece,
                     PieceOutcome.KeptVerbatimTooShort, partner.Failure));
                 retainedTargetIndices.Add(index);
@@ -236,7 +278,69 @@ public static class EntrapmentAssembler
         int broken = CountRunsSpanningAGap(retainedTargetIndices, digestionParams.MaxMissedCleavages);
 
         return new EntrapmentAssembly(targetSequence, entrapment.ToString(), map, pieces, broken,
-            unrepairable);
+            unrepairable, initiatorMethionineCollisions);
+    }
+
+    /// <summary>
+    /// The two per-candidate tests as one, or null when neither applies.
+    /// </summary>
+    /// <remarks>
+    /// Composed rather than chained inside the generator so that the generator keeps seeing a single
+    /// "is this candidate acceptable in context" predicate. Both tests are about what a candidate
+    /// becomes once something else is taken into account -- its neighbours, or a residue a search
+    /// removes -- and neither is a property of the candidate alone.
+    /// </remarks>
+    private static Func<string, bool>? Reject(Func<string, IReadOnlyList<string>>? completesAForbiddenRun,
+        Func<string, string?>? strippedOfInitiatorMethionine)
+    {
+        if (completesAForbiddenRun is null && strippedOfInitiatorMethionine is null)
+        {
+            return null;
+        }
+
+        return candidate =>
+            (completesAForbiddenRun is not null && completesAForbiddenRun(candidate).Count > 0)
+            || (strippedOfInitiatorMethionine is not null && strippedOfInitiatorMethionine(candidate) is not null);
+    }
+
+    /// <summary>
+    /// A test returning the real target peptide a candidate would become once a search removes its
+    /// initiator methionine, or null if it would become none.
+    /// </summary>
+    /// <remarks>
+    /// <para>Applies only to the piece that will OPEN the entrapment protein, and only when that
+    /// piece begins with methionine, because those are the only conditions under which a search
+    /// emits a shortened form at all (<c>InitiatorMethionineBehavior.Variable</c>, the default).
+    /// Every other piece is fully covered by testing the candidate itself.</para>
+    /// <para>The length bound is the same one <see cref="RejectRunCollisions"/> applies, and for the
+    /// same reason: the pairing index counts a peptide as searchable only within
+    /// <c>[MinLength, MaxLength]</c>, so testing outside that range would reject candidates over
+    /// sequences no search can report and put the exclusion list on different footing from the
+    /// population it is meant to be subtracted from.</para>
+    /// </remarks>
+    private static Func<string, string?>? RejectInitiatorMethionineCollisions(bool willOpenTheProtein,
+        IReadOnlySet<string> forbiddenSequences, int minLength, int maxLength)
+    {
+        if (!willOpenTheProtein)
+        {
+            return null;
+        }
+
+        return candidate =>
+        {
+            if (candidate.Length == 0 || candidate[0] != 'M')
+            {
+                return null;
+            }
+
+            string stripped = candidate.Substring(1);
+            if (stripped.Length < minLength || stripped.Length > maxLength)
+            {
+                return null;
+            }
+
+            return forbiddenSequences.Contains(stripped) ? stripped : null;
+        };
     }
 
     /// <summary>
@@ -291,24 +395,43 @@ public static class EntrapmentAssembler
     }
 
     /// <summary>
-    /// Positions within a piece that must not move because they are the PROTEIN's termini.
+    /// Positions within a piece that must not move: the PROTEIN's termini, and the PIECE's own.
     /// </summary>
     /// <remarks>
-    /// <para>A modification can be restricted to the N- or C-terminus, and a rearrangement that
-    /// moved that residue away would make it invalid for its location -- mzLib then drops it, and
-    /// nothing counts the loss. Measured before anchoring: 3,946 N-terminal and 31 C-terminal
-    /// modifications lost across the human proteome, 2.4% of all of them.</para>
-    /// <para>Both of the first two positions are held, not just the first: a modification annotated
-    /// after initiator-methionine cleavage sits on the second residue.</para>
+    /// <para>A modification can be restricted to a terminus, and a rearrangement that moved that
+    /// residue away makes it invalid for its location. Measured before protein anchoring: 3,946
+    /// "N-terminal." and 31 "C-terminal." modifications lost across the human proteome, 2.4% of all
+    /// of them. Both of the protein's first two positions are held, not just the first: a
+    /// modification annotated after initiator-methionine cleavage sits on the second residue.</para>
+    /// <para><b>The piece's own termini are held for a restriction that is not protein-level:
+    /// "Peptide N-terminal." and "Peptide C-terminal.", which are satisfied per digestion product
+    /// rather than once per entry.</b> That case fails far more quietly than the protein one, and in
+    /// both directions at once. <c>ModificationLocalization.ModFits</c> is called with the
+    /// digestion-product index set to zero while a protein is being built, so a peptide-level
+    /// restriction falls through to "fits" and the annotation is transported and written; it is
+    /// evaluated for real only at digestion, where the modification no longer fits its new position
+    /// and the peptidoform hypothesis simply does not exist. The in-count equals the out-count, no
+    /// counter moves, and the entrapment peptide has silently lost a hypothesis its target still
+    /// has. Measured on the reviewed human proteome at MaxMissedCleavages 0: without this anchor
+    /// 69.00% of Arg-C pieces and 65.42% of Glu-C pieces move their first residue, and 72.68% of
+    /// Asp-N pieces move their last -- complementary, because for a C-terminal cutter the last
+    /// residue IS the pinned cleavage residue and for an N-terminal cutter the first one is.</para>
+    /// <para>The cost was measured before it was paid, because the obvious guess is that holding two
+    /// more positions on every piece is much dearer than holding three per protein. It is not:
+    /// pieces with no rearrangement at all rise from 32 to 52 (Arg-C), 36 to 56 (Glu-C) and 54 to 72
+    /// (Asp-N) out of roughly 400,000 searchable pieces -- 0.0075% to 0.012% -- and the mean natural
+    /// log of the permutation space falls by about two, from 37-51.</para>
     /// <para>This is unconditional -- the termini are anchored whether or not anything is actually
     /// modified there. Anchoring reactively would make the entrapment sequence a function of
     /// (sequence, seed, modifications) rather than (sequence, seed), so two databases built from the
     /// same proteome with different annotations would disagree on their sequences and the
-    /// determinism the pairing rests on would quietly weaken. The cost is two or three positions per
-    /// protein, against permutation spaces in the millions.</para>
+    /// determinism the pairing rests on would quietly weaken.</para>
     /// </remarks>
     private static int[]? TerminalAnchors(int pieceStart, int pieceLength, int proteinLength)
     {
+        // The piece's own termini, in piece coordinates already.
+        var anchors = new HashSet<int> { 0, pieceLength - 1 };
+
         // Protein coordinates, translated into piece coordinates -- not piece coordinates that
         // happen to coincide. When the opening piece is a single residue the protein's second
         // residue lives in the NEXT piece, and computing "the first two" per piece never held it, so
@@ -319,17 +442,20 @@ public static class EntrapmentAssembler
             ? new[] { 0, 1, proteinLength - 1 }
             : new[] { 0 };
 
-        List<int>? anchors = null;
         foreach (int position in protein)
         {
             int within = position - pieceStart;
             if (within >= 0 && within < pieceLength)
             {
-                (anchors ??= new List<int>(3)).Add(within);
+                anchors.Add(within);
             }
         }
 
-        return anchors?.ToArray();
+        // Ordered, because this becomes part of the pinned-position pattern that the pairing key
+        // compares and a set's enumeration order is not a contract.
+        int[] ordered = anchors.ToArray();
+        Array.Sort(ordered);
+        return ordered;
     }
 
     /// <summary>

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentAssembler.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentAssembler.cs
@@ -1,0 +1,441 @@
+﻿#nullable enable
+using System;
+using MzLibUtil;
+using Omics.Digestion;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace UsefulProteomicsDatabases.EntrapmentGeneration;
+
+/// <summary>What became of one base piece of a target sequence.</summary>
+public enum PieceOutcome
+{
+    /// <summary>Rearranged into an isomeric partner.</summary>
+    Permuted,
+
+    /// <summary>
+    /// Has no rearrangement, but is shorter than the minimum peptide length, so it is never
+    /// identified on its own. Kept exactly as it was: no real peptide enters the entrapment
+    /// database, and identity is a rearrangement, so isomerism survives.
+    /// </summary>
+    KeptVerbatimTooShort,
+
+    /// <summary>
+    /// Has no usable rearrangement and *is* long enough to be identified, so it is dropped from the
+    /// entrapment sequence. Emitting it unchanged would place a genuine target peptide inside the
+    /// entrapment database, where every hit is supposed to be false.
+    /// </summary>
+    Excised
+}
+
+/// <summary>One base piece of the target and what happened to it.</summary>
+public sealed class EntrapmentPiece
+{
+    internal EntrapmentPiece(int index, string targetPiece, string? entrapmentPiece,
+        PieceOutcome outcome, EntrapmentFailure failure)
+    {
+        Index = index;
+        TargetPiece = targetPiece;
+        EntrapmentPiece_ = entrapmentPiece;
+        Outcome = outcome;
+        Failure = failure;
+    }
+
+    /// <summary>Ordinal of this piece within the target, counted before anything was excised.</summary>
+    public int Index { get; }
+
+    public string TargetPiece { get; }
+
+    /// <summary>The piece as it appears in the entrapment sequence, or null when excised.</summary>
+    public string? EntrapmentPiece_ { get; }
+
+    public PieceOutcome Outcome { get; }
+
+    /// <summary>Why no partner was found, when <see cref="Outcome"/> is not <see cref="PieceOutcome.Permuted"/>.</summary>
+    public EntrapmentFailure Failure { get; }
+}
+
+/// <summary>An entrapment sequence, and the record of how it was built.</summary>
+public sealed class EntrapmentAssembly
+{
+    internal EntrapmentAssembly(string targetSequence, string entrapmentSequence,
+        int[] targetToEntrapmentPosition, IReadOnlyList<EntrapmentPiece> pieces,
+        int missedCleavagePeptidesSpanningAnExcision,
+        IReadOnlyList<string> unrepairableRunCollisionPeptides)
+    {
+        TargetSequence = targetSequence;
+        EntrapmentSequence = entrapmentSequence;
+        TargetToEntrapmentPosition = targetToEntrapmentPosition;
+        Pieces = pieces;
+        MissedCleavagePeptidesSpanningAnExcision = missedCleavagePeptidesSpanningAnExcision;
+        UnrepairableRunCollisionPeptides = unrepairableRunCollisionPeptides;
+    }
+
+    public string TargetSequence { get; }
+
+    public string EntrapmentSequence { get; }
+
+    /// <summary>
+    /// Position in the entrapment sequence holding each target position's residue, or -1 where the
+    /// piece was excised. Modifications ride across on this.
+    /// </summary>
+    public int[] TargetToEntrapmentPosition { get; }
+
+    public IReadOnlyList<EntrapmentPiece> Pieces { get; }
+
+    /// <summary>
+    /// Missed-cleavage peptides of the entrapment sequence whose constituent pieces were not
+    /// adjacent in the target, so they have no isomeric counterpart there.
+    /// </summary>
+    /// <remarks>
+    /// Every other missed-cleavage peptide is isomeric for free, because base-piece compositions
+    /// add. That is true but not obvious, and these exceptions are counted rather than left
+    /// implicit, because anyone computing mass statistics over the entrapment set will assume the
+    /// invariant holds everywhere.
+    /// </remarks>
+    public int MissedCleavagePeptidesSpanningAnExcision { get; }
+
+    /// <summary>
+    /// Missed-cleavage peptides of this entrapment sequence that equal a real target peptide and
+    /// could not be avoided.
+    /// </summary>
+    /// <remarks>
+    /// <para>Each piece is permuted away from any collision it can be permuted away from, runs
+    /// included. What cannot be repaired is a run whose final piece has exactly one arrangement --
+    /// a short low-complexity piece such as <c>AAR</c>, where holding the cleavage residue leaves
+    /// nothing to reorder. There is no candidate to move to, so the collision stands.</para>
+    /// <para>Repairing it would mean backtracking into an already-placed piece or excising a
+    /// perfectly good one, and this project counts collisions rather than silently repairing them.
+    /// Measured on the reviewed human proteome: 1,794 such peptides, 0.065% of the target set,
+    /// 97.9% of them ending in a piece with no alternative and 80% exactly at the minimum
+    /// searchable length of seven residues. A search that matches one counts a real peptide as an
+    /// entrapment discovery, so anyone reading an entrapment count needs this number beside it.</para>
+    /// </remarks>
+    public int UnrepairableRunCollisions => UnrepairableRunCollisionPeptides.Count;
+
+    /// <summary>
+    /// The actual peptides behind <see cref="UnrepairableRunCollisions"/> -- entrapment
+    /// missed-cleavage peptides that are also real target peptides.
+    /// </summary>
+    /// <remarks>
+    /// A count tells a consumer how much to distrust an entrapment total; the sequences let it
+    /// subtract them. The glyco project asked for the list rather than the number for exactly that
+    /// reason, and a list is the only form in which "exclude these" is actionable.
+    /// </remarks>
+    public IReadOnlyList<string> UnrepairableRunCollisionPeptides { get; }
+
+    public int ExcisedCount => Pieces.Count(p => p.Outcome == PieceOutcome.Excised);
+
+    public int KeptVerbatimCount => Pieces.Count(p => p.Outcome == PieceOutcome.KeptVerbatimTooShort);
+}
+
+/// <summary>
+/// Builds an entrapment sequence from a target one, by rearranging each of its base pieces in place.
+/// </summary>
+/// <remarks>
+/// <para>The sequence is split at the digestion agent's own cleavage sites
+/// (<see cref="DigestionAgent.GetDigestionSiteIndices"/>), each piece is given an isomeric partner
+/// by <see cref="EntrapmentPeptideGenerator"/>, and the partners are concatenated back together.
+/// Because cleavage sites stay where they were, the entrapment sequence digests into the same
+/// pieces, each isomeric with the target's.</para>
+/// <para>Rearranging the <b>zero-missed-cleavage</b> pieces is enough to cover missed cleavages
+/// too: a missed-cleavage peptide is a run of adjacent pieces, and composition adds, so it is
+/// isomeric with its target counterpart without being handled separately. The exception is a run
+/// spanning an excision, which has no counterpart -- those are counted.</para>
+/// </remarks>
+public static class EntrapmentAssembler
+{
+    /// <summary>
+    /// Builds the entrapment sequence for one fold.
+    /// </summary>
+    /// <param name="targetSequence">The target sequence, typically a protein.</param>
+    /// <param name="digestionParams">Supplies the cleavage sites and the minimum peptide length
+    /// below which a piece is not identifiable on its own.</param>
+    /// <param name="forbiddenSequences">Sequences no partner may equal, normally every target peptide.</param>
+    /// <param name="fold">Zero-based fold, in <c>[0, foldCount)</c>.</param>
+    /// <param name="foldCount">Partners per target -- the <c>r</c> of an r-fold database.</param>
+    /// <param name="seed">Changes every choice reproducibly.</param>
+    public static EntrapmentAssembly Assemble(string targetSequence, IDigestionParams digestionParams,
+        IReadOnlySet<string> forbiddenSequences, int fold = 0, int foldCount = 1, int seed = 1)
+    {
+        if (string.IsNullOrEmpty(targetSequence))
+        {
+            throw new MzLibException("Cannot assemble an entrapment sequence from an empty sequence.");
+        }
+
+        List<DigestionMotif> motifs = digestionParams.DigestionAgent.DigestionMotifs;
+        RefuseAgentsWhoseSitesCannotBeHeld(digestionParams.DigestionAgent.Name, motifs);
+
+        // GetDigestionSiteIndices returns 0, every internal cleavage site, and the length -- a
+        // complete partition. It comes back from a hash set, so it needs ordering.
+        List<int> sites = digestionParams.DigestionAgent.GetDigestionSiteIndices(targetSequence);
+        sites.Sort();
+
+        var pieces = new List<EntrapmentPiece>(sites.Count - 1);
+        var entrapment = new StringBuilder(targetSequence.Length);
+        // The entrapment pieces already placed, in the order they appear in the entrapment
+        // sequence, so a candidate can be tested against the runs it would complete.
+        var placed = new List<string>(sites.Count - 1);
+        var unrepairable = new List<string>();
+        int[] map = Enumerable.Repeat(-1, targetSequence.Length).ToArray();
+        var retainedTargetIndices = new List<int>(sites.Count - 1);
+
+        for (int index = 0; index < sites.Count - 1; index++)
+        {
+            int start = sites[index];
+            int length = sites[index + 1] - start;
+            string piece = targetSequence.Substring(start, length);
+
+            Func<string, IReadOnlyList<string>>? completesAForbiddenRun =
+                RejectRunCollisions(placed, digestionParams.MaxMissedCleavages, forbiddenSequences,
+                    digestionParams.MinLength, digestionParams.MaxLength);
+
+            EntrapmentPeptide partner = EntrapmentPeptideGenerator.Create(piece, motifs, forbiddenSequences,
+                fold, foldCount, seed, TerminalAnchors(start, length, targetSequence.Length),
+                completesAForbiddenRun is null ? null : c => completesAForbiddenRun(c).Count > 0);
+
+            if (partner.Succeeded)
+            {
+                AppendPiece(entrapment, map, start, partner.EntrapmentSequence!, partner.SwappedPositions!);
+                placed.Add(partner.EntrapmentSequence!);
+                // A permuted piece was chosen with the run test applied, so this cannot fire -- it is
+                // asserted rather than assumed only because the count below must mean one thing.
+                pieces.Add(new EntrapmentPiece(index, piece, partner.EntrapmentSequence,
+                    PieceOutcome.Permuted, EntrapmentFailure.None));
+                retainedTargetIndices.Add(index);
+                continue;
+            }
+
+            // Too short to be identified on its own: keep it, unchanged, rather than tearing a hole
+            // in the protein for a piece nobody could have matched anyway.
+            if (piece.Length < digestionParams.MinLength)
+            {
+                AppendPiece(entrapment, map, start, piece, Identity(piece.Length));
+                placed.Add(piece);
+                // Kept verbatim because it has no alternative arrangement, so if it completes a
+                // forbidden run there is nothing to move to. Name it; do not repair it.
+                // Every run this piece completes, not merely the first: several can end here, and
+                // each is a distinct peptide a consumer has to exclude.
+                foreach (string collision in completesAForbiddenRun?.Invoke(piece)
+                                             ?? System.Array.Empty<string>())
+                {
+                    unrepairable.Add(collision);
+                }
+                pieces.Add(new EntrapmentPiece(index, piece, piece,
+                    PieceOutcome.KeptVerbatimTooShort, partner.Failure));
+                retainedTargetIndices.Add(index);
+                continue;
+            }
+
+            // Long enough to be identified, and no partner exists: drop it. Its positions stay
+            // unmapped, which is what marks them excised.
+            pieces.Add(new EntrapmentPiece(index, piece, null, PieceOutcome.Excised, partner.Failure));
+        }
+
+        int broken = CountRunsSpanningAGap(retainedTargetIndices, digestionParams.MaxMissedCleavages);
+
+        return new EntrapmentAssembly(targetSequence, entrapment.ToString(), map, pieces, broken,
+            unrepairable);
+    }
+
+    /// <summary>
+    /// Refuses a digestion agent whose cleavage sites this assembler cannot hold in place.
+    /// </summary>
+    /// <remarks>
+    /// <para>The class invariant is that the entrapment sequence digests into the same pieces as its
+    /// target. That rests on every cleavage site being pinned, and two kinds of motif escape the
+    /// pinning that <see cref="DecoySequenceValidator.CleavageSitePositions"/> performs.</para>
+    /// <para>A <b>preventing</b> motif pins nothing at all: <c>CleavageSitePositions</c> skips a
+    /// position where a motif fits but is prevented, so under <c>trypsin|P</c>'s <c>K[P]|</c> neither
+    /// the K nor the P after it is held. Moving that P away invents a cleavage site the target
+    /// lacked; moving another P next to another K destroys one. That is five shipped agents --
+    /// <c>chymotrypsin|P</c>, <c>elastase|P</c>, <c>Lys-C|P</c>, <c>trypsin|P</c> and
+    /// <c>subtilisin|P</c> -- and <c>trypsin|P</c> is an ordinary choice in real work.</para>
+    /// <para>A <b>multi-residue</b> motif has its span cut by the piece boundary: <c>TX|T</c> cuts
+    /// after the second of three residues, so one piece ends <c>…TX</c> and the next begins
+    /// <c>T…</c>, neither fragment matches inside its own piece, and nothing is held at the seam.
+    /// That covers <c>collagenase</c> (<c>GPX|GPX</c>) and <c>StcE-trypsin</c> -- seven shipped
+    /// agents in all. The guard keys on the motif rather than on the name, so it also refuses the
+    /// bare <c>StcE</c> that mzLib gains separately, without naming it here.</para>
+    /// <para>The real fix is to pin across piece boundaries, which means this stops being a per-piece
+    /// loop. Until then, refusing is the honest answer: a database that digests differently from its
+    /// target produces peptides that then fail to pair, and it does so silently. Failing at the call
+    /// is better than a caller discovering it from a search result.</para>
+    /// </remarks>
+    /// <exception cref="MzLibException">The agent carries a preventing or multi-residue motif.</exception>
+    internal static void RefuseAgentsWhoseSitesCannotBeHeld(string agentName, List<DigestionMotif> motifs)
+    {
+        foreach (DigestionMotif motif in motifs ?? new List<DigestionMotif>())
+        {
+            if (!string.IsNullOrEmpty(motif.PreventingCleavage))
+            {
+                throw new MzLibException(
+                    $"The digestion agent '{agentName}' has a preventing-cleavage motif "
+                    + $"('{motif.InducingCleavage}[{motif.PreventingCleavage}]'), whose residues this "
+                    + "assembler cannot hold in place. A rearrangement could then invent or destroy a "
+                    + "cleavage site, so the entrapment protein would not digest into the same pieces "
+                    + "as its target and its peptides would not pair. Use an agent without one.");
+            }
+
+            if ((motif.InducingCleavage?.Length ?? 0) > 1)
+            {
+                throw new MzLibException(
+                    $"The digestion agent '{agentName}' has a multi-residue motif "
+                    + $"('{motif.InducingCleavage}'), whose span is cut by the boundary between base "
+                    + "pieces, so neither fragment matches inside its own piece and nothing is held at "
+                    + "the seam. The entrapment protein would not digest into the same pieces as its "
+                    + "target. Use a single-residue agent.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Positions within a piece that must not move because they are the PROTEIN's termini.
+    /// </summary>
+    /// <remarks>
+    /// <para>A modification can be restricted to the N- or C-terminus, and a rearrangement that
+    /// moved that residue away would make it invalid for its location -- mzLib then drops it, and
+    /// nothing counts the loss. Measured before anchoring: 3,946 N-terminal and 31 C-terminal
+    /// modifications lost across the human proteome, 2.4% of all of them.</para>
+    /// <para>Both of the first two positions are held, not just the first: a modification annotated
+    /// after initiator-methionine cleavage sits on the second residue.</para>
+    /// <para>This is unconditional -- the termini are anchored whether or not anything is actually
+    /// modified there. Anchoring reactively would make the entrapment sequence a function of
+    /// (sequence, seed, modifications) rather than (sequence, seed), so two databases built from the
+    /// same proteome with different annotations would disagree on their sequences and the
+    /// determinism the pairing rests on would quietly weaken. The cost is two or three positions per
+    /// protein, against permutation spaces in the millions.</para>
+    /// </remarks>
+    private static int[]? TerminalAnchors(int pieceStart, int pieceLength, int proteinLength)
+    {
+        // Protein coordinates, translated into piece coordinates -- not piece coordinates that
+        // happen to coincide. When the opening piece is a single residue the protein's second
+        // residue lives in the NEXT piece, and computing "the first two" per piece never held it, so
+        // an "N-terminal." modification annotated at position 2 could still move. Under trypsin that
+        // needs an entry beginning with K or R, which is rare rather than impossible, and the
+        // documentation promised to cover it either way.
+        int[] protein = proteinLength > 1
+            ? new[] { 0, 1, proteinLength - 1 }
+            : new[] { 0 };
+
+        List<int>? anchors = null;
+        foreach (int position in protein)
+        {
+            int within = position - pieceStart;
+            if (within >= 0 && within < pieceLength)
+            {
+                (anchors ??= new List<int>(3)).Add(within);
+            }
+        }
+
+        return anchors?.ToArray();
+    }
+
+    /// <summary>
+    /// A test that rejects a candidate piece which would complete a run equal to a real target
+    /// peptide.
+    /// </summary>
+    /// <remarks>
+    /// <para>A missed-cleavage peptide is a run of adjacent base pieces, and composition adds, so
+    /// the run is isomeric with its target counterpart for free. What does <i>not</i> come for free
+    /// is that the run differs from every real peptide: each piece is permuted knowing only itself,
+    /// so <c>E1+E2</c> can equal a genuine target peptide even when neither <c>E1</c> nor <c>E2</c>
+    /// does. Such a sequence is a real peptide sitting in the entrapment database, where every hit
+    /// is supposed to be false, and a search that matches it counts a true peptide as an entrapment
+    /// discovery.</para>
+    /// <para>Every run ends at some piece, so testing the runs that <i>end</i> at the piece being
+    /// placed covers all of them, and left-to-right assembly has already placed everything such a
+    /// run needs. The runs are built once per piece rather than once per candidate, because the
+    /// probe loop may try many candidates and the preceding pieces do not change between them.</para>
+    /// <para>The cost is that a piece's permutation now depends on its neighbours, so the
+    /// construction is a pure function of <c>(protein, seed)</c> rather than of <c>(piece, seed)</c>.
+    /// Determinism, parallel safety across proteins, and the composition-plus-pinning pairing key
+    /// are all unaffected -- the piece is still a permutation of its target piece.</para>
+    /// </remarks>
+    private static Func<string, IReadOnlyList<string>>? RejectRunCollisions(List<string> placed,
+        int maxMissedCleavages, IReadOnlySet<string> forbiddenSequences,
+        int minLength, int maxLength)
+    {
+        if (maxMissedCleavages < 1 || placed.Count == 0)
+        {
+            return null;
+        }
+
+        int longest = Math.Min(maxMissedCleavages, placed.Count);
+        var runs = new string[longest];
+        var builder = new StringBuilder();
+        for (int back = 1; back <= longest; back++)
+        {
+            builder.Insert(0, placed[placed.Count - back]);
+            runs[back - 1] = builder.ToString();
+        }
+
+        // Returns *every* offending run rather than the first, and only runs a search could report.
+        //
+        // Both halves were wrong in ways that pulled the count in opposite directions. Returning on
+        // the first match meant several colliding runs ending at one piece were reported as one, so
+        // a property documenting a count of peptides was really counting pieces. And with no length
+        // bound a concatenation shorter than MinLength -- six residues from "AAKAAR" under a minimum
+        // of seven -- still rejected candidates and still counted, while the pairing index that
+        // defines the searchable population had already excluded it. The assembler and the pairing
+        // have to agree about what a peptide is or the exclusion list is not on the same footing as
+        // the population it is meant to be subtracted from.
+        return candidate =>
+        {
+            List<string>? offending = null;
+            foreach (string run in runs)
+            {
+                int length = run.Length + candidate.Length;
+                if (length < minLength || length > maxLength)
+                {
+                    continue;
+                }
+
+                string whole = run + candidate;
+                if (forbiddenSequences.Contains(whole))
+                {
+                    (offending ??= new List<string>()).Add(whole);
+                }
+            }
+
+            return (IReadOnlyList<string>)offending ?? System.Array.Empty<string>();
+        };
+    }
+
+    private static void AppendPiece(StringBuilder entrapment, int[] map, int targetStart,
+        string entrapmentPiece, int[] swappedWithinPiece)
+    {
+        int entrapmentStart = entrapment.Length;
+        entrapment.Append(entrapmentPiece);
+
+        for (int offset = 0; offset < swappedWithinPiece.Length; offset++)
+        {
+            map[targetStart + offset] = entrapmentStart + swappedWithinPiece[offset];
+        }
+    }
+
+    private static int[] Identity(int length) => Enumerable.Range(0, length).ToArray();
+
+    /// <summary>
+    /// How many runs of up to <paramref name="maxMissedCleavages"/>+1 retained pieces are not
+    /// contiguous in the target -- i.e. how many missed-cleavage peptides straddle an excision.
+    /// </summary>
+    private static int CountRunsSpanningAGap(List<int> retainedTargetIndices, int maxMissedCleavages)
+    {
+        int broken = 0;
+
+        for (int i = 0; i < retainedTargetIndices.Count; i++)
+        {
+            for (int span = 2; span <= maxMissedCleavages + 1 && i + span - 1 < retainedTargetIndices.Count; span++)
+            {
+                if (retainedTargetIndices[i + span - 1] - retainedTargetIndices[i] != span - 1)
+                {
+                    broken++;
+                }
+            }
+        }
+
+        return broken;
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentMassGroups.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentMassGroups.cs
@@ -1,0 +1,458 @@
+#nullable enable
+using MzLibUtil;
+using Omics;
+using Omics.Modifications;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace UsefulProteomicsDatabases.EntrapmentGeneration;
+
+/// <summary>
+/// A set of modifications a search engine cannot tell apart on a precursor, and the residues they
+/// can sit on.
+/// </summary>
+/// <remarks>
+/// <para><b>Why a group and not a modification.</b> The localization candidate set a search actually
+/// explores is defined by <b>mass shift</b>, not by modification name. A precursor carries a mass;
+/// every modification of that mass competes for it. Measured on a real GPTMD database by the first
+/// consumer of this code: grouping by modification description, 32.7% of (peptide, modification)
+/// pairs have two or more candidate sites; grouping by <b>mass</b>, 71.3% do. <c>+15.995</c> alone
+/// spans seventeen modification IDs -- Hydroxylation on K/N/P and Oxidation on C/D/E/F/H/I/L/Q/R/S/T/V/W/Y.
+/// An invariant stated per modification is therefore not the invariant the search engine sees, and
+/// the two sentences are easy to confuse: <i>"the companion carries the same modifications"</i> and
+/// <i>"the companion has the same mass groups"</i> are different claims.</para>
+/// <para><b>Residues, not names.</b> Membership is by <c>(residue, mass)</c>. Names cannot be relied
+/// on: the modification dictionary has no residue-specific N-terminal acetyl record, so a wildcard
+/// <c>Acetylation on X</c> is kept in real configurations, and being "explicit" would mean
+/// hand-authoring modifications -- exactly the sort of free choice this project avoids.</para>
+/// </remarks>
+public sealed class MassGroup
+{
+    internal MassGroup(double representativeMass, double lowestMass, double highestMass,
+        IReadOnlySet<char> residues, IReadOnlyList<string> modifications)
+    {
+        RepresentativeMass = representativeMass;
+        LowestMass = lowestMass;
+        HighestMass = highestMass;
+        Residues = residues;
+        Modifications = modifications;
+    }
+
+    /// <summary>The group's lowest member mass -- a stable label, not an average.</summary>
+    /// <remarks>
+    /// An average would move when a member is added, so two reports of the same database under
+    /// different modification lists would name the same group differently and could not be diffed.
+    /// </remarks>
+    public double RepresentativeMass { get; }
+
+    public double LowestMass { get; }
+
+    public double HighestMass { get; }
+
+    /// <summary>Residues that some member of this group can occupy.</summary>
+    public IReadOnlySet<char> Residues { get; }
+
+    /// <summary>The member modifications, by <c>IdWithMotif</c>, for a reader rather than for logic.</summary>
+    public IReadOnlyList<string> Modifications { get; }
+
+    /// <summary>How wide the group actually is, in daltons.</summary>
+    public double Span => HighestMass - LowestMass;
+
+    public override string ToString() =>
+        RepresentativeMass.ToString("F5", CultureInfo.InvariantCulture)
+        + " {" + string.Concat(Residues.OrderBy(c => c)) + "}";
+}
+
+/// <summary>
+/// The mass groups of a set of modifications, and the counts a companion peptide must match.
+/// </summary>
+/// <remarks>
+/// <para><b>The tolerance is a parameter and deliberately has no clever default.</b> Where the
+/// boundary sits is the whole question -- it decides whether near-isobars such as phospho and sulfo
+/// (9.5 mDa apart) are one candidate set or two -- and picking it here would be choosing a consumer's
+/// analysis for them. Zero groups only exactly-equal masses, which is already the right unit and is
+/// the conservative answer.</para>
+/// <para><b>Grouping is single-linkage</b>, so a chain of members each within tolerance of the next
+/// forms one group even when its ends are further apart than the tolerance. That is the honest
+/// reading of "cannot be told apart" transitively, and <see cref="MassGroup.Span"/> is published so a
+/// reader can see when it has happened rather than discover it later.</para>
+/// <para><b>What this does not model.</b> A modification whose composition is an integer multiple of
+/// a smaller one acquires a combinatorial competitor once several modifications are allowed on one
+/// peptide -- trimethylation is exactly isobaric with three methylations. That competitor is a
+/// property of the search's settings rather than of the database, and composition preservation
+/// already guarantees the companion offers the same residues to it, so it is documented here rather
+/// than counted.</para>
+/// </remarks>
+public sealed class MassGroupIndex
+{
+    private readonly List<MassGroup> _groups;
+
+    /// <param name="modifications">The modifications in play -- normally every one annotated in the
+    /// target database.</param>
+    /// <param name="toleranceDaltons">Masses within this of one another join the same group.
+    /// Zero groups only exactly-equal masses.</param>
+    public MassGroupIndex(IEnumerable<Modification> modifications, double toleranceDaltons = 0.0)
+    {
+        if (modifications is null)
+        {
+            throw new MzLibException("Mass groups need the modifications they are grouping.");
+        }
+        if (toleranceDaltons < 0 || double.IsNaN(toleranceDaltons))
+        {
+            throw new MzLibException(
+                $"Mass-group tolerance must be zero or more, but was {toleranceDaltons}.");
+        }
+
+        Tolerance = toleranceDaltons;
+
+        // A modification with no mass cannot define a mass group and is dropped rather than treated
+        // as zero -- a zero-mass group would swallow every other unmassed modification and read as a
+        // real candidate set.
+        var usable = modifications
+            .Where(m => m is not null && m.MonoisotopicMass.HasValue
+                        && double.IsFinite(m.MonoisotopicMass.Value))
+            .OrderBy(m => m.MonoisotopicMass!.Value)
+            .ToList();
+
+        _groups = new List<MassGroup>();
+        var pending = new List<Modification>();
+        foreach (Modification m in usable)
+        {
+            if (pending.Count > 0
+                && m.MonoisotopicMass!.Value - pending[^1].MonoisotopicMass!.Value > toleranceDaltons)
+            {
+                _groups.Add(Close(pending));
+                pending.Clear();
+            }
+            pending.Add(m);
+        }
+        if (pending.Count > 0)
+        {
+            _groups.Add(Close(pending));
+        }
+    }
+
+    public double Tolerance { get; }
+
+    public IReadOnlyList<MassGroup> Groups => _groups;
+
+    private static MassGroup Close(List<Modification> members)
+    {
+        var residues = new HashSet<char>();
+        var names = new List<string>();
+        foreach (Modification m in members)
+        {
+            foreach (char residue in ResiduesOf(m))
+            {
+                residues.Add(residue);
+            }
+            string name = m.IdWithMotif ?? m.OriginalId ?? "unnamed";
+            if (!names.Contains(name))
+            {
+                names.Add(name);
+            }
+        }
+
+        return new MassGroup(members[0].MonoisotopicMass!.Value, members[0].MonoisotopicMass!.Value,
+            members[^1].MonoisotopicMass!.Value, residues, names);
+    }
+
+    /// <summary>
+    /// The residues a modification's motif can sit on -- the capital letters of the motif.
+    /// </summary>
+    /// <remarks>
+    /// A motif is written with the modified residue capitalised and its context in lower case
+    /// ("Nxs" for an N-glycosylation sequon), so the capitals are the positions that carry the mass.
+    /// A wildcard "X" is expanded to every amino acid rather than kept as a literal, because a
+    /// wildcard modification really can sit anywhere and treating "X" as a residue would make a
+    /// peptide's capacity for it zero.
+    /// </remarks>
+    private static IEnumerable<char> ResiduesOf(Modification modification)
+    {
+        string motif = modification.Target?.ToString() ?? string.Empty;
+        foreach (char c in motif)
+        {
+            if (!char.IsUpper(c))
+            {
+                continue;
+            }
+            if (c == 'X')
+            {
+                foreach (char any in "ACDEFGHIKLMNPQRSTVWY")
+                {
+                    yield return any;
+                }
+            }
+            else
+            {
+                yield return c;
+            }
+        }
+    }
+
+    /// <summary>The group holding <paramref name="mass"/>, or null when none does.</summary>
+    public MassGroup? GroupFor(double mass)
+    {
+        foreach (MassGroup g in _groups)
+        {
+            if (mass >= g.LowestMass - Tolerance && mass <= g.HighestMass + Tolerance)
+            {
+                return g;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// How many residues of <paramref name="peptide"/> could carry <paramref name="group"/>'s mass.
+    /// </summary>
+    public static int Capacity(string peptide, MassGroup group)
+    {
+        if (string.IsNullOrEmpty(peptide) || group is null)
+        {
+            return 0;
+        }
+
+        int n = 0;
+        foreach (char c in peptide)
+        {
+            if (group.Residues.Contains(c))
+            {
+                n++;
+            }
+        }
+        return n;
+    }
+
+    /// <summary>
+    /// Annotated sites per mass group on one digestion product, counting only annotations a search
+    /// could actually apply there.
+    /// </summary>
+    /// <param name="polymerSequence">The whole protein the peptide came from.</param>
+    /// <param name="peptideStart">Zero-based offset of the peptide within it.</param>
+    /// <param name="peptideLength">Length of the peptide.</param>
+    /// <param name="annotations">The protein's modifications, keyed one-based.</param>
+    /// <remarks>
+    /// <b>The fit test is the point of this method.</b> An annotation is counted only where
+    /// <c>ModificationLocalization.ModFits</c> accepts it at its position <i>within the peptide</i>,
+    /// which is where a peptide-level restriction is finally judged. Counting annotations without it
+    /// reproduces the failure this exists to detect: a modification restricted to a peptide terminus
+    /// is transported, written, and counted by every protein-level tally, and then quietly does not
+    /// exist as a hypothesis because it no longer sits at the terminus.
+    /// </remarks>
+    public Dictionary<MassGroup, int> AnnotatedSites(string polymerSequence, int peptideStart,
+        int peptideLength, IDictionary<int, List<Modification>> annotations)
+    {
+        var counts = new Dictionary<MassGroup, int>();
+        if (annotations is null || string.IsNullOrEmpty(polymerSequence))
+        {
+            return counts;
+        }
+
+        for (int offset = 0; offset < peptideLength; offset++)
+        {
+            int oneBasedInPolymer = peptideStart + offset + 1;
+            if (!annotations.TryGetValue(oneBasedInPolymer, out List<Modification>? mods))
+            {
+                continue;
+            }
+
+            foreach (Modification m in mods)
+            {
+                if (m?.MonoisotopicMass is null || !double.IsFinite(m.MonoisotopicMass.Value))
+                {
+                    continue;
+                }
+                if (!ModificationLocalization.ModFits(m, polymerSequence, offset + 1, peptideLength,
+                        oneBasedInPolymer))
+                {
+                    continue;   // transported, written, and unusable -- exactly what we are counting
+                }
+
+                MassGroup? g = GroupFor(m.MonoisotopicMass.Value);
+                if (g is null)
+                {
+                    continue;
+                }
+                counts[g] = counts.GetValueOrDefault(g) + 1;
+            }
+        }
+
+        return counts;
+    }
+}
+
+/// <summary>Target-versus-companion totals for one mass group, over a whole database.</summary>
+public sealed class MassGroupTally
+{
+    internal MassGroupTally(MassGroup group)
+    {
+        Group = group;
+    }
+
+    public MassGroup Group { get; }
+
+    /// <summary>Residues able to carry this mass, summed over target peptides.</summary>
+    public long TargetCapacity { get; internal set; }
+
+    /// <summary>The same, over their companions.</summary>
+    public long CompanionCapacity { get; internal set; }
+
+    /// <summary>Annotated sites a search could apply, summed over target peptides.</summary>
+    public long TargetAnnotatedSites { get; internal set; }
+
+    /// <summary>The same, over their companions.</summary>
+    public long CompanionAnnotatedSites { get; internal set; }
+
+    /// <summary>Peptides whose companion offers a different number of usable residues.</summary>
+    public int PeptidesWithCapacityMismatch { get; internal set; }
+
+    /// <summary>Peptides whose companion offers a different number of usable annotated sites.</summary>
+    public int PeptidesWithAnnotatedSiteMismatch { get; internal set; }
+
+    public bool Holds => TargetCapacity == CompanionCapacity
+                         && TargetAnnotatedSites == CompanionAnnotatedSites
+                         && PeptidesWithCapacityMismatch == 0
+                         && PeptidesWithAnnotatedSiteMismatch == 0;
+}
+
+/// <summary>
+/// Accumulates the mass-group invariant across a database, peptide by peptide.
+/// </summary>
+/// <remarks>
+/// <para><b>The invariant, in the units a search engine sees:</b> for each (peptide, mass group), the
+/// number of residues in the companion that can carry that mass equals the number in its target, and
+/// the number of <i>annotated</i> sites for that group is equal too.</para>
+/// <para>Under composition-preserving permutation with each modification transported to the residue
+/// it was on, this already holds. It is asserted rather than argued because the two clauses fail for
+/// different reasons and only the second one has ever failed here: a modification restricted to a
+/// peptide terminus survives every protein-level count and then does not fit its new position. That
+/// is invisible to a modification tally and visible here.</para>
+/// <para><b>Report the distribution, not only the per-peptide equality.</b> A per-peptide check is
+/// pointwise and is satisfied vacuously by a peptide that was excised and no longer exists; only the
+/// totals catch a whole class going missing. Both are kept, which is why there are four counters per
+/// group rather than one flag.</para>
+/// </remarks>
+public sealed class MassGroupComparison
+{
+    private readonly MassGroupIndex _index;
+    private readonly Dictionary<MassGroup, MassGroupTally> _tallies = new();
+
+    public MassGroupComparison(MassGroupIndex index)
+    {
+        _index = index ?? throw new MzLibException("A mass-group comparison needs an index.");
+        foreach (MassGroup g in index.Groups)
+        {
+            _tallies[g] = new MassGroupTally(g);
+        }
+    }
+
+    public int PeptidesCompared { get; private set; }
+
+    public IReadOnlyList<MassGroupTally> Tallies =>
+        _tallies.Values.OrderBy(t => t.Group.RepresentativeMass).ToList();
+
+    /// <summary>Whether every group's totals and per-peptide counts agree.</summary>
+    public bool Holds => _tallies.Values.All(t => t.Holds);
+
+    /// <summary>
+    /// Compares one target protein against its companion, piece by piece.
+    /// </summary>
+    /// <param name="target">The target polymer, with its annotations.</param>
+    /// <param name="companion">Its entrapment partner, with the transported annotations.</param>
+    /// <param name="assembly">What happened to each piece.</param>
+    /// <param name="minPeptideLength">Pieces shorter than this are skipped: no search reports them on
+    /// their own, so counting them would put unidentifiable peptides into an invariant about what a
+    /// search can see.</param>
+    public void Add(IBioPolymer target, IBioPolymer companion, EntrapmentAssembly assembly,
+        int minPeptideLength)
+    {
+        if (target is null || companion is null || assembly is null)
+        {
+            throw new MzLibException("A mass-group comparison needs a target, a companion and an assembly.");
+        }
+
+        foreach (EntrapmentPiece piece in assembly.Pieces)
+        {
+            // An excised piece has no companion peptide at all. It is not a mismatch -- there is
+            // nothing to mismatch with -- and the achieved fold ratio is where that loss is reported.
+            if (piece.Outcome == PieceOutcome.Excised || piece.EntrapmentPiece_ is null)
+            {
+                continue;
+            }
+            if (piece.TargetPiece.Length < minPeptideLength)
+            {
+                continue;
+            }
+
+            PeptidesCompared++;
+
+            Dictionary<MassGroup, int> targetSites = _index.AnnotatedSites(target.BaseSequence,
+                piece.TargetStart, piece.TargetPiece.Length, target.OneBasedPossibleLocalizedModifications);
+            Dictionary<MassGroup, int> companionSites = _index.AnnotatedSites(companion.BaseSequence,
+                piece.EntrapmentStart, piece.EntrapmentPiece_.Length,
+                companion.OneBasedPossibleLocalizedModifications);
+
+            foreach (MassGroupTally tally in _tallies.Values)
+            {
+                int targetCapacity = MassGroupIndex.Capacity(piece.TargetPiece, tally.Group);
+                int companionCapacity = MassGroupIndex.Capacity(piece.EntrapmentPiece_, tally.Group);
+                int targetAnnotated = targetSites.GetValueOrDefault(tally.Group);
+                int companionAnnotated = companionSites.GetValueOrDefault(tally.Group);
+
+                tally.TargetCapacity += targetCapacity;
+                tally.CompanionCapacity += companionCapacity;
+                tally.TargetAnnotatedSites += targetAnnotated;
+                tally.CompanionAnnotatedSites += companionAnnotated;
+                if (targetCapacity != companionCapacity)
+                {
+                    tally.PeptidesWithCapacityMismatch++;
+                }
+                if (targetAnnotated != companionAnnotated)
+                {
+                    tally.PeptidesWithAnnotatedSiteMismatch++;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// The comparison as a tab-separated table, one row per mass group plus a total.
+    /// </summary>
+    /// <remarks>
+    /// Every group is emitted, including those with no annotation anywhere, because "this mass had no
+    /// annotated site on either side" and "this mass was not looked at" are different statements and
+    /// only the table can distinguish them.
+    /// </remarks>
+    public string ToTabSeparated()
+    {
+        var text = new StringBuilder();
+        text.AppendLine("# massGroupToleranceDaltons\t"
+                        + _index.Tolerance.ToString("G17", CultureInfo.InvariantCulture));
+        text.AppendLine("# peptidesCompared\t" + PeptidesCompared.ToString(CultureInfo.InvariantCulture));
+        text.AppendLine("# invariantHolds\t" + (Holds ? "true" : "false"));
+        text.AppendLine(string.Join("\t", "massGroup", "spanDaltons", "residues", "modifications",
+            "targetCapacity", "companionCapacity", "targetAnnotatedSites", "companionAnnotatedSites",
+            "peptidesWithCapacityMismatch", "peptidesWithAnnotatedSiteMismatch"));
+
+        foreach (MassGroupTally t in Tallies)
+        {
+            text.AppendLine(string.Join("\t",
+                t.Group.RepresentativeMass.ToString("F5", CultureInfo.InvariantCulture),
+                t.Group.Span.ToString("F5", CultureInfo.InvariantCulture),
+                string.Concat(t.Group.Residues.OrderBy(c => c)),
+                string.Join("; ", t.Group.Modifications),
+                t.TargetCapacity.ToString(CultureInfo.InvariantCulture),
+                t.CompanionCapacity.ToString(CultureInfo.InvariantCulture),
+                t.TargetAnnotatedSites.ToString(CultureInfo.InvariantCulture),
+                t.CompanionAnnotatedSites.ToString(CultureInfo.InvariantCulture),
+                t.PeptidesWithCapacityMismatch.ToString(CultureInfo.InvariantCulture),
+                t.PeptidesWithAnnotatedSiteMismatch.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        return text.ToString();
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentPairing.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentPairing.cs
@@ -1,0 +1,172 @@
+#nullable enable
+using MzLibUtil;
+using Omics.Digestion;
+using Proteomics;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UsefulProteomicsDatabases.EntrapmentGeneration;
+
+/// <summary>
+/// Finds the target peptide an entrapment peptide was built from, using nothing but the target
+/// protein and the peptide itself.
+/// </summary>
+/// <remarks>
+/// <para>A rearrangement preserves the residue multiset and leaves every cleavage-site residue in
+/// place, so those two things together are a key: the partner of an entrapment peptide is the
+/// target peptide of the same protein with the same free-residue composition and the same pinned
+/// pattern. That is guaranteed by the construction rather than recorded anywhere, which is why no
+/// index file has to be written, shipped, or kept in step with the database. A search reports a
+/// protein accession and a peptide sequence, and that is enough.</para>
+/// <para>The key can collide: a protein may contain two different peptides sharing both, and
+/// P57071 really does contain <c>LIHTGVK</c> and <c>LIHTVGK</c>. Those are reported in
+/// <see cref="AmbiguousPeptides"/> and refuse to resolve, because a guess between them would be
+/// wrong half the time and silently so.</para>
+/// </remarks>
+public sealed class EntrapmentPairing
+{
+    private readonly Dictionary<string, string> _byKey;
+    private readonly HashSet<string> _ambiguous;
+    private readonly List<DigestionMotif> _motifs;
+
+    /// <summary>Indexes a target protein's peptides, missed cleavages included, by composition and pinned pattern.</summary>
+    public EntrapmentPairing(Protein target, IDigestionParams digestionParams)
+    {
+        if (target is null)
+        {
+            throw new MzLibException("Cannot build a pairing without a target protein.");
+        }
+
+        _byKey = new Dictionary<string, string>();
+        _ambiguous = new HashSet<string>();
+        var collided = new HashSet<string>();
+
+        _motifs = digestionParams.DigestionAgent.DigestionMotifs;
+        List<int> sites = digestionParams.DigestionAgent.GetDigestionSiteIndices(target.BaseSequence);
+        sites.Sort();
+
+        // Index runs of adjacent base pieces, not just single ones: a search reports missed-cleavage
+        // peptides too, and those are pairable for the same reason -- base-piece compositions add, so
+        // a run is isomeric with the run its partner was built from.
+        int maxPieces = digestionParams.MaxMissedCleavages + 1;
+
+        // Only peptides a search could actually report. Without this the index holds every run
+        // however short, and short peptides collide constantly -- "AK" shares its key with every
+        // other "AK" -- which inflated the ambiguity count nearly tenfold with peptides nobody will
+        // ever see (6,889 against 736 on the reviewed human proteome). Filtering is safe as well as
+        // honest: a key begins with the peptide's length, so peptides of different lengths never
+        // collide and removing the short ones cannot change how a searchable peptide resolves.
+        int minLength = digestionParams.MinLength;
+        int maxLength = digestionParams.MaxLength;
+
+        for (int first = 0; first < sites.Count - 1; first++)
+        {
+            for (int pieces = 1; pieces <= maxPieces && first + pieces < sites.Count; pieces++)
+            {
+                int start = sites[first];
+                int length = sites[first + pieces] - start;
+                if (length < minLength || length > maxLength)
+                {
+                    continue;
+                }
+
+                string peptide = target.BaseSequence.Substring(start, length);
+                string key = KeyOf(peptide);
+
+                if (_byKey.TryGetValue(key, out string? existing))
+                {
+                    if (existing != peptide)
+                    {
+                        collided.Add(key);
+                        _ambiguous.Add(existing);
+                        _ambiguous.Add(peptide);
+                    }
+                    continue;
+                }
+
+                _byKey[key] = peptide;
+            }
+        }
+
+        foreach (string key in collided)
+        {
+            _byKey.Remove(key);
+        }
+    }
+
+    /// <summary>
+    /// Target peptides sharing a composition-and-pinning key with another peptide of the same
+    /// protein, and therefore not resolvable. Report these rather than pairing them.
+    /// </summary>
+    public IReadOnlyCollection<string> AmbiguousPeptides => _ambiguous;
+
+    /// <summary>
+    /// Distinct peptides of this protein a search could report -- runs of up to
+    /// <c>MaxMissedCleavages + 1</c> base pieces, within the length bounds. This is the population
+    /// an FDP estimator's <c>r</c> is over, and the denominator an ambiguity rate needs: the
+    /// report's own peptide counts are over <i>base pieces</i>, which is a different and smaller
+    /// population, and dividing one by the other gives a rate of nothing.
+    /// </summary>
+    public int SearchablePeptideCount => _byKey.Count + _ambiguous.Count;
+
+    /// <summary>
+    /// The same count for a bare sequence, so the <b>entrapment</b> side of a database can be
+    /// measured on the same footing as the target side.
+    /// </summary>
+    /// <remarks>
+    /// Without this a consumer has only <c>entrapmentPeptides</c>, which counts base pieces, so the
+    /// achieved ratio is a base-piece ratio rather than the peptide-level <c>r</c> an FDP estimator
+    /// is over -- and excision means the two search spaces differ by more than a fold factor, so it
+    /// cannot be derived from the target side and a correction.
+    /// </remarks>
+    public static int CountSearchablePeptides(string sequence, IDigestionParams digestionParams)
+    {
+        if (string.IsNullOrEmpty(sequence))
+        {
+            return 0;
+        }
+
+        return new EntrapmentPairing(new Protein(sequence, "counting-only"), digestionParams)
+            .SearchablePeptideCount;
+    }
+
+    /// <summary>The target peptide <paramref name="entrapmentPeptide"/> was built from.</summary>
+    /// <returns>False when the peptide belongs to no target peptide of this protein, or when its
+    /// key is ambiguous.</returns>
+    public bool TryResolve(string entrapmentPeptide, out string targetPeptide)
+    {
+        targetPeptide = string.Empty;
+        if (string.IsNullOrEmpty(entrapmentPeptide))
+        {
+            return false;
+        }
+
+        return _byKey.TryGetValue(KeyOf(entrapmentPeptide), out targetPeptide!);
+    }
+
+    /// <summary>
+    /// Length, the residues held in place and where, and the sorted free residues -- exactly what a
+    /// rearrangement preserves, and nothing it is free to change.
+    /// </summary>
+    private string KeyOf(string peptide)
+    {
+        HashSet<int> pinned = DecoySequenceValidator.CleavageSitePositions(peptide, _motifs);
+
+        var pinnedPart = new List<string>();
+        var free = new List<char>();
+        for (int i = 0; i < peptide.Length; i++)
+        {
+            if (pinned.Contains(i))
+            {
+                pinnedPart.Add(i + ":" + peptide[i]);
+            }
+            else
+            {
+                free.Add(peptide[i]);
+            }
+        }
+
+        free.Sort();
+        return peptide.Length + "|" + string.Join(",", pinnedPart) + "|" + new string(free.ToArray());
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentPeptideGenerator.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentPeptideGenerator.cs
@@ -20,8 +20,10 @@ public enum EntrapmentFailure
     None,
 
     /// <summary>
-    /// Every arrangement in this fold's stretch would have made a <b>missed-cleavage</b> peptide
-    /// equal to a real target peptide, so none could be used.
+    /// Every arrangement in this fold's stretch was refused for something outside the piece itself:
+    /// it would have made a <b>missed-cleavage</b> peptide equal to a real target peptide, or -- for
+    /// the piece that opens a protein -- its <b>initiator-methionine-stripped</b> form would have
+    /// been one.
     /// </summary>
     /// <remarks>
     /// Kept apart from <see cref="AllPermutationsTaken"/> because the remedies differ, which is the

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentPeptideGenerator.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentPeptideGenerator.cs
@@ -1,0 +1,242 @@
+#nullable enable
+using MzLibUtil;
+using Omics.Digestion;
+using System;
+using System.Globalization;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace UsefulProteomicsDatabases.EntrapmentGeneration;
+
+/// <summary>
+/// Why an entrapment peptide could not be produced. These are kept apart because the caller's
+/// remedy differs for each, and merging them into a single "failed" hides that.
+/// </summary>
+public enum EntrapmentFailure
+{
+    /// <summary>A partner was produced.</summary>
+    None,
+
+    /// <summary>
+    /// Every arrangement in this fold's stretch would have made a <b>missed-cleavage</b> peptide
+    /// equal to a real target peptide, so none could be used.
+    /// </summary>
+    /// <remarks>
+    /// Kept apart from <see cref="AllPermutationsTaken"/> because the remedies differ, which is the
+    /// whole reason these causes are separate. A peptide whose own arrangements are spoken for wants
+    /// a different target database; a peptide defeated by the runs it would complete wants a
+    /// different seed, or different neighbours, and is a property of where it sits rather than of
+    /// what it is.
+    /// </remarks>
+    RunCollisionsExhaustedTheSpace,
+
+    /// <summary>
+    /// The sequence has exactly one arrangement once its cleavage sites are held in place -- a
+    /// homopolymeric tract such as "SSSSSSR". Arithmetic, not competition: no seed, no extra
+    /// searching and no smaller fold count can produce a partner for this peptide.
+    /// </summary>
+    NoPermutationExists,
+
+    /// <summary>
+    /// Arrangements exist, but every one this fold may draw on is already spoken for -- it is a
+    /// target peptide, or it has already been issued. Depends on the database, so a different
+    /// target set may succeed where this one did not.
+    /// </summary>
+    AllPermutationsTaken,
+
+    /// <summary>
+    /// The space is real but too small to give every fold its own partner. The remedy is a smaller
+    /// fold count, which distinguishes this from <see cref="AllPermutationsTaken"/>.
+    /// </summary>
+    SpaceTooSmallForFoldCount
+}
+
+/// <summary>
+/// One target peptide's entrapment partner, or the reason it has none.
+/// </summary>
+public sealed class EntrapmentPeptide
+{
+    internal EntrapmentPeptide(string targetSequence, string? entrapmentSequence, int[]? swappedPositions,
+        int fold, BigInteger permutationSpaceSize, int probesUsed, EntrapmentFailure failure)
+    {
+        TargetSequence = targetSequence;
+        EntrapmentSequence = entrapmentSequence;
+        SwappedPositions = swappedPositions;
+        Fold = fold;
+        PermutationSpaceSize = permutationSpaceSize;
+        ProbesUsed = probesUsed;
+        Failure = failure;
+    }
+
+    public string TargetSequence { get; }
+
+    /// <summary>The partner, isomeric with the target. Null when <see cref="Succeeded"/> is false.</summary>
+    public string? EntrapmentSequence { get; }
+
+    /// <summary>
+    /// Maps each position in the target to its position in the partner, the same contract as
+    /// <see cref="DecoySequenceValidator.ScrambleSequence"/>, so modifications ride across unchanged.
+    /// </summary>
+    public int[]? SwappedPositions { get; }
+
+    /// <summary>Zero-based fold this partner belongs to.</summary>
+    public int Fold { get; }
+
+    /// <summary>How many distinct arrangements exist. Reported even on failure, because the value
+    /// is what distinguishes an impossible peptide from a merely crowded one.</summary>
+    public BigInteger PermutationSpaceSize { get; }
+
+    /// <summary>Candidates examined, including the one returned. One means the first choice was free.</summary>
+    public int ProbesUsed { get; }
+
+    public EntrapmentFailure Failure { get; }
+
+    public bool Succeeded => Failure == EntrapmentFailure.None;
+}
+
+/// <summary>
+/// Produces the entrapment partner of a target peptide: the same residues in a different order,
+/// with every cleavage site left where it was.
+/// </summary>
+/// <remarks>
+/// <para>The partner is <b>isomeric</b> with its target -- same composition, so same mass and the
+/// same count of any residue of interest. For localization work that last property is the point:
+/// the number of candidate sites in a peptide sets the difficulty of placing a modification on it,
+/// so a partner carrying a different count would be compared at a difficulty its target never had.
+/// It also makes target and partner the hardest possible pair to tell apart, which is the
+/// discrimination an entrapment experiment is trying to measure.</para>
+/// <para>Selection is by <b>index, not by chance</b>. The starting point is derived from the
+/// sequence and the seed, and search walks forward from there, so the answer is a pure function of
+/// its inputs: unchanged by processing order, by the protein the peptide came from, by threading,
+/// and by framework version. Nothing here consumes random state, and folds never consult one
+/// another, so a database can be regenerated in pieces without invalidating what already exists.
+/// </para>
+/// <para>Because the search enumerates rather than samples, "no partner exists" is a
+/// <b>proven</b> statement rather than a search that gave up, and the three ways it can fail are
+/// reported apart (<see cref="EntrapmentFailure"/>).</para>
+/// </remarks>
+public static class EntrapmentPeptideGenerator
+{
+    /// <summary>
+    /// The entrapment partner of <paramref name="targetSequence"/> for one fold.
+    /// </summary>
+    /// <param name="targetSequence">The target peptide.</param>
+    /// <param name="motifs">Cleavage motifs whose residues must stay in place, so that the partner
+    /// still digests the same way. Typically <c>DigestionAgent.DigestionMotifs</c>.</param>
+    /// <param name="forbiddenSequences">Sequences the partner may not equal -- normally every target
+    /// peptide in the database.</param>
+    /// <param name="fold">Zero-based fold, in <c>[0, foldCount)</c>.</param>
+    /// <param name="foldCount">How many partners each target is to receive (the <c>r</c> of an
+    /// r-fold entrapment database).</param>
+    /// <param name="seed">Changes every choice reproducibly.</param>
+    /// <param name="alsoHeldInPlace">Extra zero-based positions within this peptide to hold still
+    /// on top of the cleavage sites. The assembler uses this to anchor a protein's termini, so a
+    /// modification restricted to one of them survives the rearrangement.</param>
+    /// <param name="rejectInContext">An extra test a candidate must pass, on top of not being a
+    /// forbidden sequence itself. The assembler uses this to reject a candidate that would make a
+    /// *missed-cleavage* peptide equal to a real target peptide: this generator sees one base piece
+    /// at a time, and a missed-cleavage peptide is a run of adjacent pieces, so a concatenation can
+    /// collide even when none of its parts does. Measured before this existed: 2,094 peptides
+    /// (0.076%) appeared in both the target and entrapment sets, 2,090 of them with a missed
+    /// cleavage.</param>
+    public static EntrapmentPeptide Create(string targetSequence, List<DigestionMotif> motifs,
+        IReadOnlySet<string> forbiddenSequences, int fold = 0, int foldCount = 1, int seed = 1,
+        IReadOnlyCollection<int>? alsoHeldInPlace = null, Func<string, bool>? rejectInContext = null)
+    {
+        if (string.IsNullOrEmpty(targetSequence))
+        {
+            throw new MzLibException("Cannot build an entrapment peptide from an empty sequence.");
+        }
+        if (foldCount < 1)
+        {
+            throw new MzLibException($"Fold count must be at least 1, but was {foldCount}.");
+        }
+        if (fold < 0 || fold >= foldCount)
+        {
+            throw new MzLibException($"Fold {fold} is outside the {foldCount} requested folds.");
+        }
+
+        BigInteger size = DecoySequenceValidator.PermutationSpaceSize(targetSequence, motifs, alsoHeldInPlace);
+
+        // One arrangement means the identity and nothing else. No fold count and no seed can help.
+        if (size <= BigInteger.One)
+        {
+            return Failed(targetSequence, fold, size, EntrapmentFailure.NoPermutationExists);
+        }
+
+        // Give each fold its own contiguous stretch of the space. Disjoint stretches make the folds
+        // distinct by construction and independent of one another -- neither has to know what the
+        // others chose, so they can be produced in any order, in parallel, or years apart.
+        BigInteger stretch = size / foldCount;
+        if (stretch.IsZero)
+        {
+            return Failed(targetSequence, fold, size, EntrapmentFailure.SpaceTooSmallForFoldCount);
+        }
+
+        BigInteger start = fold * stretch;
+        BigInteger offset = DeriveOffset(targetSequence, seed, stretch);
+
+        bool anyRejectedOnlyByContext = false;
+
+        for (BigInteger step = BigInteger.Zero; step < stretch; step++)
+        {
+            BigInteger index = start + (offset + step) % stretch;
+            string candidate = DecoySequenceValidator.UnrankPermutation(targetSequence, motifs, index,
+                out int[] swapped, alsoHeldInPlace);
+
+            if (candidate == targetSequence || forbiddenSequences.Contains(candidate))
+            {
+                continue;
+            }
+
+            if (rejectInContext is not null && rejectInContext(candidate))
+            {
+                // Usable on its own merits, and refused only because of what it sits next to.
+                anyRejectedOnlyByContext = true;
+                continue;
+            }
+
+            return new EntrapmentPeptide(targetSequence, candidate, swapped, fold, size,
+                (int)(step + BigInteger.One), EntrapmentFailure.None);
+        }
+
+        // The stretch was walked end to end, so this is a proof rather than an abandoned search --
+        // and which proof it is depends on what did the refusing. Reporting a run collision as
+        // "all permutations taken" would send a caller after a different target database when the
+        // answer is a different seed.
+        return Failed(targetSequence, fold, size, anyRejectedOnlyByContext
+            ? EntrapmentFailure.RunCollisionsExhaustedTheSpace
+            : EntrapmentFailure.AllPermutationsTaken);
+    }
+
+    private static EntrapmentPeptide Failed(string targetSequence, int fold, BigInteger size,
+        EntrapmentFailure failure) =>
+        new(targetSequence, null, null, fold, size, 0, failure);
+
+    /// <summary>
+    /// Where in a fold's stretch to start looking, derived from the sequence and the seed.
+    /// </summary>
+    /// <remarks>
+    /// SHA-256 rather than <see cref="string.GetHashCode()"/> or a home-made hash: its output is
+    /// fixed by specification, so a database regenerated on another machine, another runtime or in
+    /// another decade is byte-identical. String hash codes are explicitly not stable across runs.
+    /// </remarks>
+    private static BigInteger DeriveOffset(string sequence, int seed, BigInteger stretch)
+    {
+        // Format the seed invariantly. Interpolation uses the current culture, and a negative
+        // seed renders its sign as U+002D under en-US but U+2212 MINUS SIGN under sv-SE, fi-FI and
+        // lt-LT -- different bytes into SHA-256, so the same request would produce a different
+        // database on a differently-configured machine. The reproducibility this method exists for
+        // has to survive a culture change, not only a process restart.
+        string material = seed.ToString(CultureInfo.InvariantCulture) + ":" + sequence;
+        byte[] digest = SHA256.HashData(Encoding.UTF8.GetBytes(material));
+
+        // Leading zero byte keeps BigInteger's two's-complement reading non-negative.
+        byte[] unsigned = new byte[digest.Length + 1];
+        Array.Copy(digest, unsigned, digest.Length);
+
+        return new BigInteger(unsigned) % stretch;
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentProteinGenerator.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentProteinGenerator.cs
@@ -1,0 +1,403 @@
+﻿#nullable enable
+using System;
+using MzLibUtil;
+using Omics.Digestion;
+using Omics.BioPolymer;
+using Omics.Modifications;
+using Proteomics;
+using Proteomics.ProteolyticDigestion;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UsefulProteomicsDatabases.EntrapmentGeneration;
+
+/// <summary>
+/// Builds the entrapment partner of a target protein: an isomeric sequence, its modifications
+/// carried onto the residues they were on, and an accession that says what it is and where it came
+/// from.
+/// </summary>
+public static class EntrapmentProteinGenerator
+{
+    /// <summary>
+    /// Entrapment entries taken from a foreign proteome, and the peptides they share with the
+    /// target database.
+    /// </summary>
+    /// <param name="foreignProteins">Proteins of a species absent from the sample.</param>
+    /// <param name="digestionParams">Used to digest the foreign proteins for the sharing check.</param>
+    /// <param name="targetPeptides">Every peptide of the target database.</param>
+    /// <param name="sharedWithTarget">Foreign peptides that are also target peptides, by the
+    /// foreign protein's own accession. Empty when the two proteomes are disjoint.</param>
+    /// <remarks>
+    /// <para><b>Why this arm is required scope rather than a nicety.</b> If the entrapment sequences
+    /// and the decoy sequences are both shuffles of the target, they are the same construction, and
+    /// comparing one against the other demonstrates nothing about either -- the circularity Madej
+    /// and Lam describe. A foreign proteome is the one entrapment source that is not derived from
+    /// the target at all, so it is what makes that comparison mean something.</para>
+    /// <para><b>Nothing is rearranged.</b> A foreign protein already is a sequence the sample cannot
+    /// contain, so it is relabelled, not permuted; its own annotations describe its own sequence and
+    /// stay valid, unlike the permutation path where every positional annotation had to be dropped.
+    /// It has no target partner by construction, and <see cref="EntrapmentAccession.TryParse"/>
+    /// refuses its accession for that reason.</para>
+    /// <para><b>The hazard is homology, and it is counted rather than repaired.</b> A conserved
+    /// protein shares peptides with its ortholog, and a shared peptide is a <i>real target peptide</i>
+    /// sitting in the entrapment database -- a search matching it counts a true peptide as an
+    /// entrapment discovery. Nothing can be permuted away here: the sequence is what it is. So they
+    /// are reported, and the caller decides whether to exclude the peptides or drop the proteins.
+    /// That is the same rule this generator applies everywhere: flag and count, never silently
+    /// repair.</para>
+    /// </remarks>
+    public static List<Protein> GenerateForeignEntrapment(IEnumerable<Protein> foreignProteins,
+        IDigestionParams digestionParams, IReadOnlySet<string> targetPeptides,
+        out IReadOnlyDictionary<string, IReadOnlyCollection<string>> sharedWithTarget,
+        string entrapmentIdentifier = ProteinDbLoader.DefaultEntrapmentIdentifier)
+    {
+        if (foreignProteins is null)
+        {
+            throw new MzLibException("Cannot build a foreign-species arm from a null protein list.");
+        }
+        if (targetPeptides is null)
+        {
+            throw new MzLibException("The sharing check needs the target database's peptides.");
+        }
+
+        var shared = new Dictionary<string, IReadOnlyCollection<string>>();
+        var entrapment = new List<Protein>();
+        var noMods = new List<Modification>();
+
+        foreach (Protein foreign in DatabaseEntries(foreignProteins))
+        {
+            var collisions = new HashSet<string>();
+            foreach (var peptide in foreign.Digest(digestionParams, noMods, noMods))
+            {
+                if (targetPeptides.Contains(peptide.BaseSequence))
+                {
+                    collisions.Add(peptide.BaseSequence);
+                }
+            }
+
+            if (collisions.Count > 0)
+            {
+                shared[foreign.Accession] = collisions;
+            }
+
+            entrapment.Add(CreateForeign(foreign, entrapmentIdentifier));
+        }
+
+        sharedWithTarget = shared;
+        return entrapment;
+    }
+
+    /// <summary>One foreign protein, relabelled as an entrapment entry.</summary>
+    public static Protein CreateForeign(Protein foreign,
+        string entrapmentIdentifier = ProteinDbLoader.DefaultEntrapmentIdentifier)
+    {
+        if (foreign is null)
+        {
+            throw new MzLibException("Cannot build a foreign entrapment entry from a null protein.");
+        }
+
+        // The sequence is untouched, so unlike the permutation path the positional annotations still
+        // describe it and are kept. Sequence variations are the exception: applying them would
+        // expand one entry into several, and the entrapment side is one entry per entry.
+        return new Protein(foreign,
+            accession: EntrapmentAccession.FormatForeign(foreign.Accession, entrapmentIdentifier),
+            isEntrapment: true,
+            sequenceVariations: new List<SequenceVariation>(),
+            appliedSequenceVariations: new List<SequenceVariation>());
+    }
+
+    /// <summary>
+    /// The entrapment partners for a whole target database: one per database <b>entry</b>, per fold.
+    /// </summary>
+    /// <param name="targets">The target proteins, as a loader returns them.</param>
+    /// <param name="digestionParams">Supplies the cleavage sites, and the minimum peptide length
+    /// below which a piece is not identifiable on its own.</param>
+    /// <param name="forbiddenSequences">Sequences no partner peptide may equal, normally every
+    /// target peptide in the database.</param>
+    /// <param name="foldCount">Partners per target -- the <c>r</c> of an r-fold database.</param>
+    /// <param name="seed">Changes every choice reproducibly.</param>
+    /// <remarks>
+    /// <para><b>Why this exists, and why it is not a <c>foreach</c> over the list.</b> A protein
+    /// database is a list of entries, but a loader does not hand back a list of entries: it applies
+    /// each entry's sequence variations and hands back one protein per applied combination, all of
+    /// them sharing one <see cref="Protein.ConsensusVariant"/>. Loading the reviewed human XML gives
+    /// 52,337 proteins from 20,416 entries.</para>
+    /// <para>Generating a partner for each of those proteins produces 52,337 entrapment proteins,
+    /// and because each is constructed fresh it is its own consensus.
+    /// <see cref="ProteinDbWriter.WriteXmlDatabase"/> writes one entry per distinct consensus, so
+    /// the targets fold back to 20,416 entries and the entrapment proteins do not fold at all. The
+    /// database that reaches a search engine then holds <b>2.56 entrapment entries per target</b>,
+    /// while every FDP estimator reading it is told <c>r = 1</c>. Measured, not hypothetical: it is
+    /// what the human XML arm of this project's own experiment was searched against.</para>
+    /// <para>So the unit of entrapment is the entry. A sequence variant is an annotation on an
+    /// entry, not an entry of its own, and an entrapment partner for every point variant of a
+    /// protein is not something anyone asked for -- it is only what a naive loop produces. The
+    /// FASTA path is unaffected either way, because a FASTA has no variants and every protein is
+    /// already its own consensus.</para>
+    /// </remarks>
+    public static List<Protein> GenerateEntrapment(IEnumerable<Protein> targets,
+        IDigestionParams digestionParams, IReadOnlySet<string> forbiddenSequences,
+        int foldCount = 1, int seed = 1,
+        string entrapmentIdentifier = ProteinDbLoader.DefaultEntrapmentIdentifier)
+        => GenerateEntrapment(targets, digestionParams, forbiddenSequences, null, foldCount, seed,
+            entrapmentIdentifier);
+
+    /// <summary>
+    /// As above, reporting each partner's <see cref="EntrapmentAssembly"/> as it is produced.
+    /// </summary>
+    /// <param name="observe">Called with the entry, the fold, and how that partner was built.</param>
+    /// <remarks>
+    /// The parameterless overload discards the assembly, so a caller building a QC report had to
+    /// write its own <see cref="DatabaseEntries"/> plus per-protein <see cref="Create(Protein, IDigestionParams, IReadOnlySet{string}, out EntrapmentAssembly, int, int, int, string)"/>
+    /// loop -- two loops obliged to agree about folds and about what an entry is. They stopped
+    /// agreeing: one such caller compared its partner count against the <i>loaded</i> protein count
+    /// rather than the entry count and failed silently for a day. One loop cannot disagree with
+    /// itself.
+    /// </remarks>
+    public static List<Protein> GenerateEntrapment(IEnumerable<Protein> targets,
+        IDigestionParams digestionParams, IReadOnlySet<string> forbiddenSequences,
+        Action<Protein, int, EntrapmentAssembly>? observe,
+        int foldCount = 1, int seed = 1,
+        string entrapmentIdentifier = ProteinDbLoader.DefaultEntrapmentIdentifier)
+    {
+        if (targets is null)
+        {
+            throw new MzLibException("Cannot build entrapment proteins from a null target list.");
+        }
+
+        // Refused here as well as inside the assembler. The assembler's copy fires on the first
+        // protein so nothing is wasted either way, but a throw from that depth reaches a GUI user
+        // as a crash part-way through a run rather than as "this agent cannot be used", and this
+        // is the call they actually made.
+        EntrapmentAssembler.RefuseAgentsWhoseSitesCannotBeHeld(
+            digestionParams?.DigestionAgent?.Name ?? string.Empty,
+            digestionParams?.DigestionAgent?.DigestionMotifs ?? new List<DigestionMotif>());
+
+        var entrapment = new List<Protein>();
+        foreach (Protein entry in DatabaseEntries(targets))
+        {
+            for (int fold = 0; fold < foldCount; fold++)
+            {
+                Protein partner = Create(entry, digestionParams, forbiddenSequences, out EntrapmentAssembly assembly,
+                    fold, foldCount, seed, entrapmentIdentifier);
+
+                // Reported before the emptiness check, so a report still sees a protein that
+                // produced nothing. An entry that contributes no partner is exactly what a reader of
+                // the achieved ratio needs to know about.
+                observe?.Invoke(entry, fold, assembly);
+
+                // Every piece excised leaves nothing behind. A protein with an empty sequence is not
+                // a database entry: a loader warns and discards it, and its decoy with it.
+                // Q156A1 is the real case -- a methionine followed by 79 glutamines, whose only base
+                // piece has exactly one arrangement once the termini are anchored.
+                //
+                // The loaded database is unchanged by skipping it: the loader discarded it anyway,
+                // and the target, entrapment and decoy counts come out the same either way. What
+                // skipping it removes is the loader's "N empty entries ignored" warning, which was
+                // the only signal that the arm was short. EntrapmentReport.EntriesYieldingNoPartner
+                // carries that instead -- short by construction, said where it is decided, rather
+                // than short and then noticed by whatever happens to load the file.
+                if (assembly.EntrapmentSequence.Length == 0)
+                {
+                    continue;
+                }
+
+                entrapment.Add(partner);
+            }
+        }
+
+        return entrapment;
+    }
+
+    /// <summary>
+    /// The entries behind a loaded protein list: each distinct consensus, once, in the order first
+    /// seen. This is the list an entrapment database is one-to-one with, and the list a database
+    /// writer will persist.
+    /// </summary>
+    /// <remarks>
+    /// <para>Public because <see cref="GenerateEntrapment"/> cannot serve every caller: building the
+    /// QC report needs the <see cref="EntrapmentAssembly"/> of each partner, which only the
+    /// per-protein <see cref="Create(Protein, IDigestionParams, IReadOnlySet{string}, out EntrapmentAssembly, int, int, int, string)"/>
+    /// overload returns. Such a caller must iterate the same entries, and should not have to
+    /// re-derive what an entry is.</para>
+    /// <para>Keyed by reference, not by value. <see cref="Protein"/> overrides <c>Equals</c>, and the
+    /// question here is which entry a protein came from -- object identity -- rather than whether
+    /// two proteins happen to look alike. <see cref="DecoyProteinGenerator"/> keys its own consensus
+    /// map the same way and for the same reason.</para>
+    /// </remarks>
+    public static IEnumerable<Protein> DatabaseEntries(IEnumerable<Protein> targets)
+    {
+        var seen = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        foreach (Protein target in targets)
+        {
+            if (target is null)
+            {
+                continue;
+            }
+
+            // A protein with no variants is its own consensus, so this is the protein itself.
+            Protein entry = target.ConsensusVariant as Protein ?? target;
+            if (seen.Add(entry))
+            {
+                yield return entry;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The entrapment partner of <paramref name="target"/> for one fold.
+    /// </summary>
+    /// <param name="target">The target protein.</param>
+    /// <param name="digestionParams">Supplies the cleavage sites, and the minimum peptide length
+    /// below which a piece is not identifiable on its own.</param>
+    /// <param name="forbiddenSequences">Sequences no partner peptide may equal, normally every
+    /// target peptide in the database.</param>
+    /// <param name="fold">Zero-based fold, in <c>[0, foldCount)</c>.</param>
+    /// <param name="foldCount">Partners per target -- the <c>r</c> of an r-fold database.</param>
+    /// <param name="seed">Changes every choice reproducibly.</param>
+    /// <remarks>
+    /// Built in two steps, both through existing constructors and neither through reflection:
+    /// <see cref="Protein.CloneWithNewSequenceAndMods"/> for the sequence and modifications, then
+    /// Protein's copy constructor for the accession and the entrapment flag.
+    /// </remarks>
+    public static Protein Create(Protein target, IDigestionParams digestionParams,
+        IReadOnlySet<string> forbiddenSequences, int fold = 0, int foldCount = 1, int seed = 1,
+        string entrapmentIdentifier = ProteinDbLoader.DefaultEntrapmentIdentifier) =>
+        Create(target, digestionParams, forbiddenSequences, out _, fold, foldCount, seed, entrapmentIdentifier);
+
+    /// <summary>
+    /// The entrapment partner of <paramref name="target"/>, along with the record of how it was
+    /// built.
+    /// </summary>
+    /// <param name="assembly">What happened to each piece of the target: rearranged, kept because
+    /// it was too short to identify, or excised for want of a partner. Feed this to
+    /// <see cref="EntrapmentReportBuilder"/> rather than assembling a second time to find out.</param>
+    public static Protein Create(Protein target, IDigestionParams digestionParams,
+        IReadOnlySet<string> forbiddenSequences, out EntrapmentAssembly assembly,
+        int fold = 0, int foldCount = 1, int seed = 1,
+        string entrapmentIdentifier = ProteinDbLoader.DefaultEntrapmentIdentifier)
+    {
+        if (target is null)
+        {
+            throw new MzLibException("Cannot build an entrapment protein from a null target.");
+        }
+
+        assembly = EntrapmentAssembler.Assemble(target.BaseSequence, digestionParams,
+            forbiddenSequences, fold, foldCount, seed);
+
+        Dictionary<int, List<Modification>> movedMods =
+            MoveModifications(target.OneBasedPossibleLocalizedModifications, assembly.TargetToEntrapmentPosition);
+
+        var withNewSequence = (Protein)target.CloneWithNewSequenceAndMods(assembly.EntrapmentSequence, movedMods);
+
+        return new Protein(withNewSequence,
+            accession: EntrapmentAccession.Format(target.Accession, fold, entrapmentIdentifier),
+            isEntrapment: true,
+            uniProtSequenceAttributes: DescribeSequence(target, assembly.EntrapmentSequence),
+            oneBasedModifications: movedMods,
+            // Every other positional annotation describes the TARGET's sequence and means nothing
+            // once the residues have moved. Carrying them over is not merely untidy: excision
+            // shortens the protein, so a coordinate can point past its end, and a consumer that
+            // indexes with it -- MetaMorpheus applies sequence variations while loading a database
+            // -- throws. Measured on the human proteome: 131 entrapment entries carried a feature
+            // position beyond their own length, and every search against that database failed.
+            // Modifications are the one annotation that survives, because they alone are remapped.
+            sequenceVariations: new List<SequenceVariation>(),
+            appliedSequenceVariations: new List<SequenceVariation>(),
+            proteolysisProducts: new List<TruncationProduct>(),
+            disulfideBonds: new List<DisulfideBond>(),
+            spliceSites: new List<SpliceSite>());
+    }
+
+    /// <summary>
+    /// Sequence attributes describing the entrapment sequence rather than the one it came from.
+    /// </summary>
+    /// <remarks>
+    /// The copy constructor carries the target's <c>UniProtSequenceAttributes</c> across, and
+    /// excision changes the length -- so a 15-residue partner was written as
+    /// <c>&lt;sequence length="30" mass="3114"&gt;</c>. <see cref="ProteinDbLoader.LoadProteinXML"/>
+    /// recomputes length on read, which is why a round trip through mzLib never noticed, but the file
+    /// on disk was self-inconsistent for anything else that reads it.
+    /// <para>Mass is recomputed too, though for a different reason: a rearrangement is isomeric, so
+    /// an unexcised partner has exactly its target's mass and only an excised one does not. Deriving
+    /// both from the sequence is right in either case and does not depend on knowing which.</para>
+    /// </remarks>
+    private static UniProtSequenceAttributes? DescribeSequence(Protein target, string entrapmentSequence)
+    {
+        UniProtSequenceAttributes? source = target.UniProtSequenceAttributes;
+        if (source is null)
+        {
+            return null;   // the target carried none, so inventing some would assert more than is known
+        }
+
+        // Checksum and sequence version describe the TARGET's sequence, and the partner's is a
+        // different one. Carrying them across wrote every entrapment entry with its target's CRC64
+        // -- a checksum that both ProteinXmlEntry parses and ProteinDbWriter writes, so it is read
+        // back as an assertion about a sequence it does not describe. "unknown" and an unset
+        // version say the true thing, and are what Protein's own constructor synthesizes when it is
+        // handed nothing.
+        var described = new UniProtSequenceAttributes(source.Length, source.Mass,
+            checkSum: "unknown", source.EntryModified, sequenceVersion: -1,
+            source.IsPrecursor, source.Fragment);
+        described.UpdateLengthAttribute(entrapmentSequence);
+
+        // MonoisotopicMass is NaN for a sequence holding X or B, and (int)Math.Round(NaN) is 0, so
+        // an entry whose target carried a real mass was written as mass="0". A rearrangement is
+        // isomeric, so the target's own mass is the right answer whenever the partner was not
+        // excised; where it was, an inherited mass is still closer to true than zero.
+        double mass = new PeptideWithSetModifications(entrapmentSequence,
+            new Dictionary<string, Modification>()).MonoisotopicMass;
+        if (double.IsFinite(mass))
+        {
+            described.UpdateMassAttribute(entrapmentSequence);
+        }
+
+        return described;
+    }
+
+    /// <summary>
+    /// Carries modifications onto the positions their residues moved to.
+    /// </summary>
+    /// <remarks>
+    /// Because the rearrangement only moves positions, a modification always lands on the same
+    /// residue it was on, so its motif still fits. A modification whose residue was excised has
+    /// nowhere to go and is dropped rather than placed somewhere arbitrary -- silently relocating it
+    /// would invent a site the target never had.
+    /// </remarks>
+    private static Dictionary<int, List<Modification>> MoveModifications(
+        IDictionary<int, List<Modification>> oneBasedModifications, int[] targetToEntrapmentPosition)
+    {
+        var moved = new Dictionary<int, List<Modification>>();
+        if (oneBasedModifications is null)
+        {
+            return moved;
+        }
+
+        foreach ((int oneBasedPosition, List<Modification> mods) in oneBasedModifications)
+        {
+            int zeroBased = oneBasedPosition - 1;
+            if (zeroBased < 0 || zeroBased >= targetToEntrapmentPosition.Length)
+            {
+                continue;
+            }
+
+            int destination = targetToEntrapmentPosition[zeroBased];
+            if (destination < 0)
+            {
+                continue;   // the residue was excised, and its modifications go with it
+            }
+
+            int newOneBased = destination + 1;
+            if (moved.TryGetValue(newOneBased, out List<Modification>? existing))
+            {
+                existing.AddRange(mods);
+            }
+            else
+            {
+                moved[newOneBased] = new List<Modification>(mods);
+            }
+        }
+
+        return moved;
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentReport.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentReport.cs
@@ -170,7 +170,8 @@ public sealed class EntrapmentReport
         EntrapmentStratum total,
         IReadOnlyDictionary<string, IReadOnlyCollection<string>> ambiguousByAccession,
         IReadOnlyDictionary<string, IReadOnlyCollection<string>> unrepairableByAccession,
-        IReadOnlyDictionary<string, IReadOnlyCollection<string>> initiatorMethionineByAccession)
+        IReadOnlyDictionary<string, IReadOnlyCollection<string>> initiatorMethionineByAccession,
+        MassGroupComparison? massGroups)
     {
         Provenance = provenance;
         Strata = strata;
@@ -178,7 +179,18 @@ public sealed class EntrapmentReport
         AmbiguousPeptidesByAccession = ambiguousByAccession;
         UnrepairableRunCollisionsByAccession = unrepairableByAccession;
         InitiatorMethionineCollisionsByAccession = initiatorMethionineByAccession;
+        MassGroups = massGroups;
     }
+
+    /// <summary>
+    /// The per-(peptide, mass group) invariant, or null when the builder was not given mass groups.
+    /// </summary>
+    /// <remarks>
+    /// A sidecar rather than columns on the stratified table, because the two partition the same
+    /// peptides along different axes -- that one by candidate-site count, this one by mass shift --
+    /// and crossing them would multiply rows without answering either question.
+    /// </remarks>
+    public MassGroupComparison? MassGroups { get; }
 
     /// <summary>
     /// Target peptides that cannot be traced back to one target, by accession -- two peptides of the
@@ -424,6 +436,7 @@ public sealed class EntrapmentReportBuilder
     private readonly Dictionary<string, HashSet<string>> _ambiguousByAccession = new();
     private readonly Dictionary<string, List<string>> _unrepairableByAccession = new();
     private readonly Dictionary<string, List<string>> _initiatorMethionineByAccession = new();
+    private readonly MassGroupComparison? _massGroups;
     private readonly string _entrapmentIdentifier;
     private int _entriesYieldingNoPartner;
     private readonly Dictionary<string, HashSet<string>> _foreignSharedByAccession = new();
@@ -439,9 +452,14 @@ public sealed class EntrapmentReportBuilder
     /// <see cref="EntrapmentReport.CountResidues"/>("ST"). Null puts everything in one stratum.</param>
     /// <param name="entrapmentIdentifier">The accession prefix the partners were minted with. The
     /// collision list is keyed by the entrapment accession, so it has to match the generator's.</param>
+    /// <param name="massGroups">Mass groups to check the per-(peptide, mass group) invariant
+    /// against, or null to leave that section out. Supplying it also requires the companion protein
+    /// to be handed to <see cref="Add(Protein, int, EntrapmentAssembly, Protein)"/>; the invariant is
+    /// about what the companion offers, so it cannot be computed from the target alone.</param>
     public EntrapmentReportBuilder(IDigestionParams digestionParams, int foldCount, int seed,
         Func<string, int>? siteCounter = null,
-        string entrapmentIdentifier = ProteinDbLoader.DefaultEntrapmentIdentifier)
+        string entrapmentIdentifier = ProteinDbLoader.DefaultEntrapmentIdentifier,
+        MassGroupIndex? massGroups = null)
     {
         if (digestionParams is null)
         {
@@ -453,15 +471,27 @@ public sealed class EntrapmentReportBuilder
         _seed = seed;
         _siteCounter = siteCounter ?? (_ => 0);
         _entrapmentIdentifier = entrapmentIdentifier;
+        _massGroups = massGroups is null ? null : new MassGroupComparison(massGroups);
     }
 
     /// <summary>Records one target protein's assembly for one fold.</summary>
-    public void Add(Protein target, int fold, EntrapmentAssembly assembly)
+    /// <param name="companion">The entrapment partner. Optional, and needed only when the builder
+    /// was given mass groups: the per-(peptide, mass group) invariant is a statement about what the
+    /// companion offers a search, so nothing about it can be recovered from the target alone.</param>
+    public void Add(Protein target, int fold, EntrapmentAssembly assembly, Protein? companion = null)
     {
         if (target is null || assembly is null)
         {
             throw new MzLibException("A report entry needs both a target protein and its assembly.");
         }
+        if (_massGroups is not null && companion is null)
+        {
+            throw new MzLibException(
+                "This report was asked for the mass-group invariant, which compares a target against "
+                + "its companion, so the companion protein has to be supplied to Add.");
+        }
+
+        _massGroups?.Add(target, companion!, assembly, _digestionParams.MinLength);
 
         if (!_ambiguousByAccession.TryGetValue(target.Accession, out HashSet<string>? ambiguous))
         {
@@ -672,7 +702,8 @@ public sealed class EntrapmentReportBuilder
             _unrepairableByAccession.Where(kv => kv.Value.Count > 0)
                 .ToDictionary(kv => kv.Key, kv => (IReadOnlyCollection<string>)kv.Value),
             _initiatorMethionineByAccession.Where(kv => kv.Value.Count > 0)
-                .ToDictionary(kv => kv.Key, kv => (IReadOnlyCollection<string>)kv.Value))
+                .ToDictionary(kv => kv.Key, kv => (IReadOnlyCollection<string>)kv.Value),
+            _massGroups)
         {
             ForeignEntries = _foreignEntries,
             EntriesYieldingNoPartner = _entriesYieldingNoPartner,

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentReport.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentReport.cs
@@ -1,0 +1,630 @@
+﻿#nullable enable
+using MzLibUtil;
+using Omics.Digestion;
+using Proteomics;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace UsefulProteomicsDatabases.EntrapmentGeneration;
+
+/// <summary>How the database was made, recorded alongside what came out of it.</summary>
+/// <remarks>
+/// Without these an entrapment database cannot be regenerated or compared against another, and the
+/// numbers below cannot be interpreted -- the peptide population, and therefore every distribution
+/// in the report, depends on the enzyme and the digestion settings as much as on the method.
+/// </remarks>
+public sealed class EntrapmentProvenance
+{
+    internal EntrapmentProvenance(string method, string enzyme, int seed, int foldCount,
+        int maxMissedCleavages, int minPeptideLength, int maxPeptideLength)
+    {
+        Method = method;
+        Enzyme = enzyme;
+        Seed = seed;
+        FoldCount = foldCount;
+        MaxMissedCleavages = maxMissedCleavages;
+        MinPeptideLength = minPeptideLength;
+        MaxPeptideLength = maxPeptideLength;
+    }
+
+    public string Method { get; }
+    public string Enzyme { get; }
+    public int Seed { get; }
+    public int FoldCount { get; }
+    public int MaxMissedCleavages { get; }
+    public int MinPeptideLength { get; }
+    public int MaxPeptideLength { get; }
+}
+
+/// <summary>Counts for one stratum -- one value of whatever the report is stratified by.</summary>
+public sealed class EntrapmentStratum
+{
+    internal EntrapmentStratum(int siteCount) => SiteCount = siteCount;
+
+    /// <summary>The value being stratified by, e.g. the number of candidate sites in a peptide.</summary>
+    public int SiteCount { get; }
+
+    /// <summary>Distinct target peptides in this stratum, counted once however many folds ran.</summary>
+    /// <remarks>
+    /// <b>Base pieces</b> -- the unit the generator permutes -- not what a search reports. For that,
+    /// see <see cref="SearchSpacePeptides"/>. The two differ by roughly five-fold at two missed
+    /// cleavages, so a rate computed against the wrong one is meaningless.
+    /// </remarks>
+    public int TargetPeptides { get; internal set; }
+
+    /// <summary>
+    /// Distinct peptides in this stratum a search could report: runs of up to
+    /// <c>MaxMissedCleavages + 1</c> base pieces, within the length bounds.
+    /// </summary>
+    /// <remarks>
+    /// This is the population an FDP estimator's <c>r</c> is over, and the denominator
+    /// <see cref="Ambiguous"/> belongs to -- <see cref="Ambiguous"/> is counted over missed-cleavage
+    /// peptides too, so dividing it by <see cref="TargetPeptides"/> divides two different
+    /// populations. On the reviewed human proteome that mistake turned 0.24% into "1.19%".
+    /// </remarks>
+    public int SearchSpacePeptides { get; internal set; }
+
+    /// <summary>
+    /// Distinct peptides a search could report from the <b>entrapment</b> side of the database.
+    /// </summary>
+    /// <remarks>
+    /// The counterpart of <see cref="SearchSpacePeptides"/>, and the other half of a peptide-level
+    /// <c>r</c>. <see cref="EntrapmentPeptides"/> counts base pieces, so the ratio built from it is a
+    /// base-piece ratio; excision makes the two search spaces differ by more than the fold factor, so
+    /// this cannot be derived from the target count and a correction. An FDP estimator wants
+    /// <c>entrapmentSearchSpacePeptides / searchSpacePeptides</c>.
+    /// </remarks>
+    public int EntrapmentSearchSpacePeptides { get; internal set; }
+
+    /// <summary>Entrapment peptides produced for them, across every fold.</summary>
+    public int EntrapmentPeptides { get; internal set; }
+
+    /// <summary>Exactly one arrangement exists. Arithmetic: no seed and no fold count can help.</summary>
+    public int UnpairableNoPermutationExists { get; internal set; }
+
+    /// <summary>Arrangements exist but every one available to the fold was already spoken for.</summary>
+    public int UnpairableAllPermutationsTaken { get; internal set; }
+
+    /// <summary>The space is real but too small to give every fold its own partner.</summary>
+    public int UnpairableSpaceTooSmallForFoldCount { get; internal set; }
+
+    /// <summary>
+    /// Pieces excised because every arrangement would have completed a missed-cleavage peptide equal
+    /// to a real target peptide.
+    /// </summary>
+    /// <remarks>
+    /// Kept apart from <see cref="UnpairableAllPermutationsTaken"/> because the remedies differ,
+    /// which is the reason these causes are separate at all. A piece whose own arrangements are
+    /// spoken for wants a different target database; a piece defeated by the runs it would complete
+    /// wants a different seed or different neighbours, and is a property of where it sits rather
+    /// than of what it is. Folding the two together would send a reader after the wrong fix.
+    /// </remarks>
+    public int UnpairableRunCollisionsExhausted { get; internal set; }
+
+    /// <summary>
+    /// Target peptides sharing a composition-and-pinning key with another peptide of the same
+    /// protein, so a discovery cannot be traced back to one of them.
+    /// </summary>
+    public int Ambiguous { get; internal set; }
+
+    /// <summary>
+    /// Entrapment missed-cleavage peptides whose pieces were not adjacent in the target, so they
+    /// have no isomeric counterpart. The only peptides in the database that break that invariant.
+    /// </summary>
+    public int MissedCleavagePeptidesSpanningAnExcision { get; internal set; }
+
+    /// <summary>
+    /// Missed-cleavage peptides of the entrapment database that equal a real target peptide and
+    /// could not be permuted away from it, because the run's final piece has only one arrangement.
+    /// </summary>
+    /// <remarks>
+    /// A search matching one of these counts a <i>true</i> peptide as an entrapment discovery,
+    /// inflating an FDP estimate directly. They are counted rather than repaired -- repair would
+    /// mean backtracking into a placed piece or excising a good one -- so a consumer that needs an
+    /// exact count must exclude them. See <see cref="EntrapmentAssembly.UnrepairableRunCollisions"/>.
+    /// </remarks>
+    public int UnrepairableRunCollisions { get; internal set; }
+
+    public int Unpairable => UnpairableNoPermutationExists + UnpairableAllPermutationsTaken
+                             + UnpairableSpaceTooSmallForFoldCount + UnpairableRunCollisionsExhausted;
+
+    /// <summary>
+    /// Partners actually delivered per target peptide. Compare against the requested fold count:
+    /// the shortfall is where the database could not honour what was asked of it.
+    /// </summary>
+    public double AchievedFoldRatio =>
+        TargetPeptides == 0 ? 0d : EntrapmentPeptides / (double)TargetPeptides;
+}
+
+/// <summary>
+/// What an entrapment database actually contains, stratified, next to how it was made.
+/// </summary>
+/// <remarks>
+/// <para>The report emits the <b>distribution</b>, not a summary of it. There is no universal
+/// distribution of peptides to validate against -- it moves with the proteome, the enzyme and the
+/// digestion settings -- so only this database's own numbers mean anything, and a single headline
+/// figure would hide exactly the stratum-by-stratum differences worth looking at.</para>
+/// <para>Failures are kept apart by cause as well as by stratum, because the remedies differ:
+/// nothing helps a peptide with one arrangement, a smaller fold count helps one whose space is too
+/// small, and a different target database may help one whose space is merely crowded.</para>
+/// </remarks>
+public sealed class EntrapmentReport
+{
+    internal EntrapmentReport(EntrapmentProvenance provenance, IReadOnlyList<EntrapmentStratum> strata,
+        EntrapmentStratum total,
+        IReadOnlyDictionary<string, IReadOnlyCollection<string>> ambiguousByAccession,
+        IReadOnlyDictionary<string, IReadOnlyCollection<string>> unrepairableByAccession)
+    {
+        Provenance = provenance;
+        Strata = strata;
+        Total = total;
+        AmbiguousPeptidesByAccession = ambiguousByAccession;
+        UnrepairableRunCollisionsByAccession = unrepairableByAccession;
+    }
+
+    /// <summary>
+    /// Target peptides that cannot be traced back to one target, by accession -- two peptides of the
+    /// same protein sharing a composition-and-pinning key.
+    /// </summary>
+    /// <remarks>
+    /// A consumer computing the paired FDP estimator has to exclude the <i>same</i> peptides this
+    /// generator excluded, or its <c>r = 1</c> assumption fails silently -- no error, just a wrong
+    /// number. That is only possible if it can see which ones they are, so the list is the
+    /// deliverable and the count is the summary.
+    /// </remarks>
+    public IReadOnlyDictionary<string, IReadOnlyCollection<string>> AmbiguousPeptidesByAccession { get; }
+
+    /// <summary>
+    /// Entrapment missed-cleavage peptides that are also real target peptides, by the accession of
+    /// the ENTRAPMENT protein holding them (<c>Random_&lt;target&gt;_f&lt;fold&gt;</c>) -- the accession a
+    /// search reports them under, and so the one a consumer can filter on.
+    /// </summary>
+    /// <remarks>
+    /// A search matching one of these counts a <i>true</i> peptide as an entrapment discovery. They
+    /// could not be permuted away because the run's final piece has only one arrangement, and this
+    /// project counts collisions rather than repairing them by backtracking or excising a good
+    /// piece. Excluding them is the consumer's call, and needs the sequences.
+    /// </remarks>
+    public IReadOnlyDictionary<string, IReadOnlyCollection<string>> UnrepairableRunCollisionsByAccession { get; }
+
+    /// <summary>
+    /// Peptides of the foreign-species arm that are also target peptides, by the foreign protein's
+    /// own accession.
+    /// </summary>
+    /// <remarks>
+    /// Homology, not a defect. A conserved protein shares peptides with its ortholog, and a shared
+    /// peptide is a real target peptide sitting in the entrapment database. Nothing can be permuted
+    /// away -- the foreign sequence is what it is -- so the arm reports them and the caller decides
+    /// whether to exclude the peptides or drop the proteins.
+    /// </remarks>
+    public IReadOnlyDictionary<string, IReadOnlyCollection<string>> ForeignPeptidesSharedWithTarget { get; internal set; }
+        = new Dictionary<string, IReadOnlyCollection<string>>();
+
+    /// <summary>Entries contributed by the foreign-species arm.</summary>
+    public int ForeignEntries { get; internal set; }
+
+    /// <summary>
+    /// Database entries that produced no entrapment partner at all, because every base piece was
+    /// excised and nothing was left to write.
+    /// </summary>
+    /// <remarks>
+    /// This replaces a signal that used to come from the loader. An empty protein was written and
+    /// <see cref="ProteinDbLoader"/> warned "N empty entries ignored" and discarded it; not writing
+    /// it is correct, but the warning was the only thing telling anyone the arm was short. Counting
+    /// it here says the same thing at the point it is decided -- short by construction, rather than
+    /// short and then reported by whatever happens to load the file. Q156A1 is the real case: a
+    /// methionine followed by 79 glutamines, whose only base piece has one arrangement once the
+    /// termini are anchored.
+    /// </remarks>
+    public int EntriesYieldingNoPartner { get; internal set; }
+
+    /// <summary>
+    /// The two exclusion lists as a tab-separated table: <c>accession, peptide, reason</c>.
+    /// </summary>
+    /// <remarks>
+    /// A sidecar rather than more columns on the stratified table, because these are per-peptide
+    /// facts and that table is per-stratum. Empty but for its header when nothing is excluded, which
+    /// is a meaningful answer rather than a missing file.
+    /// </remarks>
+    public string ExclusionsToTabSeparated()
+    {
+        var text = new StringBuilder();
+        text.AppendLine(string.Join("\t", "accession", "peptide", "reason"));
+
+        foreach ((string accession, IReadOnlyCollection<string> peptides) in
+                 AmbiguousPeptidesByAccession.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            foreach (string peptide in peptides.OrderBy(p => p, StringComparer.Ordinal))
+            {
+                text.AppendLine(string.Join("\t", accession, peptide, "ambiguous"));
+            }
+        }
+
+        foreach ((string accession, IReadOnlyCollection<string> peptides) in
+                 UnrepairableRunCollisionsByAccession.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            foreach (string peptide in peptides.OrderBy(p => p, StringComparer.Ordinal))
+            {
+                text.AppendLine(string.Join("\t", accession, peptide, "unrepairableRunCollision"));
+            }
+        }
+
+        foreach ((string accession, IReadOnlyCollection<string> peptides) in
+                 ForeignPeptidesSharedWithTarget.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            foreach (string peptide in peptides.OrderBy(p => p, StringComparer.Ordinal))
+            {
+                text.AppendLine(string.Join("\t", accession, peptide, "sharedWithTarget"));
+            }
+        }
+
+        return text.ToString();
+    }
+
+    public EntrapmentProvenance Provenance { get; }
+
+    /// <summary>One entry per observed stratum, ascending.</summary>
+    public IReadOnlyList<EntrapmentStratum> Strata { get; }
+
+    /// <summary>The same counts across every stratum.</summary>
+    public EntrapmentStratum Total { get; }
+
+    /// <summary>Counts occurrences of any of <paramref name="residues"/> in a peptide.</summary>
+    /// <remarks>O-glycosylation localization stratifies on "ST": the count of candidate sites in a
+    /// peptide is what sets the difficulty of placing a modification on it.</remarks>
+    public static Func<string, int> CountResidues(string residues)
+    {
+        if (string.IsNullOrEmpty(residues))
+        {
+            throw new MzLibException("CountResidues needs at least one residue to count.");
+        }
+
+        var wanted = new HashSet<char>(residues);
+        return peptide => peptide.Count(wanted.Contains);
+    }
+
+    /// <summary>Counts N-X-S/T sequons, where X is any residue but proline.</summary>
+    /// <remarks>
+    /// A rearrangement destroys and creates these, so unlike a plain residue count this one is not
+    /// preserved. Reporting it is the point: drift is acceptable, drift nobody can see is not.
+    /// </remarks>
+    public static int CountNGlycoSequons(string peptide)
+    {
+        int count = 0;
+        for (int i = 0; i + 2 < peptide.Length; i++)
+        {
+            if (peptide[i] == 'N' && peptide[i + 1] != 'P' && (peptide[i + 2] == 'S' || peptide[i + 2] == 'T'))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>The report as a tab-separated table, provenance in leading comment lines.</summary>
+    public string ToTabSeparated()
+    {
+        var text = new StringBuilder();
+        // InvariantCulture, like every numeric column further down this method. These rows are
+        // what a consumer reads to regenerate a database, and a culture whose negative sign is
+        // not ASCII (sv-SE writes U+2212) wrote a seed no parser reading it back would accept.
+        text.AppendLine($"# method\t{Provenance.Method}");
+        text.AppendLine($"# enzyme\t{Provenance.Enzyme}");
+        text.AppendLine($"# seed\t{Provenance.Seed.ToString(CultureInfo.InvariantCulture)}");
+        text.AppendLine($"# foldCount\t{Provenance.FoldCount.ToString(CultureInfo.InvariantCulture)}");
+        text.AppendLine($"# maxMissedCleavages\t{Provenance.MaxMissedCleavages.ToString(CultureInfo.InvariantCulture)}");
+        text.AppendLine($"# minPeptideLength\t{Provenance.MinPeptideLength.ToString(CultureInfo.InvariantCulture)}");
+        text.AppendLine($"# maxPeptideLength\t{Provenance.MaxPeptideLength.ToString(CultureInfo.InvariantCulture)}");
+        if (EntriesYieldingNoPartner > 0)
+        {
+            text.AppendLine($"# entriesYieldingNoPartner\t{EntriesYieldingNoPartner.ToString(CultureInfo.InvariantCulture)}");
+        }
+        // The foreign arm contributes entries that no permutation figure describes, so
+        // without these the provenance describes only half a database that has one, and the
+        // arm's r is not recoverable from the report at all. Emitted only when it was used,
+        // so a bottom-up report is byte-identical to before.
+        if (ForeignEntries > 0)
+        {
+            text.AppendLine($"# foreignEntries\t{ForeignEntries.ToString(CultureInfo.InvariantCulture)}");
+            text.AppendLine($"# foreignPeptidesSharedWithTarget\t"
+                + ForeignPeptidesSharedWithTarget.Sum(kv => kv.Value.Count).ToString(CultureInfo.InvariantCulture));
+        }
+        // targetPeptides/entrapmentPeptides count BASE PIECES; searchSpacePeptides counts what a
+        // search reports, missed cleavages included. `ambiguous` belongs to the latter -- dividing
+        // it by the former divides two different populations, which is how 0.24% got written
+        // as "1.19%".
+        text.AppendLine(string.Join("\t", "siteCount", "targetPeptides", "entrapmentPeptides",
+            "achievedFoldRatio", "unpairableNoPermutationExists", "unpairableAllPermutationsTaken",
+            "unpairableSpaceTooSmallForFoldCount", "unpairableRunCollisionsExhausted",
+            "searchSpacePeptides",
+            "entrapmentSearchSpacePeptides", "ambiguous",
+            "mcSpanningAnExcision", "unrepairableRunCollisions"));
+
+        foreach (EntrapmentStratum stratum in Strata.Append(Total))
+        {
+            text.AppendLine(string.Join("\t",
+                ReferenceEquals(stratum, Total) ? "all" : stratum.SiteCount.ToString(CultureInfo.InvariantCulture),
+                stratum.TargetPeptides.ToString(CultureInfo.InvariantCulture),
+                stratum.EntrapmentPeptides.ToString(CultureInfo.InvariantCulture),
+                stratum.AchievedFoldRatio.ToString("0.0000", CultureInfo.InvariantCulture),
+                stratum.UnpairableNoPermutationExists.ToString(CultureInfo.InvariantCulture),
+                stratum.UnpairableAllPermutationsTaken.ToString(CultureInfo.InvariantCulture),
+                stratum.UnpairableSpaceTooSmallForFoldCount.ToString(CultureInfo.InvariantCulture),
+                stratum.UnpairableRunCollisionsExhausted.ToString(CultureInfo.InvariantCulture),
+                stratum.SearchSpacePeptides.ToString(CultureInfo.InvariantCulture),
+                stratum.EntrapmentSearchSpacePeptides.ToString(CultureInfo.InvariantCulture),
+                stratum.Ambiguous.ToString(CultureInfo.InvariantCulture),
+                stratum.MissedCleavagePeptidesSpanningAnExcision.ToString(CultureInfo.InvariantCulture),
+                stratum.UnrepairableRunCollisions.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        return text.ToString();
+    }
+}
+
+/// <summary>
+/// Accumulates a report while a database is generated, one target protein and fold at a time.
+/// </summary>
+/// <remarks>
+/// Counts are over the peptides a search could actually report -- base pieces at least
+/// <see cref="IDigestionParams.MinLength"/> long. Shorter pieces are never identified on their own,
+/// so counting them would flatter every ratio here.
+/// </remarks>
+public sealed class EntrapmentReportBuilder
+{
+    private readonly IDigestionParams _digestionParams;
+    private readonly int _foldCount;
+    private readonly int _seed;
+    private readonly Func<string, int> _siteCounter;
+    private readonly Dictionary<int, EntrapmentStratum> _strata = new();
+    private readonly HashSet<string> _countedTargetPieces = new();
+    private readonly Dictionary<string, HashSet<string>> _ambiguousByAccession = new();
+    private readonly Dictionary<string, List<string>> _unrepairableByAccession = new();
+    private readonly string _entrapmentIdentifier;
+    private int _entriesYieldingNoPartner;
+    private readonly Dictionary<string, HashSet<string>> _foreignSharedByAccession = new();
+
+    /// <summary>
+    /// Figures that belong to the database rather than to any candidate-site stratum. Kept apart so
+    /// they reach <see cref="EntrapmentReport.Total"/> without ever appearing in a stratum row.
+    /// </summary>
+    private readonly EntrapmentStratum _wholeProtein = new(-1);
+    private int _foreignEntries;
+
+    /// <param name="siteCounter">What to stratify by, e.g.
+    /// <see cref="EntrapmentReport.CountResidues"/>("ST"). Null puts everything in one stratum.</param>
+    /// <param name="entrapmentIdentifier">The accession prefix the partners were minted with. The
+    /// collision list is keyed by the entrapment accession, so it has to match the generator's.</param>
+    public EntrapmentReportBuilder(IDigestionParams digestionParams, int foldCount, int seed,
+        Func<string, int>? siteCounter = null,
+        string entrapmentIdentifier = ProteinDbLoader.DefaultEntrapmentIdentifier)
+    {
+        if (digestionParams is null)
+        {
+            throw new MzLibException("A report needs the digestion parameters it was generated under.");
+        }
+
+        _digestionParams = digestionParams;
+        _foldCount = foldCount;
+        _seed = seed;
+        _siteCounter = siteCounter ?? (_ => 0);
+        _entrapmentIdentifier = entrapmentIdentifier;
+    }
+
+    /// <summary>Records one target protein's assembly for one fold.</summary>
+    public void Add(Protein target, int fold, EntrapmentAssembly assembly)
+    {
+        if (target is null || assembly is null)
+        {
+            throw new MzLibException("A report entry needs both a target protein and its assembly.");
+        }
+
+        if (!_ambiguousByAccession.TryGetValue(target.Accession, out HashSet<string>? ambiguous))
+        {
+            var pairing = new EntrapmentPairing(target, _digestionParams);
+            ambiguous = pairing.AmbiguousPeptides.ToHashSet();
+            _ambiguousByAccession[target.Accession] = ambiguous;
+
+            foreach (string peptide in ambiguous)
+            {
+                StratumFor(peptide).Ambiguous++;
+            }
+
+            // Straight onto the total, never a stratum. StratumFor("") resolves to the zero-site
+            // stratum -- it short-circuits an empty peptide to 0 and then reuses the real one -- so
+            // a whole-protein figure was being published beside that stratum's own per-peptide
+            // counts, and every other row read 0 for a column that is not zero. This one is sold as
+            // a denominator and the documented use is the stratified one, which is exactly where
+            // dividing within a row would go wrong.
+            _wholeProtein.SearchSpacePeptides += pairing.SearchablePeptideCount;
+        }
+
+        foreach (EntrapmentPiece piece in assembly.Pieces)
+        {
+            if (piece.TargetPiece.Length < _digestionParams.MinLength)
+            {
+                continue;   // never identified on its own, so not part of any ratio here
+            }
+
+            EntrapmentStratum stratum = StratumFor(piece.TargetPiece);
+
+            // Each target peptide is counted once however many folds run, so the ratio below is
+            // partners per target -- the achieved r -- rather than a fraction of what was asked.
+            if (_countedTargetPieces.Add(target.Accession + " " + piece.Index))
+            {
+                stratum.TargetPeptides++;
+            }
+
+            switch (piece.Outcome)
+            {
+                case PieceOutcome.Permuted:
+                case PieceOutcome.KeptVerbatimTooShort:
+                    stratum.EntrapmentPeptides++;
+                    break;
+                case PieceOutcome.Excised when piece.Failure == EntrapmentFailure.NoPermutationExists:
+                    stratum.UnpairableNoPermutationExists++;
+                    break;
+                case PieceOutcome.Excised when piece.Failure == EntrapmentFailure.SpaceTooSmallForFoldCount:
+                    stratum.UnpairableSpaceTooSmallForFoldCount++;
+                    break;
+                case PieceOutcome.Excised when piece.Failure == EntrapmentFailure.RunCollisionsExhaustedTheSpace:
+                    stratum.UnpairableRunCollisionsExhausted++;
+                    break;
+                case PieceOutcome.Excised:
+                    stratum.UnpairableAllPermutationsTaken++;
+                    break;
+            }
+        }
+
+        // Whole-protein figures, so onto the total rather than into a stratum. A broken run spans
+        // several peptides at once and a collision is a property of a placement, so neither is
+        // attributable to one candidate-site count.
+        _wholeProtein.MissedCleavagePeptidesSpanningAnExcision +=
+            assembly.MissedCleavagePeptidesSpanningAnExcision;
+        if (assembly.EntrapmentSequence.Length == 0)
+        {
+            _entriesYieldingNoPartner++;
+        }
+
+        _wholeProtein.EntrapmentSearchSpacePeptides +=
+            EntrapmentPairing.CountSearchablePeptides(assembly.EntrapmentSequence, _digestionParams);
+        if (assembly.UnrepairableRunCollisionPeptides.Count > 0)
+        {
+            // Keyed by the accession a search will report the peptide under, not by the target it
+            // was rearranged from. These peptides belong to the ENTRAPMENT protein; filing them
+            // under the target made the two halves of one table mean different things by
+            // `accession`, and a consumer filtering on (accession, peptide) matched the ambiguous
+            // rows and silently missed these -- under-excluding, which inflates an FDP estimate.
+            string entrapmentAccession =
+                EntrapmentAccession.Format(target.Accession, fold, _entrapmentIdentifier);
+            if (!_unrepairableByAccession.TryGetValue(entrapmentAccession, out List<string>? collisions))
+            {
+                collisions = new List<string>();
+                _unrepairableByAccession[entrapmentAccession] = collisions;
+            }
+
+            // Distinct peptides, not placements. The same run can collide at two points in one
+            // low-complexity protein, and an exclusion list is read as "these peptides" -- a
+            // consumer subtracting a duplicate twice would over-correct.
+            foreach (string collision in assembly.UnrepairableRunCollisionPeptides)
+            {
+                if (!collisions.Contains(collision))
+                {
+                    collisions.Add(collision);
+                    // Incremented here rather than from assembly.UnrepairableRunCollisions, which
+                    // counts PLACEMENTS. The column and the sidecar are read together, so counting
+                    // one in placements and the other in peptides made them disagree -- 2,048
+                    // against 1,983 rows on the reviewed human database.
+                    _wholeProtein.UnrepairableRunCollisions++;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Records the foreign-species arm: how many entries it contributed, and which of its peptides
+    /// are also target peptides.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="Add"/> because a foreign entry has no assembly and no target -- it
+    /// was relabelled, not rearranged -- so none of the per-stratum permutation figures apply to it.
+    /// Folding it into those would put entries in the ratio that were never at risk of failing.
+    /// </remarks>
+    public void AddForeign(int entryCount,
+        IReadOnlyDictionary<string, IReadOnlyCollection<string>> sharedWithTarget)
+    {
+        if (entryCount < 0)
+        {
+            throw new MzLibException($"Foreign entry count must not be negative, but was {entryCount}.");
+        }
+
+        _foreignEntries += entryCount;
+        foreach ((string accession, IReadOnlyCollection<string> peptides) in
+                 sharedWithTarget ?? new Dictionary<string, IReadOnlyCollection<string>>())
+        {
+            // Merge, because the entry count beside it accumulates. Assigning here while
+            // `_foreignEntries` added meant two calls naming one accession counted both entries and
+            // kept only the second call's peptides -- the arm silently under-reporting exactly the
+            // peptides it exists to name.
+            if (!_foreignSharedByAccession.TryGetValue(accession, out HashSet<string>? merged))
+            {
+                merged = new HashSet<string>(StringComparer.Ordinal);
+                _foreignSharedByAccession[accession] = merged;
+            }
+
+            foreach (string peptide in peptides ?? Array.Empty<string>())
+            {
+                merged.Add(peptide);
+            }
+        }
+    }
+
+    /// <summary>The finished report.</summary>
+    public EntrapmentReport Build()
+    {
+        var total = new EntrapmentStratum(-1);
+        foreach (EntrapmentStratum stratum in _strata.Values)
+        {
+            total.TargetPeptides += stratum.TargetPeptides;
+            total.EntrapmentPeptides += stratum.EntrapmentPeptides;
+            total.UnpairableNoPermutationExists += stratum.UnpairableNoPermutationExists;
+            total.UnpairableAllPermutationsTaken += stratum.UnpairableAllPermutationsTaken;
+            total.UnpairableSpaceTooSmallForFoldCount += stratum.UnpairableSpaceTooSmallForFoldCount;
+            total.UnpairableRunCollisionsExhausted += stratum.UnpairableRunCollisionsExhausted;
+            total.Ambiguous += stratum.Ambiguous;
+            total.MissedCleavagePeptidesSpanningAnExcision += stratum.MissedCleavagePeptidesSpanningAnExcision;
+            total.SearchSpacePeptides += stratum.SearchSpacePeptides;
+            total.UnrepairableRunCollisions += stratum.UnrepairableRunCollisions;
+        }
+
+        // The whole-database figures join the total and no stratum, so every stratum row reads 0 for
+        // them rather than one row reading a number that does not describe its population.
+        total.SearchSpacePeptides += _wholeProtein.SearchSpacePeptides;
+        total.EntrapmentSearchSpacePeptides += _wholeProtein.EntrapmentSearchSpacePeptides;
+        total.UnrepairableRunCollisions += _wholeProtein.UnrepairableRunCollisions;
+        total.MissedCleavagePeptidesSpanningAnExcision +=
+            _wholeProtein.MissedCleavagePeptidesSpanningAnExcision;
+
+        var provenance = new EntrapmentProvenance(
+            method: "composition-preserving permutation (deterministic unranking)",
+            enzyme: _digestionParams.DigestionAgent.Name,
+            seed: _seed,
+            foldCount: _foldCount,
+            maxMissedCleavages: _digestionParams.MaxMissedCleavages,
+            minPeptideLength: _digestionParams.MinLength,
+            maxPeptideLength: _digestionParams.MaxLength);
+
+        return new EntrapmentReport(provenance,
+            _strata.Values.OrderBy(s => s.SiteCount).ToList(),
+            total,
+            _ambiguousByAccession.Where(kv => kv.Value.Count > 0)
+                .ToDictionary(kv => kv.Key, kv => (IReadOnlyCollection<string>)kv.Value),
+            _unrepairableByAccession.Where(kv => kv.Value.Count > 0)
+                .ToDictionary(kv => kv.Key, kv => (IReadOnlyCollection<string>)kv.Value))
+        {
+            ForeignEntries = _foreignEntries,
+            EntriesYieldingNoPartner = _entriesYieldingNoPartner,
+            // A snapshot, like the two dictionaries above it. Handing out the builder's live
+            // dictionary let a later AddForeign mutate a report that had already been built.
+            ForeignPeptidesSharedWithTarget = _foreignSharedByAccession
+                .Where(kv => kv.Value.Count > 0)
+                .ToDictionary(kv => kv.Key, kv => (IReadOnlyCollection<string>)kv.Value.ToList()),
+        };
+    }
+
+    private EntrapmentStratum StratumFor(string peptide)
+    {
+        int siteCount = peptide.Length == 0 ? 0 : _siteCounter(peptide);
+        if (!_strata.TryGetValue(siteCount, out EntrapmentStratum? stratum))
+        {
+            stratum = new EntrapmentStratum(siteCount);
+            _strata[siteCount] = stratum;
+        }
+
+        return stratum;
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentReport.cs
+++ b/mzLib/UsefulProteomicsDatabases/EntrapmentGeneration/EntrapmentReport.cs
@@ -128,6 +128,19 @@ public sealed class EntrapmentStratum
     /// </remarks>
     public int UnrepairableRunCollisions { get; internal set; }
 
+    /// <summary>
+    /// Entrapment peptides that are a real target peptide only once a search removes the entrapment
+    /// protein's initiator methionine, and that no arrangement of the opening piece avoided.
+    /// </summary>
+    /// <remarks>
+    /// The one route by which a real target peptide reaches the entrapment set at
+    /// <c>MaxMissedCleavages = 0</c>, where the run route does not exist. Reported separately from
+    /// <see cref="UnrepairableRunCollisions"/> because a consumer excluding them needs to know which
+    /// construction produced them, and because at MC = 0 this column reading zero and that one
+    /// reading zero mean different things.
+    /// </remarks>
+    public int InitiatorMethionineCollisions { get; internal set; }
+
     public int Unpairable => UnpairableNoPermutationExists + UnpairableAllPermutationsTaken
                              + UnpairableSpaceTooSmallForFoldCount + UnpairableRunCollisionsExhausted;
 
@@ -156,13 +169,15 @@ public sealed class EntrapmentReport
     internal EntrapmentReport(EntrapmentProvenance provenance, IReadOnlyList<EntrapmentStratum> strata,
         EntrapmentStratum total,
         IReadOnlyDictionary<string, IReadOnlyCollection<string>> ambiguousByAccession,
-        IReadOnlyDictionary<string, IReadOnlyCollection<string>> unrepairableByAccession)
+        IReadOnlyDictionary<string, IReadOnlyCollection<string>> unrepairableByAccession,
+        IReadOnlyDictionary<string, IReadOnlyCollection<string>> initiatorMethionineByAccession)
     {
         Provenance = provenance;
         Strata = strata;
         Total = total;
         AmbiguousPeptidesByAccession = ambiguousByAccession;
         UnrepairableRunCollisionsByAccession = unrepairableByAccession;
+        InitiatorMethionineCollisionsByAccession = initiatorMethionineByAccession;
     }
 
     /// <summary>
@@ -189,6 +204,20 @@ public sealed class EntrapmentReport
     /// piece. Excluding them is the consumer's call, and needs the sequences.
     /// </remarks>
     public IReadOnlyDictionary<string, IReadOnlyCollection<string>> UnrepairableRunCollisionsByAccession { get; }
+
+    /// <summary>
+    /// Entrapment peptides that a search would read as real target peptides after removing the
+    /// entrapment protein's initiator methionine, by the ENTRAPMENT accession holding them.
+    /// </summary>
+    /// <remarks>
+    /// Digestion emits the opening piece with and without its initiator methionine, so a piece
+    /// distinct from every target peptide can still have an M-stripped form that is not. Measured on
+    /// the reviewed human proteome before the check existed: two peptides under Arg-C and two under
+    /// Glu-C at MC = 0. They appeared in no exclusion list, because a run collision was the only
+    /// reason this sidecar could name -- which is why this list is separate rather than folded into
+    /// that one.
+    /// </remarks>
+    public IReadOnlyDictionary<string, IReadOnlyCollection<string>> InitiatorMethionineCollisionsByAccession { get; }
 
     /// <summary>
     /// Peptides of the foreign-species arm that are also target peptides, by the foreign protein's
@@ -249,6 +278,15 @@ public sealed class EntrapmentReport
             foreach (string peptide in peptides.OrderBy(p => p, StringComparer.Ordinal))
             {
                 text.AppendLine(string.Join("\t", accession, peptide, "unrepairableRunCollision"));
+            }
+        }
+
+        foreach ((string accession, IReadOnlyCollection<string> peptides) in
+                 InitiatorMethionineCollisionsByAccession.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            foreach (string peptide in peptides.OrderBy(p => p, StringComparer.Ordinal))
+            {
+                text.AppendLine(string.Join("\t", accession, peptide, "initiatorMethionineCollision"));
             }
         }
 
@@ -342,7 +380,7 @@ public sealed class EntrapmentReport
             "unpairableSpaceTooSmallForFoldCount", "unpairableRunCollisionsExhausted",
             "searchSpacePeptides",
             "entrapmentSearchSpacePeptides", "ambiguous",
-            "mcSpanningAnExcision", "unrepairableRunCollisions"));
+            "mcSpanningAnExcision", "unrepairableRunCollisions", "initiatorMethionineCollisions"));
 
         foreach (EntrapmentStratum stratum in Strata.Append(Total))
         {
@@ -359,7 +397,8 @@ public sealed class EntrapmentReport
                 stratum.EntrapmentSearchSpacePeptides.ToString(CultureInfo.InvariantCulture),
                 stratum.Ambiguous.ToString(CultureInfo.InvariantCulture),
                 stratum.MissedCleavagePeptidesSpanningAnExcision.ToString(CultureInfo.InvariantCulture),
-                stratum.UnrepairableRunCollisions.ToString(CultureInfo.InvariantCulture)));
+                stratum.UnrepairableRunCollisions.ToString(CultureInfo.InvariantCulture),
+                stratum.InitiatorMethionineCollisions.ToString(CultureInfo.InvariantCulture)));
         }
 
         return text.ToString();
@@ -384,6 +423,7 @@ public sealed class EntrapmentReportBuilder
     private readonly HashSet<string> _countedTargetPieces = new();
     private readonly Dictionary<string, HashSet<string>> _ambiguousByAccession = new();
     private readonly Dictionary<string, List<string>> _unrepairableByAccession = new();
+    private readonly Dictionary<string, List<string>> _initiatorMethionineByAccession = new();
     private readonly string _entrapmentIdentifier;
     private int _entriesYieldingNoPartner;
     private readonly Dictionary<string, HashSet<string>> _foreignSharedByAccession = new();
@@ -523,6 +563,30 @@ public sealed class EntrapmentReportBuilder
                 }
             }
         }
+
+        // The same shape, deliberately: same accession, same distinct-peptide rule, same reason for
+        // both. Kept as a second list rather than a second reason on the first because the two are
+        // produced by different constructions, and at MaxMissedCleavages = 0 the run list is empty
+        // by definition while this one is empty only if the check ran and found nothing.
+        if (assembly.InitiatorMethionineCollisionPeptides.Count > 0)
+        {
+            string entrapmentAccession =
+                EntrapmentAccession.Format(target.Accession, fold, _entrapmentIdentifier);
+            if (!_initiatorMethionineByAccession.TryGetValue(entrapmentAccession, out List<string>? stripped))
+            {
+                stripped = new List<string>();
+                _initiatorMethionineByAccession[entrapmentAccession] = stripped;
+            }
+
+            foreach (string collision in assembly.InitiatorMethionineCollisionPeptides)
+            {
+                if (!stripped.Contains(collision))
+                {
+                    stripped.Add(collision);
+                    _wholeProtein.InitiatorMethionineCollisions++;
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -579,6 +643,7 @@ public sealed class EntrapmentReportBuilder
             total.MissedCleavagePeptidesSpanningAnExcision += stratum.MissedCleavagePeptidesSpanningAnExcision;
             total.SearchSpacePeptides += stratum.SearchSpacePeptides;
             total.UnrepairableRunCollisions += stratum.UnrepairableRunCollisions;
+            total.InitiatorMethionineCollisions += stratum.InitiatorMethionineCollisions;
         }
 
         // The whole-database figures join the total and no stratum, so every stratum row reads 0 for
@@ -586,6 +651,7 @@ public sealed class EntrapmentReportBuilder
         total.SearchSpacePeptides += _wholeProtein.SearchSpacePeptides;
         total.EntrapmentSearchSpacePeptides += _wholeProtein.EntrapmentSearchSpacePeptides;
         total.UnrepairableRunCollisions += _wholeProtein.UnrepairableRunCollisions;
+        total.InitiatorMethionineCollisions += _wholeProtein.InitiatorMethionineCollisions;
         total.MissedCleavagePeptidesSpanningAnExcision +=
             _wholeProtein.MissedCleavagePeptidesSpanningAnExcision;
 
@@ -604,6 +670,8 @@ public sealed class EntrapmentReportBuilder
             _ambiguousByAccession.Where(kv => kv.Value.Count > 0)
                 .ToDictionary(kv => kv.Key, kv => (IReadOnlyCollection<string>)kv.Value),
             _unrepairableByAccession.Where(kv => kv.Value.Count > 0)
+                .ToDictionary(kv => kv.Key, kv => (IReadOnlyCollection<string>)kv.Value),
+            _initiatorMethionineByAccession.Where(kv => kv.Value.Count > 0)
                 .ToDictionary(kv => kv.Key, kv => (IReadOnlyCollection<string>)kv.Value))
         {
             ForeignEntries = _foreignEntries,

--- a/mzLib/UsefulProteomicsDatabases/ProteinDbLoader.cs
+++ b/mzLib/UsefulProteomicsDatabases/ProteinDbLoader.cs
@@ -53,6 +53,12 @@ namespace UsefulProteomicsDatabases
         /// </summary>
         public const string NcbiTaxonomyDatabaseReferenceType = Protein.NcbiTaxonomyDatabaseReferenceType;
 
+        /// <summary>
+        /// Marks a protein as entrapment. A protein is treated as entrapment when its accession
+        /// contains this anywhere, and it is prepended when a caller flags entrapment without it.
+        /// </summary>
+        public const string DefaultEntrapmentIdentifier = "Random";
+
         public static readonly FastaHeaderFieldRegex EnsemblAccessionRegex = new FastaHeaderFieldRegex("accession", @"([A-Z0-9_.]+)", 0, 1);
         public static readonly FastaHeaderFieldRegex EnsemblFullNameRegex = new FastaHeaderFieldRegex("fullName", @"(pep:.*)", 0, 1);
         public static readonly FastaHeaderFieldRegex EnsemblGeneNameRegex = new FastaHeaderFieldRegex("geneName", @"gene:([^ ]+)", 0, 1);
@@ -86,7 +92,7 @@ namespace UsefulProteomicsDatabases
         public static List<Protein> LoadProteinXML(string proteinDbLocation, bool generateTargets, DecoyType decoyType, IEnumerable<Modification> allKnownModifications,
             bool isContaminant, IEnumerable<string> modTypesToExclude, out Dictionary<string, Modification> unknownModifications, int maxThreads = -1,
             int maxHeterozygousVariants = 4, int minAlleleDepth = 1, bool addTruncations = false, string decoyIdentifier = "DECOY",
-            string entrapmentIdentifier = "Random", bool isEntrapment = false)
+            string entrapmentIdentifier = DefaultEntrapmentIdentifier, bool isEntrapment = false)
         {
             List<Modification> prespecified = GetPtmListFromProteinXml(proteinDbLocation);
             allKnownModifications = allKnownModifications ?? new List<Modification>();
@@ -245,7 +251,7 @@ namespace UsefulProteomicsDatabases
         public static List<Protein> LoadProteinFasta(string proteinDbLocation, bool generateTargets, DecoyType decoyType, bool isContaminant, out List<string> errors,
             FastaHeaderFieldRegex accessionRegex = null, FastaHeaderFieldRegex fullNameRegex = null, FastaHeaderFieldRegex nameRegex = null,
             FastaHeaderFieldRegex geneNameRegex = null, FastaHeaderFieldRegex organismRegex = null, int maxThreads = -1, bool addTruncations = false, string decoyIdentifier = "DECOY",
-            string entrapmentIdentifier = "Random", bool isEntrapment = false, FastaHeaderFieldRegex organismIdRegex = null)
+            string entrapmentIdentifier = DefaultEntrapmentIdentifier, bool isEntrapment = false, FastaHeaderFieldRegex organismIdRegex = null)
         {
             FastaHeaderType? HeaderType = null;
             HashSet<string> unique_accessions = new HashSet<string>();


### PR DESCRIPTION
<!-- project-of-origin -->
> **Project of origin:** `entrapment`

Gives mzLib a managed entrapment-database generator: from any target protein database and any protease, an **r-fold entrapment database whose peptides are isomeric with their targets**, deterministically paired to them **without a side file**, and **honestly reported** where the construction cannot be achieved. No external executable, no reflection.

### Why one PR

This consolidates work previously split across #1253–#1265 and #1267. That stack was reviewed in two rounds by @acesnik — every finding is folded in here — but a 15-PR chain has a real hazard: it is merged in order and can be stopped at any point, and the intermediate heads carried defects that were only fixed further up. A reviewer merging three PRs and pausing would have landed known-broken code.

**This branch is self-sufficient.** It is cut from current master, it builds, its tests pass, and it does not depend on any later PR to be correct.

### What it contains

| | |
|---|---|
| `EntrapmentPeptideGenerator` | one peptide's partner, by deterministic unranking of the multiset permutation space — a pure function of (peptide, seed), reproducible across runs, threads and machines, and parallel-safe. Emptiness is *proven*, not discovered by a retry budget. |
| `EntrapmentAssembler` | a protein's partner: cleavage sites pinned so it digests into the same pieces, termini anchored so terminally-restricted modifications survive, missed-cleavage runs collision-checked. |
| `EntrapmentProteinGenerator` | a database entry's partner, modifications moved onto the residues they were on, one partner per **entry** rather than per loaded protein. |
| `EntrapmentAccession` | `Random_<target>_f<fold>`, parsed back safely; the foreign form is refused as a partner rather than mis-parsed. |
| `EntrapmentPairing` | the partner recovered from accession and sequence alone, by composition plus pinned pattern. |
| `EntrapmentReport` | the QC report as a first-class output — the distribution rather than a summary, failures kept apart by cause, and the peptides a consumer must exclude **named individually** rather than counted. |

### Measured, not assumed

Reviewed human proteome, trypsin, MC ≤ 2: **2,591,131** distinct peptides in **114 s**; 99.77% first-probe success; achieved r **8.998** at r = 9; pairing unambiguous for **99.979%** of base peptides; end-to-end retention **99.99%**. Searched at scale with MetaMorpheus across twelve fractions of PXD001468, with every discovery paired back to its target with nothing carried alongside the file.

Three findings contradicted the design assumptions and are documented where they bite:

- **Mucins do not fail** — zero unpairable across 4,770 peptides from all 20 MUC genes. The real failure mode is homopolymeric poly-S/poly-T, and site-rich peptides turn out to be the *easiest* to entrap.
- **Achieved r degrades at `n` = 0**, the opposite end from the one predicted.
- **`DigestionMotif` cannot express "glycosylated"**, so a mucinase encoded as a sequence motif over-digests.

### Known limit, counted rather than hidden

**1,794 peptide sequences (0.065%)** appear in both the target and entrapment digests of the written database, because the run's final piece has exactly one arrangement and there is no candidate to move to. They are named in `<db>_entrapment_exclusions.tsv` so a consumer can subtract them. Repairing would mean backtracking into a placed piece or excising a good one.

### Blast radius

The only existing code touched is `ProteinDbLoader.DefaultEntrapmentIdentifier` — a duplicated literal replaced by a name with the same value — and a clarified `<remarks>` on `DecoySequenceValidator.PermutationSpaceSize`. Everything else is additive.

**498 tests passing** across the database, decoy, entrapment and protein-reader suites.

Proteoform (top-down) mode follows in a separate PR, opened as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLa2EL9kF2er4CASwRnPvz

