### PR TITLE
Write the 1.0.589 release notes before the tag exists

### DIFF
--- a/release-notes/1.0.589.md
+++ b/release-notes/1.0.589.md
@@ -1,0 +1,117 @@
+# mzLib 1.0.589 — accessions, and the quantification tables
+**Source:** `1.0.588..1.0.589` (16 PRs)
+**Contributors:** @acesnik, @trishorts
+
+Two groups of changes alter output that existing callers already have. **FASTA accession parsing
+changes for any defline with more than two pipes**, and the three quantification fixes change the
+shape and the sample keys of the written tables. Both are corrections — the previous answers were
+wrong — but neither is comparable with what you produced before. Everything else is additive,
+robustness, or test-only.
+
+- **The UniProt FASTA accession is now the last pipe-delimited field (#1251)** — `UniprotAccessionRegex`
+  was unanchored with a greedy `.+`, so it ran from the *first* pipe to the *last*. On a two-pipe
+  UniProt defline that coincides with "capture field 2", which is why it survived this long. On a
+  four-pipe legacy NCBI defline it concatenated three fields: `>gi|16128008|ref|NP_414555.1|` yielded
+  `16128008|ref|NP_414555.1` where the accession is `NP_414555.1`. **Accession is the join key in every
+  file we write**, and `|` is also the separator our own multi-valued columns use, so a pipe inside an
+  accession desynchronises any reader splitting columns in lockstep and turns one protein into several
+  tokens in a protein-group name. Two-pipe UniProt and modern two-pipe RefSeq headers are **unchanged**;
+  databases with more than two pipes now produce different — correct — accessions, and results across
+  the boundary are not comparable.
+
+- **The quantification table is rectangular (#1240)** — Intensity columns were emitted from a per-group
+  check, so a group with no assigned intensities wrote a row with fewer fields than the header claimed.
+  Header and row are now gated on the same condition, so every row carries the same tab count as its
+  header. If you parse the written protein table positionally, this is the release that makes that safe.
+  MetaMorpheus's own copy of the block is fixed separately in MetaMorpheus #2772.
+
+- **Collapsing samples reaches the peptide table (#1243)** — `RunProteinQuant` collapsed by reassigning
+  a by-value parameter the caller never saw, so `QuantificationResults.Samples` held the collapsed
+  samples while the peptide table still held the uncollapsed ones. The two tables shared no keys, and a
+  written peptide file could name different samples than the protein file beside it. One sample list now
+  keys both.
+
+- **An unset quantification strategy is rejected by name (#1242)** — Six strategy properties defaulted to
+  null and were not validated, so a run started, wrote `RawQuantification.tsv`, and then threw from
+  mid-run with a `NullReferenceException` that named nothing. `ValidateEngine` now rejects the
+  configuration before the first write, naming the property. `ICollapseStrategy` gains
+  `RequiresAggregation` (default `true`) so a non-aggregating strategy — `NoCollapse` — can still run
+  with no aggregator. That is a **new member on a shipped public interface**: an external implementation
+  inherits the default and needs no change unless it wants the other arm.
+
+- **`IntensityNormalizationEngine` honours `quantifyAmbiguousPeptides` (#1192)** — The constructor took
+  the argument and never stored it, so the field was permanently `false` and all four
+  `CalculatePeptideResults` calls ignored what the caller asked for. **An external caller passing `true`
+  was silently getting `false` and now gets `true`.** No in-repo caller passes it, so nothing in mzLib
+  itself quantifies differently. The same PR clears nineteen meaningful compiler warnings (1027 → 1008
+  solution-wide, no new warning codes) and removes a dead `SpectralSimilarity._keepAllTheoreticalPeaks`
+  field whose condition was always true.
+
+- **A malformed MGF line is skipped, not fatal (#1184)** — Four places in the MGF scan parser read the
+  second element of a split without checking it existed, so one bad line threw
+  `IndexOutOfRangeException` and made the whole file unreadable. A peak line with an m/z but no
+  intensity, a `PEPMASS`/`CHARGE`/`SCANS` with no `=`, and an empty `CHARGE=` are all guarded now. This
+  is the reader's existing contract rather than a new one — `tester_corrupt.mgf` already loaded — and
+  nothing invents data: an unreadable line contributes no peak, and a scan left with no peaks was
+  already dropped. Fixes MetaMorpheus #2366, reported on an MGF converted from Bruker by MSConvert.
+
+- **A stalled PRIDE download now ends (#1199)** — `DownloadFileAsync` read the body with a bare
+  `CopyToAsync` and no read deadline. Because the download uses
+  `HttpCompletionOption.ResponseHeadersRead`, `HttpClient.Timeout` is spent once the headers arrive, so
+  a body that stopped mid-transfer was bounded by nothing. `BodyStallTimeout` is an **inactivity**
+  deadline, not a total cap — every byte restarts the clock, so a merely slow multi-gigabyte transfer is
+  unaffected and only silence ends it. Two minutes, the value #1189 measured against a degraded UniProt
+  rather than a fresh guess.
+
+- **mzIdentML 1.3.0 files load (#1169)** — 1.3.0 was released in June 2024; the reader knew 1.1.0, 1.1.1
+  and 1.2.0, so a 1.3.0 file failed to deserialize against all of them and every accessor then threw
+  `NullReferenceException`. All 24 version cascades gain a 1.3.0 level. The generated binding is 1.2.0's
+  with three textual substitutions, mirroring how the schema itself was derived.
+
+- **Non-specific digestion for nucleic acids (#1217)** — `Rnase.GetUnmodifiedOligos` threw for `Semi`,
+  `SingleN` and `SingleC`, so there was no way to express "I don't know where this was cut" and a
+  non-specific RNA search had nothing to work with. `singleN` and `singleC` RNase entries now select
+  them. A naming trap worth stating because it inverts the proteomics intuition: for a nucleic acid,
+  `CleavageSpecificity.None` means top-down whole molecule, not non-specific.
+
+- **An SDRF can be audited for what it says about quantification (#1244)** — `SdrfQuantAuditor` reports,
+  read-only and per document, whether a file is channel-level, kit-only or not isobaric; the channels
+  and implied plex with its provenance; eleven facts as present, absent or unparseable; label form per
+  cell; repeated (data file, label) pairs; ragged rows; and which data files exist on disk. Calibrated
+  against a 1,236-file corpus: 61 channel-level and 37 kit-only across all isobaric families, 51 and 31
+  counting the TMT family alone.
+
+- **SDRF validation and drift lint are public (#1207)** — Eight types, the exact transitive closure of
+  `SdrfValidator.Validate` and `SdrfDriftLint.Analyze`. An outside consumer — the C# bridge behind
+  pyMzLib, mzLibRust and mzLibR, and equally a native consumer such as MetaMorpheus writing an SDRF —
+  can now check its own output instead of reimplementing structural validation once per language.
+  `SdrfCell` stays internal deliberately: it appears in neither signature. No behaviour change.
+
+- **Deterministic, composition-preserving sequence permutation (#1250)** — Three additive members on
+  `DecoySequenceValidator`: `CleavageSitePositions`, `PermutationSpaceSize` and `UnrankPermutation`.
+  Where `ScrambleSequence` rearranges with a `Random`, these rearrange by index — the same integer
+  yields the same rearrangement every time. No existing member changes.
+
+- **Four optional parameters are annotated as nullable (#1191)** —
+  `IsoDecDeconvolutionParameters.mzWindow` and three `IndexingEngine.GetXic` parameters defaulted a
+  non-nullable reference type to `null`. Annotations only; erased at compile time, so behaviour, output
+  and IL are identical. `IFlashLfqIndexingEngine` is deliberately left alone — FlashLFQ has nullable
+  disabled with no per-file opt-in, so annotating there trades one warning for another.
+
+- **Dead code removed from `MzLibUtil`, and the rest pinned (#1234)** — The outcome of a Stryker.NET
+  mutation run over the best-tested project in mzLib (97.7% line, 95.7% branch). Two of the four
+  findings were not missing tests but redundant and unreachable code that no test could have
+  distinguished from correct code. Five tests cover the rest.
+
+- **The dynamic-connection tests actually read dynamically (#1176)** — Test-only. `TestDynamicMzml`,
+  `TestDynamicMzmlWithPeakFiltering` and the Thermo equivalent called `LoadAllStaticData()` and then
+  `InitiateDynamicConnection()` on one reader, so the short-circuit in
+  `GetOneBasedScanFromDynamicConnection` returned the same instance and every static-versus-dynamic
+  assertion compared a scan with itself. Roughly 225 dead assertions now do what they claim.
+
+- **Trimethyllysine's formal-charge arithmetic is pinned (#1270)** — Test-only, no production change.
+  Nothing asserted the adjustment that turns UniProt's `C3H7` quaternary ammonium into the neutral
+  `C3H6` increment Unimod calls Trimethyl, and getting it wrong is a silent one-proton error on every
+  trimethyl site. Asserts mass (42.046951) and formula together, so it cannot pass by coincidence.
+
+**Full Changelog**: https://github.com/smith-chem-wisc/mzLib/compare/1.0.588...1.0.589


### PR DESCRIPTION
Adds `release-notes/1.0.589.md` so the release page is written before the tag exists rather than after it.

Since #1206, the release job checks out the tag and publishes `release-notes/<version>.md` as the page body when that file is present, falling back to a list of pull request titles when it is not. The file therefore has to be on master **first**. 1.0.587 is what the fallback looks like: its page had to be hand-written afterwards, and the repository directory and the published page then had to be reconciled by hand.

## Sixteen PRs, not seventeen

A changeset taken by date reports 17. **#1247 is still open at 0/2 and is not on master**, so it is not in these notes. If it merges before the tag is pushed, the file needs one more item.

## What the notes lead with

Two groups of changes alter output that existing callers already have, so both are stated above the list rather than left to be discovered halfway down:

- **#1251** — the accession captured from a FASTA defline with more than two pipes. The old pattern was unanchored with a greedy `.+`, so it ran from the first pipe to the last and returned `16128008|ref|NP_414555.1` where the accession is `NP_414555.1`. Accession is the join key in every file we write, and `|` is also our own multi-value separator. Two-pipe UniProt and modern two-pipe RefSeq headers are unchanged, and the notes say so explicitly.
- **#1240, #1243, #1242** — the written quantification table's shape, the sample list that keys the peptide table, and when an unset strategy is rejected.

**#1192** is called out separately because its title hides it: the constructor took `quantifyAmbiguousPeptides` and never stored it, so an external caller passing `true` was silently getting `false` and now gets `true`. No in-repo caller passes it, so the behaviour change lives entirely on the other side of the package boundary.

Test-only work (#1176, #1270) is last and labelled as such.

## Version

`1.0.589`, patch, per convention. #1251 being output-affecting and #1242 adding `ICollapseStrategy.RequiresAggregation` to a shipped interface would both support a minor; the interface member is defaulted, so existing implementations still compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Bv5dBuCszEConVeVDG1nB
