### PR TITLE
Add #1247 to the 1.0.589 notes, which described sixteen PRs of seventeen

### DIFF
--- a/release-notes/1.0.589.md
+++ b/release-notes/1.0.589.md
@@ -1,5 +1,5 @@
 # mzLib 1.0.589 — accessions, and the quantification tables
-**Source:** `1.0.588..1.0.589` (16 PRs)
+**Source:** `1.0.588..1.0.589` (17 PRs)
 **Contributors:** @acesnik, @trishorts
 
 Two groups of changes alter output that existing callers already have. **FASTA accession parsing
@@ -102,6 +102,14 @@ robustness, or test-only.
   mutation run over the best-tested project in mzLib (97.7% line, 95.7% branch). Two of the four
   findings were not missing tests but redundant and unreachable code that no test could have
   distinguished from correct code. Five tests cover the rest.
+
+- **A Koina model that fails to run skips its test instead of failing it (#1247)** — Koina answers
+  HTTP 400 both for a request it will never accept and for a model it failed to execute, putting the
+  difference only in the response body. `HTTP.InferenceRequest` now throws `KoinaServiceException`
+  when the body names a server-side execution failure. It derives from `HttpRequestException`, so
+  existing `catch` blocks are unaffected; a 400 meaning "your request is wrong" still fails, which is
+  deliberately narrower than `ExternalServiceTestHelper.RunAsync`, which skips on any
+  `HttpRequestException`. Closes #1241.
 
 - **The dynamic-connection tests actually read dynamically (#1176)** — Test-only. `TestDynamicMzml`,
   `TestDynamicMzmlWithPeakFiltering` and the Thermo equivalent called `LoadAllStaticData()` and then


### PR DESCRIPTION
Follow-up to #1274, before the 1.0.589 tag is pushed.

#1247 merged at 22:53 UTC on 2026-09-01 — approved, and about half an hour before the notes in #1274 were written. Those notes said it was open at 0/2 and excluded it, and #1274's own body and merge commit repeated the claim. All three were wrong for one reason: the "is it merged" check ran against a `smith/master` fetched *before* #1247 landed and never re-fetched.

- **Source** line corrected from 16 PRs to **17**.
- **New item added** for #1247, placed above the test-only entries rather than among them.

It is not a test-only change, which is how the title reads. `HTTP.InferenceRequest` now throws `KoinaServiceException` where it previously threw `HttpRequestException` for a Koina server-side execution failure. The new type derives from the old one, so existing `catch` blocks are unaffected — but a caller matching on the exact type sees something new, and the narrowing is deliberate: a 400 meaning "your request is wrong" still fails, unlike `ExternalServiceTestHelper.RunAsync`, which skips on any `HttpRequestException`.

The tag has not been pushed, so nothing public was ever wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
