### PR TITLE
Add BioPolymerWithSetModsGroup for digestion-product-level occupancy reporting

### DIFF
--- a/mzLib/Omics/BioPolymerGroup/BioPolymerGroup.cs
+++ b/mzLib/Omics/BioPolymerGroup/BioPolymerGroup.cs
@@ -18,27 +18,24 @@ namespace Omics.BioPolymerGroup
     ///   <item><description>Quantification support for label-free (spectral counting) and isobaric (TMT/iTRAQ) methods</description></item>
     ///   <item><description>Modification occupancy statistics</description></item>
     ///   <item><description>FDR calculation support via cumulative target/decoy counting</description></item>
-    ///   <item><description>Tab-separated output formatting for results files</description></item>
     /// </list>
-    /// 
+    ///
+    /// This class holds data only; rendering it to a results file is the job of
+    /// <see cref="BioPolymerGroupTsvSchema"/> together with <see cref="TsvWriter"/>.
+    /// A row depends on the whole dataset — the quantification columns come from every group being
+    /// written — so no single group can render itself.
+    ///
+    /// Note for anyone migrating a caller: this type no longer overrides <c>ToString</c>, and there
+    /// is no compile-time guard against forgetting that. Writing a group directly
+    /// (<c>writer.WriteLine(group)</c>, <c>$"{group}"</c>) still compiles and silently emits the type
+    /// name instead of a data row. Marking an override <c>[Obsolete(error: true)]</c> does not help:
+    /// those calls bind to <see cref="object.ToString"/>, so the attribute is never consulted.
+    /// Build a schema and go through <see cref="TsvWriter"/> instead.
+    ///
     /// Fragment-level coverage is only calculated when PSMs implement <see cref="IHasSequenceCoverageFromFragments"/>.
     /// </summary>
     public class BioPolymerGroup : IBioPolymerGroup
     {
-        /// <summary>
-        /// Maximum length for string fields in output. Strings exceeding this length will be truncated.
-        /// 
-        /// Default is 32,000 characters, which is slightly below Excel's cell limit of 32,767 characters.
-        /// This ensures output files can be opened in Excel without data truncation or corruption.
-        /// Set to 0 or negative to disable truncation (useful for programmatic processing where 
-        /// Excel compatibility is not required).
-        /// </summary>
-        /// <remarks>
-        /// Excel specification: A cell can contain up to 32,767 characters.
-        /// See: https://support.microsoft.com/en-us/office/excel-specifications-and-limits
-        /// </remarks>
-        public static int MaxStringLength { get; set; } = 32000;
-
         /// <summary>
         /// Creates a new biopolymer group from the specified biopolymers and identified sequences.
         /// </summary>
@@ -117,7 +114,7 @@ namespace Omics.BioPolymerGroup
         /// List of samples that contribute quantification data for this group.
         /// Supports both <see cref="SpectraFileInfo"/> (label-free) and <see cref="IsobaricQuantSampleInfo"/> (TMT/iTRAQ).
         /// Setting this property invalidates <see cref="SampleGroupResults"/>, which will be 
-        /// re-populated on the next call to <see cref="GetTabSeparatedHeader"/> or <see cref="ToString"/>.
+        /// re-populated on the next call to <see cref="PopulateSampleGroupResults"/>.
         /// </summary>
         private List<ISampleInfo>? _samplesForQuantification;
         public List<ISampleInfo>? SamplesForQuantification
@@ -134,7 +131,7 @@ namespace Omics.BioPolymerGroup
         /// Dictionary mapping sample identifiers to measured intensity values for this group.
         /// Supports both <see cref="SpectraFileInfo"/> (label-free) and <see cref="IsobaricQuantSampleInfo"/> (TMT/iTRAQ) as keys.
         /// Setting this property invalidates <see cref="SampleGroupResults"/>, which will be
-        /// re-populated on the next call to <see cref="GetTabSeparatedHeader"/> or <see cref="ToString"/>.
+        /// re-populated on the next call to <see cref="PopulateSampleGroupResults"/>.
         /// </summary>
         private Dictionary<ISampleInfo, double>? _intensitiesBySample;
         public Dictionary<ISampleInfo, double>? IntensitiesBySample
@@ -227,7 +224,7 @@ namespace Omics.BioPolymerGroup
         /// or one (File × Channel) for isobaric data.
         /// Built by <see cref="PopulateSampleGroupResults"/> from <see cref="SamplesForQuantification"/>,
         /// <see cref="IntensitiesBySample"/>, and <see cref="AllPsmsBelowOnePercentFDR"/>.
-        /// Consumed by <see cref="ToString"/> and <see cref="GetTabSeparatedHeader"/> for per-group output columns.
+        /// Consumed by <see cref="BioPolymerGroupTsvSchema"/> to build the per-sample output columns.
         /// </summary>
         public List<SampleGroupResult>? SampleGroupResults { get; set; }
 
@@ -276,278 +273,17 @@ namespace Omics.BioPolymerGroup
                 return _coverageResult!;
             }
         }
+
+        /// <summary>
+        /// True once <see cref="CalculateSequenceCoverage"/> has run and its result is still valid.
+        /// Lets a caller read <see cref="CoverageResult"/> only when it is already available, since
+        /// reading it otherwise triggers the calculation.
+        /// </summary>
+        public bool IsSequenceCoverageCalculated => _coverageResult is not null;
+
         #endregion
 
         #region Methods
-
-        /// <summary>
-        /// Returns a tab-separated header line for output files, matching the format of <see cref="ToString"/>.
-        /// Header includes columns for biopolymer information, quantification, and statistical metrics.
-        /// </summary>
-        /// <remarks>
-        /// Virtual because <see cref="ToString"/> is, and the two must be overridden together or a
-        /// writer pairs one type's header with another type's rows. A derived group that hides this
-        /// with <c>new</c> while overriding <see cref="ToString"/> is dispatched inconsistently: a
-        /// call through <see cref="IBioPolymerGroup"/> or a base reference gets this header and the
-        /// derived row. Overriding both keeps the pair together however the call is typed.
-        /// </remarks>
-        /// <returns>Tab-separated header string suitable for TSV file output.</returns>
-        public virtual string GetTabSeparatedHeader()
-        {
-            var sb = new StringBuilder();
-            sb.Append("BioPolymer Accession" + '\t');
-            sb.Append("Gene" + '\t');
-            sb.Append("Organism" + '\t');
-            sb.Append("BioPolymer Full Name" + '\t');
-            sb.Append("BioPolymer Unmodified Mass" + '\t');
-            sb.Append("Number of BioPolymers in Group" + '\t');
-            sb.Append("Unique Sequences" + '\t');
-            sb.Append("Shared Sequences" + '\t');
-            sb.Append("Number of Sequences" + '\t');
-            sb.Append("Number of Unique Sequences" + '\t');
-            sb.Append("Sequence Coverage Fraction" + '\t');
-            sb.Append("Sequence Coverage" + '\t');
-            sb.Append("Sequence Coverage with Mods" + '\t');
-            sb.Append("Fragment Sequence Coverage" + '\t');
-
-            #region Quantification Header Building
-            if (SampleGroupResults is null) PopulateSampleGroupResults();
-
-            bool quantified = HasAssignedSampleIntensities;
-            foreach (var group in SampleGroupResults!)
-            {
-                sb.Append($"SpectralCount_{group.Label}\t");
-                if (quantified)
-                    sb.Append($"Intensity_{group.Label}\t");
-                sb.Append($"CountOccupancy_{group.Label}\t");
-                if (quantified)
-                    sb.Append($"IntensityOccupancy_{group.Label}\t");
-            }
-            #endregion
-
-            sb.Append("Number of PSMs" + '\t');
-            sb.Append("BioPolymer Decoy/Contaminant/Target" + '\t');
-            sb.Append("BioPolymer Cumulative Target" + '\t');
-            sb.Append("BioPolymer Cumulative Decoy" + '\t');
-            sb.Append("BioPolymer QValue" + '\t');
-            sb.Append("Best Sequence Score" + '\t');
-            sb.Append("Best Sequence Notch QValue");
-            return sb.ToString();
-        }
-
-        /// <summary>
-        /// Whether sample intensities have been assigned to this group -- a non-empty sample list
-        /// AND an assigned dictionary -- which is what decides whether the intensity columns exist.
-        /// Named for what it tests rather than for "was quantified": the setters are public and
-        /// non-coalescing, so an assignment is evidence that something populated this group, not
-        /// proof that an engine did.
-        /// Protected rather than private so a derived group can adopt the same predicate instead of
-        /// copying the expression.
-        /// </summary>
-        /// <remarks>
-        /// Deliberately NOT <see cref="SampleGroupResult.HasIntensityData"/>. That answers a per-group
-        /// question -- did this sample group get a value -- and using it to choose columns made rows
-        /// disagree with the header: a group whose samples were all unobserved emitted two columns per
-        /// sample group where its neighbour emitted four, so every value after the disagreement was
-        /// written under the wrong column name.
-        ///
-        /// Both fields are required. <see cref="IHasSampleIntensities.IntensitiesBySample"/> alone is
-        /// not enough: <see cref="ConstructSubsetBioPolymerGroup"/> assigns an empty-but-non-null
-        /// dictionary alongside an empty sample list when no sample matches the requested file, and
-        /// gating on the dictionary alone would then advertise intensity columns that
-        /// <see cref="PopulateSampleGroupResults"/> can never fill.
-        ///
-        /// SCOPE, because this does not make every table rectangular. It makes the four columns per
-        /// sample group agree across the groups of one quantified run. When no engine has run,
-        /// <see cref="PopulateSampleGroupResults"/> builds one result per file in each group's OWN
-        /// spectral matches, so two groups covering different files still emit different column
-        /// counts -- a pre-existing defect on the unquantified path that no per-group flag can fix,
-        /// because a single group does not know the run's full file list.
-        /// </remarks>
-        protected bool HasAssignedSampleIntensities =>
-            SamplesForQuantification is { Count: > 0 } && IntensitiesBySample is not null;
-
-        /// <summary>
-        /// Returns a tab-separated string representation of this biopolymer group,
-        /// including all identification, quantification, and statistical information.
-        /// Format matches the header returned by <see cref="GetTabSeparatedHeader"/>.
-        /// </summary>
-        /// <returns>Tab-separated string suitable for TSV file output.</returns>
-        public override string ToString()
-        {
-            var sb = new StringBuilder();
-
-            sb.Append(BioPolymerGroupName);
-            sb.Append("\t");
-
-            sb.Append(TruncateString(string.Join("|",
-                ListOfBioPolymersOrderedByAccession.Select(p => p.GeneNames.Select(x => x.Item2).FirstOrDefault()))));
-            sb.Append("\t");
-
-            sb.Append(TruncateString(string.Join("|",
-                ListOfBioPolymersOrderedByAccession.Select(p => p.Organism).Distinct())));
-            sb.Append("\t");
-
-            sb.Append(TruncateString(string.Join("|",
-                ListOfBioPolymersOrderedByAccession.Select(p => p.FullName).Distinct())));
-            sb.Append("\t");
-
-            var sequences = ListOfBioPolymersOrderedByAccession.Select(p => p.BaseSequence).Distinct();
-            var masses = sequences.Select(sequence =>
-                AllBioPolymersWithSetMods.FirstOrDefault(bpws => bpws.BaseSequence == sequence)?.MonoisotopicMass ?? double.NaN);
-
-            sb.Append(TruncateString(string.Join("|", masses)));
-            sb.Append("\t");
-
-            sb.Append("" + BioPolymers.Count);
-            sb.Append("\t");
-
-            // Compute unique and shared sequences directly
-            var (uniqueSeqOutput, sharedSeqOutput) = GetIdentifiedSequencesOutput();
-            sb.Append(TruncateString(uniqueSeqOutput));
-            sb.Append("\t");
-            sb.Append(TruncateString(sharedSeqOutput));
-            sb.Append("\t");
-
-            if (!DisplayModsOnPeptides)
-            {
-                sb.Append("" + AllBioPolymersWithSetMods.Select(p => p.BaseSequence).Distinct().Count());
-            }
-            else
-            {
-                sb.Append("" + AllBioPolymersWithSetMods.Select(p => p.FullSequence).Distinct().Count());
-            }
-            sb.Append("\t");
-
-            if (!DisplayModsOnPeptides)
-            {
-                sb.Append("" + UniqueBioPolymersWithSetMods.Select(p => p.BaseSequence).Distinct().Count());
-            }
-            else
-            {
-                sb.Append("" + UniqueBioPolymersWithSetMods.Select(p => p.FullSequence).Distinct().Count());
-            }
-            sb.Append("\t");
-
-            // Use cached coverage results (empty if not yet calculated)
-            var coverage = _coverageResult ?? new SequenceCoverageResult();
-
-            sb.Append(TruncateString(string.Join("|",
-                coverage.SequenceCoverageFraction.Select(p => string.Format("{0:0.#####}", p)))));
-            sb.Append("\t");
-
-            sb.Append(TruncateString(string.Join("|", coverage.SequenceCoverageDisplayList)));
-            sb.Append("\t");
-
-            sb.Append(TruncateString(string.Join("|", coverage.SequenceCoverageDisplayListWithMods)));
-            sb.Append("\t");
-
-            sb.Append(TruncateString(string.Join("|", coverage.FragmentSequenceCoverageDisplayList)));
-            sb.Append("\t");
-
-            #region Quantification Column Writing
-            // Output per-group quantification and occupancy
-            if (SampleGroupResults is null) PopulateSampleGroupResults();
-
-            bool isParentLevel = GroupType == BioPolymerGroupType.Parent;
-
-            List<string> orderedKeys = (isParentLevel
-                ? ListOfBioPolymersOrderedByAccession.Select(p => p.Accession)
-                : AllBioPolymersWithSetMods.Select(p => p.BaseSequence).Distinct().OrderBy(s => s))
-                .ToList();
-
-            bool quantifiedRow = HasAssignedSampleIntensities;
-            foreach (var group in SampleGroupResults!)
-            {
-                sb.Append(group.SpectralCount);
-                sb.Append("\t");
-
-                if (quantifiedRow)
-                {
-                    // Empty rather than 0, so the cell does not assert a measurement that was
-                    // not made. Note this does not make absent distinguishable from a measured zero
-                    // through the engine: QuantificationEngine.OverwriteSampleIntensities drops
-                    // zero-valued cells, so a genuine zero never reaches IntensitiesBySample either.
-                    if (group.HasIntensityData)
-                        sb.Append(group.Intensity);
-                    sb.Append("\t");
-                }
-
-                sb.Append(TruncateString(group.FormatOccupancy(orderedKeys, isParentLevel, intensityBased: false)));
-                sb.Append("\t");
-
-                if (quantifiedRow)
-                {
-                    if (group.HasIntensityData)
-                        sb.Append(TruncateString(group.FormatOccupancy(orderedKeys, isParentLevel, intensityBased: true)));
-                    sb.Append("\t");
-                }
-            }
-            #endregion
-
-            sb.Append("" + AllPsmsBelowOnePercentFDR.Count);
-            sb.Append("\t");
-
-            if (IsEntrapment && IsDecoy)
-            {
-                sb.Append("ED");
-            }
-            else if (IsEntrapment)
-            {
-                sb.Append("ET");
-            }
-            else if (IsDecoy)
-            {
-                sb.Append("D");
-            }
-            else if (IsContaminant)
-            {
-                sb.Append("C");
-            }
-            else
-            {
-                sb.Append("T");
-            }
-
-            sb.Append("\t");
-            sb.Append(CumulativeTarget);
-            sb.Append("\t");
-            sb.Append(CumulativeDecoy);
-            sb.Append("\t");
-            sb.Append(QValue);
-            sb.Append("\t");
-            sb.Append(BestBioPolymerWithSetModsScore);
-            sb.Append("\t");
-            sb.Append(BestBioPolymerWithSetModsQValue);
-
-            return sb.ToString();
-        }
-
-        /// <summary>
-        /// Computes pipe-delimited output strings for unique and shared sequences identified in this group.
-        /// Uses <see cref="DisplayModsOnPeptides"/> to determine whether to include modification annotations.
-        /// </summary>
-        /// <returns>Tuple of (uniqueSequences, sharedSequences) pipe-delimited output strings.</returns>
-        private (string UniqueSequences, string SharedSequences) GetIdentifiedSequencesOutput()
-        {
-            var sharedSequences = AllBioPolymersWithSetMods.Except(UniqueBioPolymersWithSetMods);
-
-            string uniqueOutput;
-            string sharedOutput;
-
-            if (!DisplayModsOnPeptides)
-            {
-                uniqueOutput = string.Join("|", UniqueBioPolymersWithSetMods.Select(p => p.BaseSequence).Distinct());
-                sharedOutput = string.Join("|", sharedSequences.Select(p => p.BaseSequence).Distinct());
-            }
-            else
-            {
-                uniqueOutput = string.Join("|", UniqueBioPolymersWithSetMods.Select(p => p.FullSequence).Distinct());
-                sharedOutput = string.Join("|", sharedSequences.Select(p => p.FullSequence).Distinct());
-            }
-
-            return (uniqueOutput, sharedOutput);
-        }
 
         /// <summary>
         /// Builds <see cref="SampleGroupResults"/> from the existing <see cref="SamplesForQuantification"/>,
@@ -559,136 +295,18 @@ namespace Omics.BioPolymerGroup
         /// </summary>
         /// <remarks>
         /// Must be called after <see cref="AllPsmsBelowOnePercentFDR"/> has been populated.
-        /// Invoked on the next call to <see cref="GetTabSeparatedHeader"/> or
-        /// <see cref="ToString"/> whenever <see cref="SampleGroupResults"/> is null — which
-        /// occurs after construction or after setting <see cref="SamplesForQuantification"/>,
-        /// <see cref="IntensitiesBySample"/>, or <see cref="AllPsmsBelowOnePercentFDR"/>.
+        /// Invoked by <see cref="BioPolymerGroupTsvSchema"/> whenever <see cref="SampleGroupResults"/>
+        /// is null — which occurs after construction or after setting
+        /// <see cref="SamplesForQuantification"/>, <see cref="IntensitiesBySample"/>,
+        /// or <see cref="AllPsmsBelowOnePercentFDR"/>.
         /// </remarks>
         public void PopulateSampleGroupResults()
         {
-            var results = new List<SampleGroupResult>();
-
-            var spectraFiles = SamplesForQuantification?.OfType<SpectraFileInfo>().ToList() ?? [];
-            var isobaricSamples = SamplesForQuantification?.OfType<IsobaricQuantSampleInfo>().ToList() ?? [];
-
-            if (spectraFiles.Count > 0)
-            {
-                bool unfractionated = spectraFiles.Select(p => p.Fraction).Distinct().Count() == 1;
-                bool conditionsUndefined = spectraFiles.All(p => string.IsNullOrEmpty(p.Condition));
-                bool silacExperimentalDesign = spectraFiles.Any(p => !File.Exists(p.FullFilePathWithExtension));
-
-                foreach (var conditionGroup in spectraFiles.GroupBy(p => p.Condition))
-                {
-                    foreach (var bioRepGroup in conditionGroup.GroupBy(p => p.BiologicalReplicate).OrderBy(p => p.Key))
-                    {
-                        var filesInGroup = bioRepGroup.ToList();
-                        string label = (conditionsUndefined && unfractionated) || silacExperimentalDesign
-                            ? filesInGroup.First().FilenameWithoutExtension
-                            : $"{conditionGroup.Key}_{bioRepGroup.Key + 1}";
-
-                        var filePaths = new HashSet<string>(filesInGroup.Select(f => f.FullFilePathWithExtension));
-                        var psmsInGroup = AllPsmsBelowOnePercentFDR
-                            .Where(p => filePaths.Contains(p.FullFilePath))
-                            .ToList();
-
-                        // Create SampleGroupResult with per-sample intensities if available.
-                        // Otherwise, create with empty intensities (HasIntensityData = false) for spectral counting.
-                        var intensitiesBySample = new Dictionary<string, double>();
-                        SampleGroupResult result;
-                        if (IntensitiesBySample != null)
-                        {
-                            foreach (var file in filesInGroup)
-                            {
-                                if (IntensitiesBySample.TryGetValue(file, out var fileIntensity))
-                                    intensitiesBySample[file.FilenameWithoutExtension] = fileIntensity;
-                            }
-
-                            result = new SampleGroupResult(conditionGroup.Key, bioRepGroup.Key)
-                            {
-                                Label = label,
-                                SpectralCount = psmsInGroup.Count,
-                                FilesInGroup = filesInGroup.ToDictionary(kvp => kvp.FilenameWithoutExtension, kvp => (ISampleInfo)kvp),
-                                IntensitiesBySample = intensitiesBySample
-                            };
-                        }
-                        else 
-                        {
-                            result = new SampleGroupResult(conditionGroup.Key, bioRepGroup.Key)
-                            {
-                                Label = label,
-                                SpectralCount = psmsInGroup.Count,
-                                FilesInGroup = filesInGroup.ToDictionary(kvp => kvp.FilenameWithoutExtension, kvp => (ISampleInfo)kvp)
-                                // IntensitiesBySample left empty → HasIntensityData = false
-                            };
-                        }
-
-                        PopulateOccupancy(result, psmsInGroup);
-                        results.Add(result);
-                    }
-                }
-            }
-            else if (isobaricSamples.Count > 0)
-            {
-                foreach (var fileGroup in isobaricSamples.GroupBy(p => p.FullFilePathWithExtension).OrderBy(g => g.Key))
-                {
-                    var psmsInFile = AllPsmsBelowOnePercentFDR
-                        .Where(p => p.FullFilePath.Equals(fileGroup.Key))
-                        .ToList();
-
-                    foreach (var sample in fileGroup.OrderBy(p => p.ChannelLabel))
-                    {
-                        string label = $"{Path.GetFileNameWithoutExtension(sample.FullFilePathWithExtension)}_{sample.ChannelLabel}";
-
-                        // Build per-channel intensity lookup for this result
-                        SampleGroupResult result;
-                        if (IntensitiesBySample != null && IntensitiesBySample.TryGetValue(sample, out var channelIntensity))
-                        {
-
-                            result = new SampleGroupResult(sample.Condition, sample.BiologicalReplicate)
-                            {
-                                Label = label,
-                                SpectralCount = psmsInFile.Count,
-                                FilesInGroup = new Dictionary<string, ISampleInfo> { { label, sample } },
-                                IntensitiesBySample = new Dictionary<string, double> { { label, channelIntensity } }
-                            };
-                        }
-                        else
-                        {
-                            result = new SampleGroupResult(sample.Condition, sample.BiologicalReplicate)
-                            {
-                                Label = label,
-                                SpectralCount = psmsInFile.Count,
-                                FilesInGroup = new Dictionary<string, ISampleInfo> { { label, sample } }
-                                // IntensitiesBySample left empty → HasIntensityData = false
-                            };
-                        }
-
-                        PopulateOccupancy(result, psmsInFile);
-                        results.Add(result);
-                    }
-                }
-            }
-            else
-            {
-                // No experimental design — group PSMs by source file for count-only results
-                foreach (var fileGroup in AllPsmsBelowOnePercentFDR.GroupBy(p => p.FullFilePath).OrderBy(g => g.Key))
-                {
-                    var psmsInFile = fileGroup.ToList();
-                    string label = Path.GetFileNameWithoutExtension(fileGroup.Key);
-
-                    var result = new SampleGroupResult(string.Empty, 0)
-                    {
-                        Label = label,
-                        SpectralCount = psmsInFile.Count
-                        // FilesInGroup and IntensitiesByFile left empty → HasIntensityData = false
-                    };
-
-                    PopulateOccupancy(result, psmsInFile);
-                    results.Add(result);
-                }
-            }
-
-            SampleGroupResults = results;
+            SampleGroupResults = SampleGroupBuilder.Build(
+                SamplesForQuantification,
+                IntensitiesBySample,
+                AllPsmsBelowOnePercentFDR,
+                PopulateOccupancy);
         }
 
         /// <summary>
@@ -846,7 +464,7 @@ namespace Omics.BioPolymerGroup
         /// Results are cached and invalidated by <see cref="MergeWith"/> or reassignment of
         /// <see cref="AllPsmsBelowOnePercentFDR"/>.
         /// </remarks>
-        public void CalculateSequenceCoverage()
+        public virtual void CalculateSequenceCoverage()
         {
             var result = new SequenceCoverageResult();
 
@@ -1063,23 +681,6 @@ namespace Omics.BioPolymerGroup
         #endregion
 
         #region Private Helpers
-
-        /// <summary>
-        /// Truncates a string to <see cref="MaxStringLength"/> if it exceeds that length.
-        /// Used to ensure output compatibility with Excel's cell character limits.
-        /// </summary>
-        /// <param name="input">The string to truncate.</param>
-        /// <returns>Truncated string, original string if within limits, or empty string if input is null/empty.</returns>
-        private static string TruncateString(string? input)
-        {
-            if (string.IsNullOrEmpty(input))
-                return string.Empty;
-
-            if (MaxStringLength <= 0 || input.Length <= MaxStringLength)
-                return input;
-
-            return input.Substring(0, MaxStringLength);
-        }
 
         /// <summary>
         /// Holds cached sequence coverage calculation results from <see cref="CalculateSequenceCoverage"/>.

--- a/mzLib/Omics/BioPolymerGroup/BioPolymerGroupTsvSchema.cs
+++ b/mzLib/Omics/BioPolymerGroup/BioPolymerGroupTsvSchema.cs
@@ -1,0 +1,266 @@
+namespace Omics.BioPolymerGroup;
+
+/// <summary>
+/// The tab-separated report schema for <see cref="BioPolymerGroup"/>: which columns appear, in
+/// what order, and how each value is formatted.
+///
+/// The schema is built from the whole dataset rather than from a single group, because the
+/// quantification columns depend on the experimental design shared by the file. Every group is
+/// then rendered against that one schema, so a group that was not quantified in some condition
+/// contributes empty fields instead of silently emitting a narrower row.
+/// </summary>
+public static class BioPolymerGroupTsvSchema
+{
+    /// <summary>
+    /// Maximum length for string fields in output. Strings exceeding this length are truncated.
+    ///
+    /// Default is 32,000 characters, slightly below Excel's cell limit of 32,767, so output files
+    /// open in Excel without truncation or corruption. Set to 0 or negative to disable truncation
+    /// (useful for programmatic processing where Excel compatibility does not matter).
+    /// </summary>
+    /// <remarks>
+    /// Excel specification: a cell can contain up to 32,767 characters.
+    /// See: https://support.microsoft.com/en-us/office/excel-specifications-and-limits
+    /// </remarks>
+    public static int MaxStringLength { get; set; } = 32000;
+
+    /// <summary>
+    /// Builds the schema for a set of groups that will be written to one file.
+    /// </summary>
+    /// <param name="groups">All groups destined for the file. Their sample group results are
+    /// populated if they have not been already, since the quantification columns derive from them.</param>
+    public static IReadOnlyList<TsvColumn<BioPolymerGroup>> For(IReadOnlyCollection<BioPolymerGroup> groups)
+    {
+        var columns = new List<TsvColumn<BioPolymerGroup>>
+        {
+            new("BioPolymer Accession", g => g.BioPolymerGroupName),
+            new("Gene", g => Truncate(string.Join("|",
+                g.ListOfBioPolymersOrderedByAccession.Select(p => p.GeneNames.Select(x => x.Item2).FirstOrDefault())))),
+            new("Organism", g => Truncate(string.Join("|",
+                g.ListOfBioPolymersOrderedByAccession.Select(p => p.Organism).Distinct()))),
+            new("BioPolymer Full Name", g => Truncate(string.Join("|",
+                g.ListOfBioPolymersOrderedByAccession.Select(p => p.FullName).Distinct()))),
+            new("BioPolymer Unmodified Mass", g => Truncate(string.Join("|", UnmodifiedMasses(g)))),
+            new("Number of BioPolymers in Group", g => g.BioPolymers.Count.ToString()),
+            new("Unique Sequences", g => Truncate(SequenceList(g, g.UniqueBioPolymersWithSetMods))),
+            new("Shared Sequences", g => Truncate(SequenceList(g,
+                g.AllBioPolymersWithSetMods.Except(g.UniqueBioPolymersWithSetMods)))),
+            new("Number of Sequences", g => CountDistinct(g, g.AllBioPolymersWithSetMods).ToString()),
+            new("Number of Unique Sequences", g => CountDistinct(g, g.UniqueBioPolymersWithSetMods).ToString()),
+            new("Sequence Coverage Fraction", g => Truncate(string.Join("|",
+                Coverage(g).SequenceCoverageFraction.Select(p => string.Format("{0:0.#####}", p))))),
+            new("Sequence Coverage", g => Truncate(string.Join("|", Coverage(g).SequenceCoverageDisplayList))),
+            new("Sequence Coverage with Mods", g => Truncate(string.Join("|", Coverage(g).SequenceCoverageDisplayListWithMods))),
+            new("Fragment Sequence Coverage", g => Truncate(string.Join("|", Coverage(g).FragmentSequenceCoverageDisplayList)))
+        };
+
+        columns.AddRange(QuantificationColumns(groups));
+
+        columns.AddRange(new TsvColumn<BioPolymerGroup>[]
+        {
+            new("Number of PSMs", g => g.AllPsmsBelowOnePercentFDR.Count.ToString()),
+            new("BioPolymer Decoy/Contaminant/Target", TargetDecoyLabel),
+            new("BioPolymer Cumulative Target", g => g.CumulativeTarget.ToString()),
+            new("BioPolymer Cumulative Decoy", g => g.CumulativeDecoy.ToString()),
+            new("BioPolymer QValue", g => g.QValue.ToString()),
+            new("Best Sequence Score", g => g.BestBioPolymerWithSetModsScore.ToString()),
+            new("Best Sequence Notch QValue", g => g.BestBioPolymerWithSetModsQValue.ToString())
+        });
+
+        return columns;
+    }
+
+    /// <summary>
+    /// One block of columns per sample group in the dataset: spectral count and count-based
+    /// occupancy always, plus intensity and intensity-based occupancy for any sample group that
+    /// carries intensity data in at least one of the groups being written.
+    /// </summary>
+    private static IEnumerable<TsvColumn<BioPolymerGroup>> QuantificationColumns(
+        IReadOnlyCollection<BioPolymerGroup> groups)
+    {
+        foreach (var group in groups)
+        {
+            if (group.SampleGroupResults is null)
+                group.PopulateSampleGroupResults();
+        }
+
+        // Union of the dataset's sample groups, in first-seen order. 
+        //
+        // Sample groups are matched across records by Identity — the files they cover — never by
+        // Label and never by position. Labels are not unique (SampleGroupBuilder names a sample
+        // group after its first file whenever conditions are undefined or a file is missing from
+        // disk, so same-named files in different directories collide), and position is not stable
+        // across records because a record only has sample groups for the files it appears in.
+        var identities = new List<string>();
+        var seen = new HashSet<string>();
+        var labelByIdentity = new Dictionary<string, (string Label, string? LabelSourcePath)>();
+
+        foreach (var group in groups)
+        {
+            foreach (var result in group.SampleGroupResults!)
+            {
+                if (seen.Add(result.Identity))
+                {
+                    identities.Add(result.Identity);
+                    labelByIdentity[result.Identity] = (result.Label, result.LabelSourcePath);
+                }
+
+            }
+        }
+
+        // Whether the intensity columns exist is a property of the run, not of a sample group:
+        // an engine either populated these groups or it did not. Deliberately not
+        // SampleGroupResult.HasIntensityData, which answers "did this sample group get a value" --
+        // using that to choose columns made a group whose samples were all unobserved describe a
+        // narrower table than its neighbour. Same predicate the group applied before rendering moved
+        // out; both members are public, so the schema computes it rather than needing access.
+        bool quantified = groups.Any(g => g.SamplesForQuantification is { Count: > 0 }
+                                       && g.IntensitiesBySample is not null);
+
+        var displayLabels = SampleGroupLabels.Disambiguate(identities, labelByIdentity);
+
+        var index = new SampleGroupIndex();
+        var columns = new List<TsvColumn<BioPolymerGroup>>();
+
+        foreach (var identity in identities)
+        {
+            string thisIdentity = identity;
+            string display = displayLabels[thisIdentity];
+
+            columns.Add(new TsvColumn<BioPolymerGroup>($"SpectralCount_{display}",
+                g => index.ResultFor(g, thisIdentity)?.SpectralCount.ToString() ?? string.Empty));
+
+            if (quantified)
+                columns.Add(new TsvColumn<BioPolymerGroup>($"Intensity_{display}",
+                    g => index.ResultFor(g, thisIdentity) is { HasIntensityData: true } r ? r.Intensity.ToString() : string.Empty));
+
+            columns.Add(new TsvColumn<BioPolymerGroup>($"CountOccupancy_{display}",
+                g => Truncate(index.ResultFor(g, thisIdentity)?.FormatOccupancy(OccupancyKeys(g), IsParentLevel(g), intensityBased: false))));
+
+            if (quantified)
+                columns.Add(new TsvColumn<BioPolymerGroup>($"IntensityOccupancy_{display}",
+                    g => Truncate(index.ResultFor(g, thisIdentity)?.FormatOccupancy(OccupancyKeys(g), IsParentLevel(g), intensityBased: true))));
+        }
+
+        return columns;
+    }
+
+    /// <summary>
+    /// Finds a group's sample group by identity, in place of scanning its list once per cell.
+    ///
+    /// Decoupling a column from its position in the group's list is what fixes the ragged-row
+    /// defect, but it also means a column can no longer read its value off the list in order. Left
+    /// as a scan, each of the ~4 columns per sample group re-walks the whole list, so writing costs
+    /// O(samples² × records) where rendering a row used to cost O(samples).
+    ///
+    /// A row is rendered one group at a time across every column, so remembering the most recent
+    /// group's lookup restores O(samples × records).
+    ///
+    /// Keyed on the sample-group list instance rather than on the group: every invalidation path
+    /// nulls SampleGroupResults, and repopulating assigns a fresh list, so a group whose
+    /// quantification changed mid-write rebuilds its index instead of serving a stale one.
+    /// Not thread-safe, in common with the lazy population it wraps.
+    /// </summary>
+    private sealed class SampleGroupIndex
+    {
+        private List<SampleGroupResult>? _source;
+        private Dictionary<string, SampleGroupResult> _byIdentity = [];
+
+        public SampleGroupResult? ResultFor(BioPolymerGroup group, string identity)
+        {
+            if (group.SampleGroupResults is null)
+                group.PopulateSampleGroupResults();
+
+            var results = group.SampleGroupResults!;
+
+            if (!ReferenceEquals(results, _source))
+            {
+                _source = results;
+                _byIdentity = new Dictionary<string, SampleGroupResult>(results.Count);
+
+                // First wins, matching the FirstOrDefault this replaces — identities are unique
+                // within a group by construction, but TryAdd keeps a hand-built list from throwing.
+                foreach (var result in results)
+                    _byIdentity.TryAdd(result.Identity, result);
+            }
+
+            return _byIdentity.GetValueOrDefault(identity);
+        }
+    }
+
+    private static bool IsParentLevel(BioPolymerGroup group)
+        => group.GroupType == BioPolymerGroupType.Parent;
+
+    /// <summary>
+    /// Entity keys the occupancy string is ordered by: accessions at parent level, base sequences
+    /// at digestion-product level.
+    /// </summary>
+    private static List<string> OccupancyKeys(BioPolymerGroup group)
+        => (IsParentLevel(group)
+                ? group.ListOfBioPolymersOrderedByAccession.Select(p => p.Accession)
+                : group.AllBioPolymersWithSetMods.Select(p => p.BaseSequence).Distinct().OrderBy(s => s))
+            .ToList();
+
+    /// <summary>
+    /// Coverage already computed for this group, or an empty result. Deliberately does not trigger
+    /// calculation — writing a report should not silently do the expensive work.
+    /// </summary>
+    /// <remarks>
+    /// The empty result is allocated per call rather than shared: its list properties are get-only
+    /// but the lists themselves are mutable, so a single shared instance would be one stray Add away
+    /// from leaking coverage between unrelated groups.
+    /// </remarks>
+    private static BioPolymerGroup.SequenceCoverageResult Coverage(BioPolymerGroup group)
+        => group.IsSequenceCoverageCalculated ? group.CoverageResult : new BioPolymerGroup.SequenceCoverageResult();
+
+    /// <summary>
+    /// Unmodified mass per distinct biopolymer sequence, in accession order.
+    /// Yields NaN for a sequence with no matching identified form.
+    /// </summary>
+    private static IEnumerable<double> UnmodifiedMasses(BioPolymerGroup group)
+        => group.ListOfBioPolymersOrderedByAccession
+            .Select(p => p.BaseSequence)
+            .Distinct()
+            .Select(sequence => group.AllBioPolymersWithSetMods
+                .FirstOrDefault(bpws => bpws.BaseSequence == sequence)?.MonoisotopicMass ?? double.NaN);
+
+    private static string SequenceList(BioPolymerGroup group, IEnumerable<IBioPolymerWithSetMods> sequences)
+        => string.Join("|", Keys(group, sequences).Distinct());
+
+    private static int CountDistinct(BioPolymerGroup group, IEnumerable<IBioPolymerWithSetMods> sequences)
+        => Keys(group, sequences).Distinct().Count();
+
+    /// <summary>
+    /// Projects sequences onto full or base sequence per <see cref="BioPolymerGroup.DisplayModsOnPeptides"/>.
+    /// </summary>
+    private static IEnumerable<string> Keys(BioPolymerGroup group, IEnumerable<IBioPolymerWithSetMods> sequences)
+        => group.DisplayModsOnPeptides
+            ? sequences.Select(p => p.FullSequence)
+            : sequences.Select(p => p.BaseSequence);
+
+    /// <summary>
+    /// Single-letter classification: entrapment decoy, entrapment target, decoy, contaminant, or target.
+    /// </summary>
+    private static string TargetDecoyLabel(BioPolymerGroup group)
+    {
+        if (group.IsEntrapment && group.IsDecoy) return "ED";
+        if (group.IsEntrapment) return "ET";
+        if (group.IsDecoy) return "D";
+        if (group.IsContaminant) return "C";
+        return "T";
+    }
+
+    /// <summary>
+    /// Truncates to <see cref="MaxStringLength"/> so output stays within Excel's cell limit.
+    /// </summary>
+    private static string Truncate(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return string.Empty;
+
+        if (MaxStringLength <= 0 || input.Length <= MaxStringLength)
+            return input;
+
+        return input.Substring(0, MaxStringLength);
+    }
+}

--- a/mzLib/Omics/BioPolymerGroup/BioPolymerGroupTsvSchema.cs
+++ b/mzLib/Omics/BioPolymerGroup/BioPolymerGroupTsvSchema.cs
@@ -12,19 +12,6 @@ namespace Omics.BioPolymerGroup;
 public static class BioPolymerGroupTsvSchema
 {
     /// <summary>
-    /// Maximum length for string fields in output. Strings exceeding this length are truncated.
-    ///
-    /// Default is 32,000 characters, slightly below Excel's cell limit of 32,767, so output files
-    /// open in Excel without truncation or corruption. Set to 0 or negative to disable truncation
-    /// (useful for programmatic processing where Excel compatibility does not matter).
-    /// </summary>
-    /// <remarks>
-    /// Excel specification: a cell can contain up to 32,767 characters.
-    /// See: https://support.microsoft.com/en-us/office/excel-specifications-and-limits
-    /// </remarks>
-    public static int MaxStringLength { get; set; } = 32000;
-
-    /// <summary>
     /// Builds the schema for a set of groups that will be written to one file.
     /// </summary>
     /// <param name="groups">All groups destined for the file. Their sample group results are
@@ -71,121 +58,23 @@ public static class BioPolymerGroupTsvSchema
     }
 
     /// <summary>
-    /// One block of columns per sample group in the dataset: spectral count and count-based
-    /// occupancy always, plus intensity and intensity-based occupancy for any sample group that
-    /// carries intensity data in at least one of the groups being written.
+    /// One block of columns per sample group in the dataset, with occupancy rendered in this
+    /// group's coordinate space.
     /// </summary>
     private static IEnumerable<TsvColumn<BioPolymerGroup>> QuantificationColumns(
         IReadOnlyCollection<BioPolymerGroup> groups)
+        => SampleGroupColumnBuilder.Build(
+            groups,
+            SampleGroupsOf,
+            (g, result) => Truncate(result.FormatOccupancy(OccupancyKeys(g), IsParentLevel(g), intensityBased: false)),
+            (g, result) => Truncate(result.FormatOccupancy(OccupancyKeys(g), IsParentLevel(g), intensityBased: true)));
+
+    private static IReadOnlyList<SampleGroupResult> SampleGroupsOf(BioPolymerGroup group)
     {
-        foreach (var group in groups)
-        {
-            if (group.SampleGroupResults is null)
-                group.PopulateSampleGroupResults();
-        }
+        if (group.SampleGroupResults is null)
+            group.PopulateSampleGroupResults();
 
-        // Union of the dataset's sample groups, in first-seen order. 
-        //
-        // Sample groups are matched across records by Identity — the files they cover — never by
-        // Label and never by position. Labels are not unique (SampleGroupBuilder names a sample
-        // group after its first file whenever conditions are undefined or a file is missing from
-        // disk, so same-named files in different directories collide), and position is not stable
-        // across records because a record only has sample groups for the files it appears in.
-        var identities = new List<string>();
-        var seen = new HashSet<string>();
-        var labelByIdentity = new Dictionary<string, (string Label, string? LabelSourcePath)>();
-
-        foreach (var group in groups)
-        {
-            foreach (var result in group.SampleGroupResults!)
-            {
-                if (seen.Add(result.Identity))
-                {
-                    identities.Add(result.Identity);
-                    labelByIdentity[result.Identity] = (result.Label, result.LabelSourcePath);
-                }
-
-            }
-        }
-
-        // Whether the intensity columns exist is a property of the run, not of a sample group:
-        // an engine either populated these groups or it did not. Deliberately not
-        // SampleGroupResult.HasIntensityData, which answers "did this sample group get a value" --
-        // using that to choose columns made a group whose samples were all unobserved describe a
-        // narrower table than its neighbour. Same predicate the group applied before rendering moved
-        // out; both members are public, so the schema computes it rather than needing access.
-        bool quantified = groups.Any(g => g.SamplesForQuantification is { Count: > 0 }
-                                       && g.IntensitiesBySample is not null);
-
-        var displayLabels = SampleGroupLabels.Disambiguate(identities, labelByIdentity);
-
-        var index = new SampleGroupIndex();
-        var columns = new List<TsvColumn<BioPolymerGroup>>();
-
-        foreach (var identity in identities)
-        {
-            string thisIdentity = identity;
-            string display = displayLabels[thisIdentity];
-
-            columns.Add(new TsvColumn<BioPolymerGroup>($"SpectralCount_{display}",
-                g => index.ResultFor(g, thisIdentity)?.SpectralCount.ToString() ?? string.Empty));
-
-            if (quantified)
-                columns.Add(new TsvColumn<BioPolymerGroup>($"Intensity_{display}",
-                    g => index.ResultFor(g, thisIdentity) is { HasIntensityData: true } r ? r.Intensity.ToString() : string.Empty));
-
-            columns.Add(new TsvColumn<BioPolymerGroup>($"CountOccupancy_{display}",
-                g => Truncate(index.ResultFor(g, thisIdentity)?.FormatOccupancy(OccupancyKeys(g), IsParentLevel(g), intensityBased: false))));
-
-            if (quantified)
-                columns.Add(new TsvColumn<BioPolymerGroup>($"IntensityOccupancy_{display}",
-                    g => Truncate(index.ResultFor(g, thisIdentity)?.FormatOccupancy(OccupancyKeys(g), IsParentLevel(g), intensityBased: true))));
-        }
-
-        return columns;
-    }
-
-    /// <summary>
-    /// Finds a group's sample group by identity, in place of scanning its list once per cell.
-    ///
-    /// Decoupling a column from its position in the group's list is what fixes the ragged-row
-    /// defect, but it also means a column can no longer read its value off the list in order. Left
-    /// as a scan, each of the ~4 columns per sample group re-walks the whole list, so writing costs
-    /// O(samples² × records) where rendering a row used to cost O(samples).
-    ///
-    /// A row is rendered one group at a time across every column, so remembering the most recent
-    /// group's lookup restores O(samples × records).
-    ///
-    /// Keyed on the sample-group list instance rather than on the group: every invalidation path
-    /// nulls SampleGroupResults, and repopulating assigns a fresh list, so a group whose
-    /// quantification changed mid-write rebuilds its index instead of serving a stale one.
-    /// Not thread-safe, in common with the lazy population it wraps.
-    /// </summary>
-    private sealed class SampleGroupIndex
-    {
-        private List<SampleGroupResult>? _source;
-        private Dictionary<string, SampleGroupResult> _byIdentity = [];
-
-        public SampleGroupResult? ResultFor(BioPolymerGroup group, string identity)
-        {
-            if (group.SampleGroupResults is null)
-                group.PopulateSampleGroupResults();
-
-            var results = group.SampleGroupResults!;
-
-            if (!ReferenceEquals(results, _source))
-            {
-                _source = results;
-                _byIdentity = new Dictionary<string, SampleGroupResult>(results.Count);
-
-                // First wins, matching the FirstOrDefault this replaces — identities are unique
-                // within a group by construction, but TryAdd keeps a hand-built list from throwing.
-                foreach (var result in results)
-                    _byIdentity.TryAdd(result.Identity, result);
-            }
-
-            return _byIdentity.GetValueOrDefault(identity);
-        }
+        return group.SampleGroupResults!;
     }
 
     private static bool IsParentLevel(BioPolymerGroup group)
@@ -250,17 +139,5 @@ public static class BioPolymerGroupTsvSchema
         return "T";
     }
 
-    /// <summary>
-    /// Truncates to <see cref="MaxStringLength"/> so output stays within Excel's cell limit.
-    /// </summary>
-    private static string Truncate(string? input)
-    {
-        if (string.IsNullOrEmpty(input))
-            return string.Empty;
-
-        if (MaxStringLength <= 0 || input.Length <= MaxStringLength)
-            return input;
-
-        return input.Substring(0, MaxStringLength);
-    }
+    private static string Truncate(string? input) => TsvWriter.Truncate(input);
 }

--- a/mzLib/Omics/BioPolymerGroup/BioPolymerWithSetModsGroup.cs
+++ b/mzLib/Omics/BioPolymerGroup/BioPolymerWithSetModsGroup.cs
@@ -1,0 +1,293 @@
+using MassSpectrometry;
+using Omics;
+using Omics.SpectralMatch;
+
+namespace Omics.BioPolymerGroup;
+
+/// <summary>
+/// A group of identified digestion products (peptides or oligonucleotides) sharing one base
+/// sequence. The modified forms of that sequence are its members, so modification occupancy is
+/// reported against peptide-local positions — position 1 means the first residue of this peptide,
+/// not of the protein it came from.
+///
+/// This is the digestion-product counterpart to <see cref="BioPolymerGroup"/>, not a subclass of
+/// it: the two share quantification machinery but almost nothing else. A peptide group has no
+/// sequence coverage, no gene or organism, and its identity is a sequence rather than a set of
+/// parent accessions.
+///
+/// Like <see cref="BioPolymerGroup"/>, this class holds data only; rendering it to a results file
+/// is the job of <see cref="BioPolymerWithSetModsGroupTsvSchema"/> together with
+/// <see cref="TsvWriter"/>.
+/// </summary>
+public class BioPolymerWithSetModsGroup : IEquatable<BioPolymerWithSetModsGroup>, IHasSampleIntensities
+{
+    /// <summary>
+    /// Creates a group for one base sequence.
+    /// </summary>
+    /// <param name="baseSequence">The unmodified sequence that identifies this group.</param>
+    /// <param name="peptidoforms">The modified forms of that sequence observed in the search.
+    /// Every form must carry <paramref name="baseSequence"/>.</param>
+    /// <exception cref="ArgumentException">A form's base sequence disagrees with the group's.</exception>
+    public BioPolymerWithSetModsGroup(string baseSequence, IEnumerable<IBioPolymerWithSetMods> peptidoforms)
+    {
+        if (string.IsNullOrEmpty(baseSequence))
+            throw new ArgumentException("A digestion product group needs a base sequence.", nameof(baseSequence));
+
+        ArgumentNullException.ThrowIfNull(peptidoforms);
+
+        BaseSequence = baseSequence;
+
+        var supplied = peptidoforms.ToList();
+
+        var mismatched = supplied.FirstOrDefault(p => p.BaseSequence != baseSequence);
+        if (mismatched is not null)
+        {
+            throw new ArgumentException(
+                $"All peptidoforms in a group must share its base sequence. Group is '{baseSequence}' " +
+                $"but form '{mismatched.FullSequence}' has base sequence '{mismatched.BaseSequence}'.",
+                nameof(peptidoforms));
+        }
+
+        // Deduplicate explicitly rather than relying on the element type's Equals, which several
+        // IBioPolymerWithSetMods implementations define on base sequence alone — that would
+        // collapse the very forms this group exists to hold.
+        //
+        // The key is (form, parent, location). Parent, because a sequence shared across biopolymers
+        // has one form per parent with the same FullSequence. Location, because a sequence can occur
+        // more than once within a single parent — repeat domains in histones, collagens and mucins
+        // are ordinary — and those occurrences are distinct observations that the residue-range
+        // columns must report separately.
+        Peptidoforms = [.. supplied
+            .GroupBy(p => (p.FullSequence, p.Parent?.Accession, p.OneBasedStartResidue, p.OneBasedEndResidue))
+            .Select(g => g.First())
+            .OrderBy(p => p.FullSequence, StringComparer.Ordinal)
+            .ThenBy(p => p.Parent?.Accession, StringComparer.Ordinal)
+            .ThenBy(p => p.OneBasedStartResidue)];
+
+        ParentBioPolymers = [.. Peptidoforms.Select(p => p.Parent).Where(p => p is not null)];
+        ListOfParentsOrderedByAccession = [.. ParentBioPolymers.OrderBy(p => p.Accession)];
+
+        foreach (var parent in ParentBioPolymers)
+        {
+            IsDecoy |= parent.IsDecoy;
+            IsContaminant |= parent.IsContaminant;
+            IsEntrapment |= parent.IsEntrapment;
+        }
+
+        AllPsmsBelowOnePercentFDR = [];
+    }
+
+    /// <summary>
+    /// Buckets PSMs into one group per base sequence, taking each group's forms from the PSMs
+    /// assigned to it. PSMs whose sequence was never resolved carry an empty base sequence and are
+    /// skipped, since they cannot be attributed to any one sequence.
+    /// </summary>
+    public static List<BioPolymerWithSetModsGroup> CreateGroups(IEnumerable<ISpectralMatch> psms)
+    {
+        var groups = new List<BioPolymerWithSetModsGroup>();
+
+        foreach (var bySequence in psms
+                     .Where(p => !string.IsNullOrEmpty(p.BaseSequence))
+                     .GroupBy(p => p.BaseSequence))
+        {
+            var psmsForSequence = bySequence.ToList();
+
+            var forms = psmsForSequence
+                .SelectMany(p => p.GetIdentifiedBioPolymersWithSetMods())
+                .Where(f => f.BaseSequence == bySequence.Key);
+
+            groups.Add(new BioPolymerWithSetModsGroup(bySequence.Key, forms)
+            {
+                AllPsmsBelowOnePercentFDR = [.. psmsForSequence]
+            });
+        }
+
+        return groups;
+    }
+
+    #region Identity
+
+    /// <summary>
+    /// The unmodified sequence shared by every member. Identity key for equality and output.
+    /// </summary>
+    public string BaseSequence { get; }
+
+    /// <summary>
+    /// The modified forms of <see cref="BaseSequence"/> observed for this group, one entry per
+    /// distinct (full sequence, parent) pair and ordered for stable output. A sequence found in
+    /// several biopolymers therefore appears once per parent; the report deduplicates to distinct
+    /// full sequences where that is what a column means.
+    /// </summary>
+    public IReadOnlyList<IBioPolymerWithSetMods> Peptidoforms { get; }
+
+    /// <summary>
+    /// Biopolymers this sequence was found in. Reported for provenance but not part of identity,
+    /// so one group covers a sequence shared across several parents.
+    /// </summary>
+    public HashSet<IBioPolymer> ParentBioPolymers { get; }
+
+    /// <summary>
+    /// <see cref="ParentBioPolymers"/> in accession order, for deterministic output.
+    /// </summary>
+    public List<IBioPolymer> ListOfParentsOrderedByAccession { get; }
+
+    /// <summary>True if any parent is a decoy, used for FDR estimation.</summary>
+    public bool IsDecoy { get; }
+
+    /// <summary>True if any parent is marked as a contaminant.</summary>
+    public bool IsContaminant { get; }
+
+    /// <summary>True if any parent is marked as an entrapment sequence.</summary>
+    public bool IsEntrapment { get; }
+
+    #endregion
+
+    #region Identification statistics
+
+    /// <summary>
+    /// PSMs for this sequence that pass the 1% FDR threshold. Setting this invalidates
+    /// <see cref="SampleGroupResults"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">A PSM's base sequence disagrees with the group's.</exception>
+    private HashSet<ISpectralMatch> _allPsmsBelowOnePercentFDR = null!;
+    public HashSet<ISpectralMatch> AllPsmsBelowOnePercentFDR
+    {
+        get => _allPsmsBelowOnePercentFDR;
+        set
+        {
+            // Assigning null would defer the failure to whichever later read dereferences it, so
+            // reject it here where the caller's mistake is still visible.
+            ArgumentNullException.ThrowIfNull(value);
+
+            // Occupancy is computed in this sequence's coordinate space, so a PSM for a different
+            // sequence would silently land on the wrong positions. Reject it at the boundary
+            // instead. A PSM whose sequence was never resolved carries an empty base sequence
+            // rather than null; those are allowed here and skipped when occupancy is computed.
+            var mismatched = value.FirstOrDefault(
+                p => !string.IsNullOrEmpty(p.BaseSequence) && p.BaseSequence != BaseSequence);
+            if (mismatched is not null)
+            {
+                throw new ArgumentException(
+                    $"All PSMs in a group must share its base sequence. Group is '{BaseSequence}' " +
+                    $"but a PSM from '{mismatched.FullFilePath}' has base sequence '{mismatched.BaseSequence}'.",
+                    nameof(value));
+            }
+
+            // Copy rather than alias. Validating the caller's set and then holding a reference to it
+            // leaves the guard bypassable: the caller keeps its own handle and can add a foreign PSM
+            // afterwards, which then gets filed under this group's base sequence and reports a
+            // modification at a residue that sequence does not have.
+            _allPsmsBelowOnePercentFDR = [.. value];
+            SampleGroupResults = null;
+        }
+    }
+
+    /// <summary>The q-value for this group. Lower is more confident (0.01 = 1% FDR).</summary>
+    public double QValue { get; set; }
+
+    /// <summary>Best (highest) score among the PSMs in this group.</summary>
+    public double BestPsmScore { get; set; }
+
+    /// <summary>Best (lowest) q-value among the PSMs in this group.</summary>
+    public double BestPsmQValue { get; set; }
+
+    /// <summary>Cumulative target count at this group's rank, for FDR calculation.</summary>
+    public int CumulativeTarget { get; set; }
+
+    /// <summary>Cumulative decoy count at this group's rank, for FDR calculation.</summary>
+    public int CumulativeDecoy { get; set; }
+
+    /// <summary>
+    /// Sets <see cref="BestPsmScore"/> to the highest score among the group's PSMs, or 0 when there
+    /// are none.
+    /// </summary>
+    public void Score()
+    {
+        BestPsmScore = AllPsmsBelowOnePercentFDR.Count == 0
+            ? 0
+            : AllPsmsBelowOnePercentFDR.Max(p => p.Score);
+    }
+
+    #endregion
+
+    #region Quantification
+
+    /// <summary>
+    /// Samples contributing quantification. Setting this invalidates <see cref="SampleGroupResults"/>.
+    /// </summary>
+    private List<ISampleInfo>? _samplesForQuantification;
+    public List<ISampleInfo>? SamplesForQuantification
+    {
+        get => _samplesForQuantification;
+        set
+        {
+            _samplesForQuantification = value;
+            SampleGroupResults = null;
+        }
+    }
+
+    /// <summary>
+    /// Measured intensities keyed by sample. Setting this invalidates <see cref="SampleGroupResults"/>.
+    /// </summary>
+    private Dictionary<ISampleInfo, double>? _intensitiesBySample;
+    public Dictionary<ISampleInfo, double>? IntensitiesBySample
+    {
+        get => _intensitiesBySample;
+        set
+        {
+            _intensitiesBySample = value;
+            SampleGroupResults = null;
+        }
+    }
+
+    /// <summary>
+    /// Per-sample-group quantification and occupancy, built by <see cref="PopulateSampleGroupResults"/>.
+    /// </summary>
+    public List<SampleGroupResult>? SampleGroupResults { get; set; }
+
+    /// <summary>
+    /// Buckets this group's PSMs and intensities by experimental design and computes modification
+    /// occupancy for each bucket in peptide-local coordinates.
+    /// </summary>
+    public void PopulateSampleGroupResults()
+    {
+        SampleGroupResults = SampleGroupBuilder.Build(
+            SamplesForQuantification,
+            IntensitiesBySample,
+            AllPsmsBelowOnePercentFDR,
+            PopulateOccupancy);
+    }
+
+    /// <summary>
+    /// Attaches occupancy for one sample group, keyed by this group's base sequence. Positions use
+    /// the AllModsOneIsNterminus convention relative to the peptide, not the parent biopolymer.
+    /// </summary>
+    private void PopulateOccupancy(SampleGroupResult result, List<ISpectralMatch> psms)
+    {
+        if (psms.Count == 0)
+            return;
+
+        var occupancy = ModificationOccupancyCalculator.CalculateDigestionProductLevelOccupancy(psms);
+
+        if (occupancy.Count > 0)
+            result.DigestionProductOccupancy[BaseSequence] = occupancy;
+    }
+
+    #endregion
+
+    #region Equality
+
+    /// <summary>Two groups are equal when they describe the same base sequence.</summary>
+    public bool Equals(BioPolymerWithSetModsGroup? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return BaseSequence == other.BaseSequence;
+    }
+
+    public override bool Equals(object? obj) => obj is BioPolymerWithSetModsGroup other && Equals(other);
+
+    public override int GetHashCode() => BaseSequence.GetHashCode();
+
+    #endregion
+}

--- a/mzLib/Omics/BioPolymerGroup/BioPolymerWithSetModsGroupTsvSchema.cs
+++ b/mzLib/Omics/BioPolymerGroup/BioPolymerWithSetModsGroupTsvSchema.cs
@@ -1,0 +1,108 @@
+namespace Omics.BioPolymerGroup;
+
+/// <summary>
+/// The tab-separated report schema for <see cref="BioPolymerWithSetModsGroup"/>.
+///
+/// Deliberately not the parent-level schema with different labels: a peptide group has no
+/// sequence coverage, gene, or organism, and its occupancy positions are peptide-local. What the
+/// two reports do share — the per-sample quantification block — comes from
+/// <see cref="SampleGroupColumnBuilder"/>, so the schema is built from the whole dataset and every
+/// row is the width of the header.
+/// </summary>
+public static class BioPolymerWithSetModsGroupTsvSchema
+{
+    /// <summary>
+    /// Builds the schema for a set of groups that will be written to one file.
+    /// </summary>
+    /// <param name="groups">All groups destined for the file. Their sample group results are
+    /// populated if they have not been already, since the quantification columns derive from them.</param>
+    public static IReadOnlyList<TsvColumn<BioPolymerWithSetModsGroup>> For(
+        IReadOnlyCollection<BioPolymerWithSetModsGroup> groups)
+    {
+        var columns = new List<TsvColumn<BioPolymerWithSetModsGroup>>
+        {
+            new("Base Sequence", g => g.BaseSequence),
+            new("Peptidoforms", g => Truncate(string.Join("|", Peptidoforms(g)))),
+            new("Number of Peptidoforms", g => Peptidoforms(g).Count().ToString()),
+            new("Parent Accessions", g => Truncate(string.Join("|",
+                Occurrences(g).Select(o => o.Accession)))),
+            new("Number of Parents", g => g.ParentBioPolymers.Count.ToString()),
+            new("Start Residue in Parent", g => Truncate(string.Join("|",
+                Occurrences(g).Select(o => o.Start.ToString())))),
+            new("End Residue in Parent", g => Truncate(string.Join("|",
+                Occurrences(g).Select(o => o.End.ToString()))))
+        };
+
+        columns.AddRange(QuantificationColumns(groups));
+
+        columns.AddRange(new TsvColumn<BioPolymerWithSetModsGroup>[]
+        {
+            new("Number of PSMs", g => g.AllPsmsBelowOnePercentFDR.Count.ToString()),
+            new("Decoy/Contaminant/Target", TargetDecoyLabel),
+            new("Cumulative Target", g => g.CumulativeTarget.ToString()),
+            new("Cumulative Decoy", g => g.CumulativeDecoy.ToString()),
+            new("QValue", g => g.QValue.ToString()),
+            new("Best PSM Score", g => g.BestPsmScore.ToString()),
+            new("Best PSM Notch QValue", g => g.BestPsmQValue.ToString())
+        });
+
+        return columns;
+    }
+
+    /// <summary>
+    /// One block of columns per sample group, with occupancy rendered at peptide-local positions.
+    /// </summary>
+    private static IEnumerable<TsvColumn<BioPolymerWithSetModsGroup>> QuantificationColumns(
+        IReadOnlyCollection<BioPolymerWithSetModsGroup> groups)
+        => SampleGroupColumnBuilder.Build(
+            groups,
+            SampleGroupsOf,
+            (g, result) => Truncate(result.FormatOccupancy([g.BaseSequence], proteinLevel: false, intensityBased: false)),
+            (g, result) => Truncate(result.FormatOccupancy([g.BaseSequence], proteinLevel: false, intensityBased: true)));
+
+    private static IReadOnlyList<SampleGroupResult> SampleGroupsOf(BioPolymerWithSetModsGroup group)
+    {
+        if (group.SampleGroupResults is null)
+            group.PopulateSampleGroupResults();
+
+        return group.SampleGroupResults!;
+    }
+
+    /// <summary>
+    /// Distinct modified forms, ordered so output is stable across runs.
+    /// </summary>
+    private static IEnumerable<string> Peptidoforms(BioPolymerWithSetModsGroup group)
+        => group.Peptidoforms.Select(p => p.FullSequence).Distinct().OrderBy(s => s, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Every place this sequence was found: one entry per (parent, residue range), ordered by
+    /// accession then position.
+    /// </summary>
+    /// <remarks>
+    /// One entry per occurrence rather than per parent, because a sequence can occur more than once
+    /// in the same parent. Reporting per parent silently dropped the later occurrences. The accession
+    /// repeats for each occurrence so that Parent Accessions, Start Residue and End Residue remain
+    /// readable as three parallel lists, one entry apiece.
+    /// </remarks>
+    private static IEnumerable<(string Accession, int Start, int End)> Occurrences(BioPolymerWithSetModsGroup group)
+        => group.Peptidoforms
+            .Where(p => p.Parent is not null)
+            .Select(p => (Accession: p.Parent.Accession, Start: p.OneBasedStartResidue, End: p.OneBasedEndResidue))
+            .Distinct()
+            .OrderBy(o => o.Accession, StringComparer.Ordinal)
+            .ThenBy(o => o.Start);
+
+    /// <summary>
+    /// Single-letter classification: entrapment decoy, entrapment target, decoy, contaminant, or target.
+    /// </summary>
+    private static string TargetDecoyLabel(BioPolymerWithSetModsGroup group)
+    {
+        if (group.IsEntrapment && group.IsDecoy) return "ED";
+        if (group.IsEntrapment) return "ET";
+        if (group.IsDecoy) return "D";
+        if (group.IsContaminant) return "C";
+        return "T";
+    }
+
+    private static string Truncate(string? input) => TsvWriter.Truncate(input);
+}

--- a/mzLib/Omics/BioPolymerGroup/IBioPolymerGroup.cs
+++ b/mzLib/Omics/BioPolymerGroup/IBioPolymerGroup.cs
@@ -10,7 +10,8 @@ namespace Omics.BioPolymerGroup
     /// during protein/gene inference when multiple biopolymers share all their identified sequences.
     /// 
     /// Supports both label-free and isobaric (TMT/iTRAQ) quantification methods.
-    /// Implementations provide scoring, FDR estimation, sequence coverage, and output formatting.
+    /// Implementations provide scoring, FDR estimation, and sequence coverage. Rendering a group to
+    /// a results file is handled separately by a TSV schema and writer, not by the group itself.
     /// Per-sample quantification values are carried via <see cref="IHasSampleIntensities"/>, which a
     /// quantification engine populates.
     /// </summary>
@@ -95,7 +96,7 @@ namespace Omics.BioPolymerGroup
         /// Per-sample-group quantification and modification occupancy results.
         /// Each entry represents one (Condition × BiologicalReplicate) group for label-free data,
         /// one (File × Channel) for isobaric data, or one file for count-only results.
-        /// Built by PopulateSampleGroupResults, consumed by ToString and GetTabSeparatedHeader.
+        /// Built by PopulateSampleGroupResults, consumed by the group's TSV schema.
         /// </summary>
         List<SampleGroupResult>? SampleGroupResults { get; set; }
 
@@ -128,13 +129,6 @@ namespace Omics.BioPolymerGroup
         /// in <see cref="AllPsmsBelowOnePercentFDR"/>.
         /// </summary>
         void CalculateSequenceCoverage();
-
-        /// <summary>
-        /// Returns a tab-separated header line for output files.
-        /// The format matches the output of <see cref="object.ToString"/>.
-        /// </summary>
-        /// <returns>Tab-separated header string suitable for TSV file output.</returns>
-        string GetTabSeparatedHeader();
 
         /// <summary>
         /// Merges another biopolymer group into this one, combining members, PSMs, sequences, 

--- a/mzLib/Omics/BioPolymerGroup/ModificationOccupancyCalculator.cs
+++ b/mzLib/Omics/BioPolymerGroup/ModificationOccupancyCalculator.cs
@@ -150,7 +150,14 @@ public static class ModificationOccupancyCalculator
         var psmList = psms as IList<ISpectralMatch> ?? psms.ToList();
         var result = new Dictionary<string, Dictionary<int, List<SiteSpecificModificationOccupancy>>>();
 
-        var psmsWithBaseSeq = psmList.Where(p => p.BaseSequence != null).ToList();
+        // A PSM whose sequence could not be resolved carries an empty base sequence, not null, so
+        // testing for null alone would let it through and then trip the all-same check below.
+        var psmsWithBaseSeq = psmList.Where(p => !string.IsNullOrEmpty(p.BaseSequence)).ToList();
+
+        // Nothing resolved means nothing to attribute a modification to — not an error. Returning
+        // here also keeps AllSame() off an empty sequence, where its First() call would throw.
+        if (psmsWithBaseSeq.Count == 0)
+            return new Dictionary<int, List<SiteSpecificModificationOccupancy>>();
 
         if (!psmsWithBaseSeq.Select(p => p.BaseSequence).AllSame())
         {

--- a/mzLib/Omics/BioPolymerGroup/ModificationOccupancyCalculator.cs
+++ b/mzLib/Omics/BioPolymerGroup/ModificationOccupancyCalculator.cs
@@ -157,14 +157,6 @@ public static class ModificationOccupancyCalculator
             throw new ArgumentException("All PSMs must have the same BaseSequence for peptide-level occupancy calculation.");
         }
 
-        // Map each PSM to the single form that owns its intensity: matching FullSequence + Accession.
-        // Ambiguous forms (psms without a full sequence match) are filtered out and do not contribute to occupancy.
-        var psmToForm = psmsWithBaseSeq
-            .ToDictionary(
-                p => p,
-                p => p.GetIdentifiedBioPolymersWithSetMods()
-                    .FirstOrDefault(s => s.FullSequence == p.FullSequence));
-
         var totalCount = psmsWithBaseSeq.Count;
         var totalIntensity = psmsWithBaseSeq
             .Where(p => p.Intensities is { Length: 1 })
@@ -173,7 +165,11 @@ public static class ModificationOccupancyCalculator
         var working = new Dictionary<int, Dictionary<string, SiteSpecificModificationOccupancy>>();
         foreach (var psm in psmsWithBaseSeq)
         {
-            var form = psmToForm[psm];
+            // The form carrying this PSM's modifications. A PSM whose full sequence matches no
+            // identified form is ambiguous: it counts toward the denominator but marks no site.
+            var form = psm.GetIdentifiedBioPolymersWithSetMods()
+                .FirstOrDefault(s => s.FullSequence == psm.FullSequence);
+
             if (form is null)
                 continue;
 

--- a/mzLib/Omics/BioPolymerGroup/SampleGroupBuilder.cs
+++ b/mzLib/Omics/BioPolymerGroup/SampleGroupBuilder.cs
@@ -1,0 +1,142 @@
+using MassSpectrometry;
+using Omics.SpectralMatch;
+
+namespace Omics.BioPolymerGroup;
+
+/// <summary>
+/// Buckets PSMs and intensities into <see cref="SampleGroupResult"/>s according to the
+/// experimental design. This is the part of quantification that does not care what is being
+/// grouped, so parent-level and digestion-product-level groups share one copy; each supplies its
+/// own occupancy calculation through a callback.
+/// </summary>
+public static class SampleGroupBuilder
+{
+    /// <summary>
+    /// Groups by (Condition × BiologicalReplicate) for label-free samples, by (File × Channel)
+    /// for isobaric samples, and by PSM source file when no experimental design is supplied.
+    /// </summary>
+    /// <param name="samples">Samples contributing quantification, or null when no design exists.</param>
+    /// <param name="intensitiesBySample">Measured intensities keyed by sample, or null when unavailable.
+    /// When null, results carry no intensity data and only spectral counts are reported.</param>
+    /// <param name="psms">The PSMs to distribute across the resulting sample groups.</param>
+    /// <param name="populateOccupancy">Invoked once per result with the PSMs belonging to it, so the
+    /// caller can attach modification occupancy in whichever coordinate space it reports.</param>
+    public static List<SampleGroupResult> Build(
+        IReadOnlyList<ISampleInfo>? samples,
+        IReadOnlyDictionary<ISampleInfo, double>? intensitiesBySample,
+        IReadOnlyCollection<ISpectralMatch> psms,
+        Action<SampleGroupResult, List<ISpectralMatch>> populateOccupancy)
+    {
+        var results = new List<SampleGroupResult>();
+
+        var spectraFiles = samples?.OfType<SpectraFileInfo>().ToList() ?? [];
+        var isobaricSamples = samples?.OfType<IsobaricQuantSampleInfo>().ToList() ?? [];
+
+        if (spectraFiles.Count > 0)
+        {
+            bool unfractionated = spectraFiles.Select(p => p.Fraction).Distinct().Count() == 1;
+            bool conditionsUndefined = spectraFiles.All(p => string.IsNullOrEmpty(p.Condition));
+            bool silacExperimentalDesign = spectraFiles.Any(p => !File.Exists(p.FullFilePathWithExtension));
+
+            foreach (var conditionGroup in spectraFiles.GroupBy(p => p.Condition))
+            {
+                foreach (var bioRepGroup in conditionGroup.GroupBy(p => p.BiologicalReplicate).OrderBy(p => p.Key))
+                {
+                    var filesInGroup = bioRepGroup.ToList();
+                    bool labelFromFileName = (conditionsUndefined && unfractionated) || silacExperimentalDesign;
+                    string label = labelFromFileName
+                        ? filesInGroup.First().FilenameWithoutExtension
+                        : $"{conditionGroup.Key}_{bioRepGroup.Key + 1}";
+
+                    var filePaths = new HashSet<string>(filesInGroup.Select(f => f.FullFilePathWithExtension));
+                    var psmsInGroup = psms.Where(p => filePaths.Contains(p.FullFilePath)).ToList();
+
+                    // With intensities available, carry the per-file values; otherwise leave them
+                    // empty so HasIntensityData stays false and only spectral counts are reported.
+                    var groupIntensities = new Dictionary<string, double>();
+                    if (intensitiesBySample != null)
+                    {
+                        foreach (var file in filesInGroup)
+                        {
+                            // Keyed by full path, not file name: a sample group spans fractions and
+                            // technical replicates, which are routinely stored one per directory
+                            // under the same name. Keying by name silently summed the wrong pair
+                            // here and threw outright in FilesInGroup below.
+                            if (intensitiesBySample.TryGetValue(file, out var fileIntensity))
+                                groupIntensities[file.FullFilePathWithExtension] = fileIntensity;
+                        }
+                    }
+
+                    var result = new SampleGroupResult(conditionGroup.Key, bioRepGroup.Key)
+                    {
+                        Label = label,
+                        // (Condition, BiologicalReplicate) identifies the sample group, not the label:
+                        // two files with the same name in different directories share a label but are
+                        // distinct samples. These two values are unique here by construction — the
+                        // enclosing GroupBy pair produces exactly one bucket per (condition, replicate) —
+                        // and the replicate is a trailing integer, so the join cannot be ambiguous.
+                        Identity = $"{conditionGroup.Key}|{bioRepGroup.Key}",
+                        LabelSourcePath = labelFromFileName ? filesInGroup.First().FullFilePathWithExtension : null,
+                        SpectralCount = psmsInGroup.Count,
+                        FilesInGroup = filesInGroup.ToDictionary(kvp => kvp.FullFilePathWithExtension, kvp => (ISampleInfo)kvp),
+                        IntensitiesBySample = groupIntensities
+                    };
+
+                    populateOccupancy(result, psmsInGroup);
+                    results.Add(result);
+                }
+            }
+        }
+        else if (isobaricSamples.Count > 0)
+        {
+            foreach (var fileGroup in isobaricSamples.GroupBy(p => p.FullFilePathWithExtension).OrderBy(g => g.Key))
+            {
+                var psmsInFile = psms.Where(p => p.FullFilePath.Equals(fileGroup.Key)).ToList();
+
+                foreach (var sample in fileGroup.OrderBy(p => p.ChannelLabel))
+                {
+                    string label = $"{Path.GetFileNameWithoutExtension(sample.FullFilePathWithExtension)}_{sample.ChannelLabel}";
+
+                    var channelIntensities = new Dictionary<string, double>();
+                    if (intensitiesBySample != null && intensitiesBySample.TryGetValue(sample, out var channelIntensity))
+                        channelIntensities[label] = channelIntensity;
+
+                    var result = new SampleGroupResult(sample.Condition, sample.BiologicalReplicate)
+                    {
+                        Label = label,
+                        Identity = $"{sample.FullFilePathWithExtension}|{sample.ChannelLabel}",
+                        LabelSourcePath = sample.FullFilePathWithExtension,
+                        SpectralCount = psmsInFile.Count,
+                        FilesInGroup = new Dictionary<string, ISampleInfo> { { label, sample } },
+                        IntensitiesBySample = channelIntensities
+                    };
+
+                    populateOccupancy(result, psmsInFile);
+                    results.Add(result);
+                }
+            }
+        }
+        else
+        {
+            // No experimental design — group PSMs by source file for count-only results
+            foreach (var fileGroup in psms.GroupBy(p => p.FullFilePath).OrderBy(g => g.Key))
+            {
+                var psmsInFile = fileGroup.ToList();
+
+                var result = new SampleGroupResult(string.Empty, 0)
+                {
+                    Label = Path.GetFileNameWithoutExtension(fileGroup.Key),
+                    Identity = fileGroup.Key,
+                    LabelSourcePath = fileGroup.Key,
+                    SpectralCount = psmsInFile.Count
+                    // FilesInGroup and IntensitiesBySample left empty → HasIntensityData = false
+                };
+
+                populateOccupancy(result, psmsInFile);
+                results.Add(result);
+            }
+        }
+
+        return results;
+    }
+}

--- a/mzLib/Omics/BioPolymerGroup/SampleGroupColumnBuilder.cs
+++ b/mzLib/Omics/BioPolymerGroup/SampleGroupColumnBuilder.cs
@@ -1,0 +1,139 @@
+namespace Omics.BioPolymerGroup;
+
+/// <summary>
+/// Builds the per-sample-group quantification columns shared by every group-level report:
+/// spectral count and count-based occupancy for each sample group, plus intensity and
+/// intensity-based occupancy for any sample group carrying intensity data.
+///
+/// The sample-group labels are the union across the whole dataset, so a record that was not
+/// quantified in some condition contributes empty fields rather than a narrower row. Each report
+/// supplies only the part that differs — how to render its own occupancy.
+/// </summary>
+public static class SampleGroupColumnBuilder
+{
+    /// <summary>
+    /// </summary>
+    /// <param name="records">Every record destined for the file.</param>
+    /// <param name="sampleGroups">Returns a record's sample group results, populating them if needed.</param>
+    /// <param name="countOccupancy">Formats count-based occupancy for one record and sample group.</param>
+    /// <param name="intensityOccupancy">Formats intensity-based occupancy for one record and sample group.</param>
+    public static IEnumerable<TsvColumn<T>> Build<T>(
+        IReadOnlyCollection<T> records,
+        Func<T, IReadOnlyList<SampleGroupResult>> sampleGroups,
+        Func<T, SampleGroupResult, string> countOccupancy,
+        Func<T, SampleGroupResult, string> intensityOccupancy)
+        where T : IHasSampleIntensities
+    {
+        // Union of sample groups in first-seen order, plus which of them carry intensity anywhere in
+        // the dataset. Taking the union is what keeps every row the header's width.
+        //
+        // Sample groups are matched across records by Identity — the files they cover — never by
+        // Label and never by position. Labels are not unique (SampleGroupBuilder names a sample
+        // group after its file whenever there is no design to name it by, so same-named files in
+        // different directories collide), and position is not stable across records because a
+        // record only has sample groups for the files it was observed in — so the same index means
+        // different files for different records, which files one record's counts under another's
+        // column.
+        var identities = new List<string>();
+        var seen = new HashSet<string>();
+
+        // Whether the intensity columns exist is a property of the run, not of a sample group: an
+        // engine either populated these records or it did not. Deliberately not
+        // SampleGroupResult.HasIntensityData, which answers "did this sample group get a value" --
+        // using that to choose columns made a record whose samples were all unobserved describe a
+        // narrower table than its neighbour. The T constraint is what makes the predicate reachable,
+        // and is why a record type must opt in via IHasSampleIntensities to be rendered here.
+        //
+        // Distinct from the TotalIntensity filter in FormatOccupancy, which stops a site printing
+        // "0.0000(0/0)" inside a column that already exists.
+        bool quantified = records.Any(r => r.SamplesForQuantification is { Count: > 0 }
+                                        && r.IntensitiesBySample is not null);
+        var labelByIdentity = new Dictionary<string, (string Label, string? LabelSourcePath)>();
+
+        foreach (var record in records)
+        {
+            foreach (var result in sampleGroups(record))
+            {
+                if (seen.Add(result.Identity))
+                {
+                    identities.Add(result.Identity);
+                    labelByIdentity[result.Identity] = (result.Label, result.LabelSourcePath);
+                }
+
+            }
+        }
+
+        var displayLabels = SampleGroupLabels.Disambiguate(identities, labelByIdentity);
+
+        var index = new SampleGroupIndex<T>(sampleGroups);
+        var columns = new List<TsvColumn<T>>();
+
+        foreach (var identity in identities)
+        {
+            string thisIdentity = identity;
+            string display = displayLabels[thisIdentity];
+
+            columns.Add(new TsvColumn<T>($"SpectralCount_{display}",
+                r => index.ResultFor(r, thisIdentity)?.SpectralCount.ToString() ?? string.Empty));
+
+            if (quantified)
+                columns.Add(new TsvColumn<T>($"Intensity_{display}",
+                    r => index.ResultFor(r, thisIdentity) is { HasIntensityData: true } result
+                        ? result.Intensity.ToString()
+                        : string.Empty));
+
+            columns.Add(new TsvColumn<T>($"CountOccupancy_{display}",
+                r => index.ResultFor(r, thisIdentity) is { } result
+                    ? countOccupancy(r, result)
+                    : string.Empty));
+
+            if (quantified)
+                columns.Add(new TsvColumn<T>($"IntensityOccupancy_{display}",
+                    r => index.ResultFor(r, thisIdentity) is { } result
+                        ? intensityOccupancy(r, result)
+                        : string.Empty));
+        }
+
+        return columns;
+    }
+
+    /// <summary>
+    /// Finds a record's sample group by identity, in place of scanning its list once per cell.
+    ///
+    /// Decoupling a column from its position in the record's list is what fixes the ragged-row
+    /// defect, but it also means a column can no longer read its value off the list in order. Left
+    /// as a scan, each of the ~4 columns per sample group re-walks the whole list, so writing costs
+    /// O(samples² × records) where rendering a row used to cost O(samples).
+    ///
+    /// A row is rendered one record at a time across every column, so remembering the most recent
+    /// record's lookup restores O(samples × records).
+    ///
+    /// Keyed on the sample-group list instance rather than on the record: every invalidation path
+    /// nulls SampleGroupResults, and repopulating assigns a fresh list, so a record whose
+    /// quantification changed mid-write rebuilds its index instead of serving a stale one.
+    /// Not thread-safe, in common with the lazy population it wraps.
+    /// </summary>
+    private sealed class SampleGroupIndex<T>(Func<T, IReadOnlyList<SampleGroupResult>> sampleGroups)
+    {
+        private IReadOnlyList<SampleGroupResult>? _source;
+        private Dictionary<string, SampleGroupResult> _byIdentity = [];
+
+        public SampleGroupResult? ResultFor(T record, string identity)
+        {
+            var results = sampleGroups(record);
+
+            if (!ReferenceEquals(results, _source))
+            {
+                _source = results;
+                _byIdentity = new Dictionary<string, SampleGroupResult>(results.Count);
+
+                // First wins, matching the FirstOrDefault this replaces — identities are unique
+                // within a record by construction, but TryAdd keeps a hand-built list from throwing.
+                foreach (var result in results)
+                    _byIdentity.TryAdd(result.Identity, result);
+            }
+
+            return _byIdentity.GetValueOrDefault(identity);
+        }
+    }
+}

--- a/mzLib/Omics/BioPolymerGroup/SampleGroupLabels.cs
+++ b/mzLib/Omics/BioPolymerGroup/SampleGroupLabels.cs
@@ -1,0 +1,138 @@
+namespace Omics.BioPolymerGroup;
+
+/// <summary>
+/// Turns sample group labels into column names that are unique within one output file.
+///
+/// A label is only a display name and is not unique — <see cref="SampleGroupBuilder"/> names a
+/// sample group after its file whenever there is no experimental design to name it by, so
+/// <c>Rep1\sample.raw</c> and <c>Rep2\sample.raw</c> both label <c>sample</c>. Emitting two columns
+/// with the same name leaves a reader unable to tell which file a value came from, so colliding
+/// labels are widened with as much of their parent path as it takes to separate them.
+/// </summary>
+public static class SampleGroupLabels
+{
+    /// <summary>
+    /// Maps each sample group identity to a column name unique across <paramref name="identities"/>.
+    /// Labels that do not collide are returned unchanged, so output is unaffected for the datasets
+    /// that were already unambiguous.
+    /// </summary>
+    /// <param name="identities">Sample group identities, in the order their columns appear.</param>
+    /// <param name="labels">Label and originating file path for each identity.</param>
+    public static Dictionary<string, string> Disambiguate(
+        IReadOnlyList<string> identities,
+        IReadOnlyDictionary<string, (string Label, string? LabelSourcePath)> labels)
+    {
+        // Widen only what still clashes, and re-check against the whole set each round rather than
+        // within one label's members: widening is itself a source of collisions, because the name a
+        // widened column takes ("run1_sample") can be the plain label of some other file that was
+        // never in that collision group ("run1_sample.raw").
+        var depth = identities.ToDictionary(id => id, _ => 0);
+
+        // Bounded by the deepest path; the no-progress branch below is the real exit.
+        for (int round = 0; round <= MaxWideningRounds; round++)
+        {
+            var display = identities.ToDictionary(
+                id => id,
+                id => WidenPath(labels[id].LabelSourcePath, labels[id].Label, depth[id]));
+
+            var clashing = display
+                .GroupBy(entry => entry.Value)
+                .Where(sameName => sameName.Count() > 1)
+                .SelectMany(sameName => sameName.Select(entry => entry.Key))
+                .ToList();
+
+            if (clashing.Count == 0)
+                return display;
+
+            bool widened = false;
+            foreach (var id in clashing)
+            {
+                if (CanWiden(labels[id].LabelSourcePath, depth[id] + 1))
+                {
+                    depth[id]++;
+                    widened = true;
+                }
+            }
+
+            // Nothing left to widen with — paths are exhausted, or the labels came from the
+            // experimental design and have no path at all. Separate them by ordinal instead.
+            if (!widened)
+                return AppendOrdinals(identities, display);
+        }
+
+        return AppendOrdinals(
+            identities,
+            identities.ToDictionary(id => id, id => WidenPath(labels[id].LabelSourcePath, labels[id].Label, depth[id])));
+    }
+
+    private const int MaxWideningRounds = 64;
+
+    /// <summary>
+    /// Last resort when no more path is available: keeps the first occurrence and suffixes the rest,
+    /// so the names are at least distinct even though they no longer say which file they came from.
+    /// </summary>
+    private static Dictionary<string, string> AppendOrdinals(
+        IReadOnlyList<string> identities, Dictionary<string, string> display)
+    {
+        var used = new HashSet<string>();
+        var resolved = new Dictionary<string, string>();
+
+        foreach (var id in identities)
+        {
+            string name = display[id];
+
+            if (used.Add(name))
+            {
+                resolved[id] = name;
+                continue;
+            }
+
+            int ordinal = 2;
+            while (!used.Add($"{name}_{ordinal}"))
+                ordinal++;
+
+            resolved[id] = $"{name}_{ordinal}";
+        }
+
+        return resolved;
+    }
+
+    /// <summary>
+    /// Prefixes <paramref name="label"/> with up to <paramref name="depth"/> parent directory names
+    /// from <paramref name="path"/>, nearest first — <c>Rep1_sample</c>, then <c>ExpA_Rep1_sample</c>.
+    /// </summary>
+    private static string WidenPath(string? path, string label, int depth)
+    {
+        if (string.IsNullOrEmpty(path))
+            return label;
+
+        var parents = ParentDirectories(path).Take(depth).Reverse();
+        var parts = parents.Append(label);
+
+        return string.Join("_", parts);
+    }
+
+    /// <summary>True when <paramref name="path"/> has at least <paramref name="depth"/> ancestors to widen with.</summary>
+    private static bool CanWiden(string? path, int depth)
+        => !string.IsNullOrEmpty(path) && ParentDirectories(path).Skip(depth - 1).Any();
+
+    /// <summary>
+    /// Directory names containing <paramref name="path"/>, nearest ancestor first.
+    /// </summary>
+    private static IEnumerable<string> ParentDirectories(string path)
+    {
+        var directory = Path.GetDirectoryName(path);
+
+        while (!string.IsNullOrEmpty(directory))
+        {
+            string name = Path.GetFileName(directory);
+
+            // A root such as "C:\" has no name of its own; stop rather than emit an empty segment.
+            if (string.IsNullOrEmpty(name))
+                yield break;
+
+            yield return name;
+            directory = Path.GetDirectoryName(directory);
+        }
+    }
+}

--- a/mzLib/Omics/BioPolymerGroup/SampleGroupResult.cs
+++ b/mzLib/Omics/BioPolymerGroup/SampleGroupResult.cs
@@ -119,9 +119,12 @@ public sealed class SampleGroupResult
     /// Output: semicolon-separated mod entries within each entity, pipe-separated between entities.
     /// </summary>
     /// <param name="orderedKeys">Ordered accessions (protein-level) or base sequences (peptide-level).</param>
-    /// <param name="proteinLevel">True for protein-level occupancy; false for peptide-level.</param>
+    /// <param name="proteinLevel">True for protein-level occupancy; false for peptide-level.
+    /// Deliberately has no default: each group kind populates only one of the two occupancy
+    /// dictionaries, and asking for the wrong one returns an empty string rather than failing —
+    /// which reads as "no modifications found" instead of "you asked the wrong question".</param>
     /// <param name="intensityBased">True to format intensity-based stoichiometry; false for count-based occupancy.</param>
-    public string FormatOccupancy(IEnumerable<string> orderedKeys, bool proteinLevel = true, bool intensityBased = false)
+    public string FormatOccupancy(IEnumerable<string> orderedKeys, bool proteinLevel, bool intensityBased = false)
     {
         var occupancy = proteinLevel ? ParentOccupancy : DigestionProductOccupancy;
 

--- a/mzLib/Omics/BioPolymerGroup/SampleGroupResult.cs
+++ b/mzLib/Omics/BioPolymerGroup/SampleGroupResult.cs
@@ -25,7 +25,33 @@ public sealed class SampleGroupResult
     /// Display label for column headers (e.g., "Control_1" or a filename).
     /// Set by the caller based on experimental design context.
     /// </summary>
+    /// <remarks>
+    /// Not unique. Whenever the label is derived from a file name, two files with the same name in
+    /// different directories produce the same label. Use <see cref="Identity"/> to tell sample
+    /// groups apart; a label is for display only.
+    /// </remarks>
     public string Label { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Stable identifier for this sample group, unique within a dataset. What identifies a sample
+    /// group differs by experimental design: (condition, replicate) for label-free, (file, channel)
+    /// for isobaric, and the source file when there is no design at all.
+    /// </summary>
+    /// <remarks>
+    /// Matching a sample group across the records of a dataset must key on this, never on
+    /// <see cref="Label"/> (not unique) nor on position within a record's list (a record only has
+    /// sample groups for the files it was actually observed in, so the same index means different
+    /// files for different records — which silently files one record's counts under another
+    /// record's column).
+    /// </remarks>
+    public string Identity { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The file path <see cref="Label"/> was derived from, or null when the label came from the
+    /// experimental design instead. Used to widen a label with parent directories when two sample
+    /// groups in a dataset would otherwise present the same column name.
+    /// </summary>
+    public string? LabelSourcePath { get; init; }
 
     #endregion
 
@@ -98,16 +124,26 @@ public sealed class SampleGroupResult
     public string FormatOccupancy(IEnumerable<string> orderedKeys, bool proteinLevel = true, bool intensityBased = false)
     {
         var occupancy = proteinLevel ? ParentOccupancy : DigestionProductOccupancy;
-        return FormatOccupancy(occupancy, orderedKeys, o => o.ToModInfoString(intensityBased));
+
+        // A site with no measured intensity has no stoichiometry to report. Formatting it anyway
+        // prints "fraction=0.0000(0/0)", which reads as a measured zero rather than as absent data —
+        // and does so in rows whose Intensity cell is blank, so the two disagree. Count-based
+        // occupancy needs no such filter: its denominator is the observation count, always real.
+        Func<SiteSpecificModificationOccupancy, bool> hasEvidence = intensityBased
+            ? site => site.TotalIntensity > 0
+            : _ => true;
+
+        return FormatOccupancy(occupancy, orderedKeys, hasEvidence, o => o.ToModInfoString(intensityBased));
     }
 
     /// <summary>
     /// Core formatting helper. Iterates ordered keys, formats each entity's modifications,
     /// and joins with the standard separators (; within entity, | between entities).
-    /// </summary>s
+    /// </summary>
     private static string FormatOccupancy(
         Dictionary<string, Dictionary<int, List<SiteSpecificModificationOccupancy>>> occupancy,
         IEnumerable<string> orderedKeys,
+        Func<SiteSpecificModificationOccupancy, bool> include,
         Func<SiteSpecificModificationOccupancy, string> formatter)
     {
         var parts = new List<string>();
@@ -120,6 +156,7 @@ public sealed class SampleGroupResult
             string entityString = string.Join(";",
                 positions.OrderBy(kvp => kvp.Key)
                     .SelectMany(kvp => kvp.Value)
+                    .Where(include)
                     .Select(formatter));
 
             if (!string.IsNullOrEmpty(entityString))

--- a/mzLib/Omics/BioPolymerGroup/TsvColumn.cs
+++ b/mzLib/Omics/BioPolymerGroup/TsvColumn.cs
@@ -1,0 +1,55 @@
+namespace Omics.BioPolymerGroup;
+
+/// <summary>
+/// One column of tab-separated output: its header text paired with an accessor that reads the
+/// value out of an item.
+/// </summary>
+/// <typeparam name="T">The record type being written, e.g. a biopolymer group.</typeparam>
+public sealed class TsvColumn<T>
+{
+    /// <summary>Column name written to the header line.</summary>
+    public string Header { get; }
+
+    /// <summary>Reads this column's value from one item.</summary>
+    public Func<T, string> GetValue { get; }
+
+    public TsvColumn(string header, Func<T, string> getValue)
+    {
+        Header = header ?? throw new ArgumentNullException(nameof(header));
+        GetValue = getValue ?? throw new ArgumentNullException(nameof(getValue));
+    }
+}
+
+/// <summary>
+/// Writes records as a tab-separated file from a schema — an ordered list of <see cref="TsvColumn{T}"/>.
+///
+/// The schema is built once for a dataset and then applied to every record, so the header and all
+/// rows are necessarily the same width. Records do not format themselves: a record that lacks a
+/// value for some column contributes an empty field rather than omitting the column, which is what
+/// keeps a ragged dataset from shifting every subsequent field on the affected rows.
+/// </summary>
+public static class TsvWriter
+{
+    /// <summary>Renders the header line for a schema.</summary>
+    public static string HeaderLine<T>(IReadOnlyList<TsvColumn<T>> schema)
+        => string.Join('\t', schema.Select(c => c.Header));
+
+    /// <summary>
+    /// Renders one record. A column accessor returning null yields an empty field so the row keeps
+    /// its alignment with the header.
+    /// </summary>
+    public static string RowLine<T>(IReadOnlyList<TsvColumn<T>> schema, T item)
+        => string.Join('\t', schema.Select(c => c.GetValue(item) ?? string.Empty));
+
+    /// <summary>
+    /// Writes the header followed by one line per item.
+    /// </summary>
+    public static void Write<T>(TextWriter output, IReadOnlyList<TsvColumn<T>> schema, IEnumerable<T> items)
+    {
+        output.WriteLine(HeaderLine(schema));
+        foreach (var item in items)
+        {
+            output.WriteLine(RowLine(schema, item));
+        }
+    }
+}

--- a/mzLib/Omics/BioPolymerGroup/TsvColumn.cs
+++ b/mzLib/Omics/BioPolymerGroup/TsvColumn.cs
@@ -30,6 +30,33 @@ public sealed class TsvColumn<T>
 /// </summary>
 public static class TsvWriter
 {
+    /// <summary>
+    /// Maximum length for a single field. Longer values are truncated by <see cref="Truncate"/>.
+    ///
+    /// Default is 32,000 characters, slightly below Excel's cell limit of 32,767, so output files
+    /// open in Excel without truncation or corruption. Set to 0 or negative to disable truncation
+    /// (useful for programmatic processing where Excel compatibility does not matter).
+    /// </summary>
+    /// <remarks>
+    /// Excel specification: a cell can contain up to 32,767 characters.
+    /// See: https://support.microsoft.com/en-us/office/excel-specifications-and-limits
+    /// </remarks>
+    public static int MaxFieldLength { get; set; } = 32000;
+
+    /// <summary>
+    /// Caps a field at <see cref="MaxFieldLength"/>. Null and empty both render as an empty field.
+    /// </summary>
+    public static string Truncate(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+
+        if (MaxFieldLength <= 0 || value.Length <= MaxFieldLength)
+            return value;
+
+        return value.Substring(0, MaxFieldLength);
+    }
+
     /// <summary>Renders the header line for a schema.</summary>
     public static string HeaderLine<T>(IReadOnlyList<TsvColumn<T>> schema)
         => string.Join('\t', schema.Select(c => c.Header));

--- a/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupSequenceCoverageTests.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupSequenceCoverageTests.cs
@@ -55,7 +55,7 @@ namespace Test.Omics.BioPolymerGroupTests
 
             group.CalculateSequenceCoverage();
 
-            var fraction = double.Parse(GetCoverageFraction(group.ToString()));
+            var fraction = double.Parse(GetCoverageFraction(GroupTsv.Row(group)));
             Assert.That(fraction, Is.EqualTo(0.25).Within(0.001));
         }
 
@@ -73,7 +73,7 @@ namespace Test.Omics.BioPolymerGroupTests
 
             group.CalculateSequenceCoverage();
 
-            var display = GetCoverageDisplay(group.ToString());
+            var display = GetCoverageDisplay(GroupTsv.Row(group));
             Assert.That(display, Is.EqualTo("acDEFghik"));
         }
 
@@ -100,7 +100,7 @@ namespace Test.Omics.BioPolymerGroupTests
             group.CalculateSequenceCoverage();
 
             // Combined coverage: 1-6 = 6 residues out of 9
-            var fraction = double.Parse(GetCoverageFraction(group.ToString()));
+            var fraction = double.Parse(GetCoverageFraction(GroupTsv.Row(group)));
             Assert.That(fraction, Is.EqualTo(6.0 / 9.0).Within(0.001));
         }
 
@@ -124,7 +124,7 @@ namespace Test.Omics.BioPolymerGroupTests
 
             group.CalculateSequenceCoverage();
 
-            var fraction = GetCoverageFraction(group.ToString());
+            var fraction = GetCoverageFraction(GroupTsv.Row(group));
             Assert.That(fraction, Is.EqualTo("0"));
         }
 
@@ -150,7 +150,7 @@ namespace Test.Omics.BioPolymerGroupTests
             Assert.DoesNotThrow(() => group.CalculateSequenceCoverage());
 
             // Only valid PSM should contribute
-            var fraction = double.Parse(GetCoverageFraction(group.ToString()));
+            var fraction = double.Parse(GetCoverageFraction(GroupTsv.Row(group)));
             Assert.That(fraction, Is.EqualTo(5.0 / 9.0).Within(0.001));
         }
 
@@ -176,7 +176,7 @@ namespace Test.Omics.BioPolymerGroupTests
 
             group.CalculateSequenceCoverage();
 
-            var fraction = GetCoverageFraction(group.ToString());
+            var fraction = GetCoverageFraction(GroupTsv.Row(group));
             Assert.That(fraction, Is.EqualTo("0")); // protein1 has no coverage
         }
 
@@ -284,7 +284,7 @@ namespace Test.Omics.BioPolymerGroupTests
 
             group.CalculateSequenceCoverage();
 
-            var output = group.ToString();
+            var output = GroupTsv.Row(group);
             var coverageWithMods = output.Split('\t').ElementAtOrDefault(12) ?? "";
             Assert.That(coverageWithMods, Does.Not.Contain("[Oxidation"));
         }

--- a/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupTests.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupTests.cs
@@ -262,8 +262,8 @@ namespace Test.Omics.BioPolymerGroupTests
         [Test]
         public void ToStringAndHeader_HaveMatchingColumnCounts()
         {
-            var header = _bioPolymerGroup.GetTabSeparatedHeader();
-            var row = _bioPolymerGroup.ToString();
+            var header = GroupTsv.Header(_bioPolymerGroup);
+            var row = GroupTsv.Row(_bioPolymerGroup);
 
             var headerColumns = header.Split('\t').Length;
             var rowColumns = row.Split('\t').Length;
@@ -287,7 +287,7 @@ namespace Test.Omics.BioPolymerGroupTests
                 isDecoy: isDecoy, isContaminant: isContaminant, isEntrapment: isEntrapment);
             var bg = new BioPolymerGroup(new HashSet<IBioPolymer> { bioPolymer }, _allSequences, _uniqueSequences);
 
-            var result = bg.ToString();
+            var result = GroupTsv.Row(bg);
 
             Assert.That(result, Does.Contain(expectedMarker));
         }
@@ -324,7 +324,7 @@ namespace Test.Omics.BioPolymerGroupTests
             });
 
             // Verify ToString doesn't throw with mixed types
-            Assert.DoesNotThrow(() => _bioPolymerGroup.ToString());
+            Assert.DoesNotThrow(() => GroupTsv.Row(_bioPolymerGroup));
         }
 
         /// <summary>
@@ -344,7 +344,7 @@ namespace Test.Omics.BioPolymerGroupTests
                 { sample127, 2222.0 }
             };
 
-            var result = _bioPolymerGroup.ToString();
+            var result = GroupTsv.Row(_bioPolymerGroup);
             var index1111 = result.IndexOf("1111");
             var index2222 = result.IndexOf("2222");
 
@@ -366,7 +366,7 @@ namespace Test.Omics.BioPolymerGroupTests
             var bioPolymer = new MockBioPolymer("SEQ", "BP00001", fullName: longName);
             var bg = new BioPolymerGroup(new HashSet<IBioPolymer> { bioPolymer }, _allSequences, _uniqueSequences);
 
-            var result = bg.ToString();
+            var result = GroupTsv.Row(bg);
 
             Assert.That(result.Length, Is.LessThan(longName.Length));
         }
@@ -381,8 +381,8 @@ namespace Test.Omics.BioPolymerGroupTests
             _bioPolymerGroup.SamplesForQuantification = null;
             _bioPolymerGroup.IntensitiesBySample = null;
 
-            Assert.DoesNotThrow(() => _bioPolymerGroup.ToString());
-            Assert.DoesNotThrow(() => _bioPolymerGroup.GetTabSeparatedHeader());
+            Assert.DoesNotThrow(() => GroupTsv.Row(_bioPolymerGroup));
+            Assert.DoesNotThrow(() => GroupTsv.Header(_bioPolymerGroup));
             Assert.DoesNotThrow(() => _bioPolymerGroup.ConstructSubsetBioPolymerGroup(@"C:\test.raw"));
         }
 
@@ -405,7 +405,7 @@ namespace Test.Omics.BioPolymerGroupTests
             _bioPolymerGroup.SamplesForQuantification = new List<ISampleInfo> { file1, file2 };
             _bioPolymerGroup.PopulateSampleGroupResults();
 
-            var header = _bioPolymerGroup.GetTabSeparatedHeader();
+            var header = GroupTsv.Header(_bioPolymerGroup);
 
             // Without IntensitiesBySample, intensity columns should not appear
             Assert.That(header, Does.Not.Contain("Intensity_test1"));
@@ -427,7 +427,7 @@ namespace Test.Omics.BioPolymerGroupTests
             };
             _bioPolymerGroup.PopulateSampleGroupResults();
 
-            var header = _bioPolymerGroup.GetTabSeparatedHeader();
+            var header = GroupTsv.Header(_bioPolymerGroup);
             Assert.That(header, Does.Contain("Intensity_test1"));
             Assert.That(header, Does.Contain("Intensity_test2"));
         }
@@ -445,7 +445,7 @@ namespace Test.Omics.BioPolymerGroupTests
             _bioPolymerGroup.SamplesForQuantification = new List<ISampleInfo> { file1, file2 };
             _bioPolymerGroup.PopulateSampleGroupResults();
 
-            var header = _bioPolymerGroup.GetTabSeparatedHeader();
+            var header = GroupTsv.Header(_bioPolymerGroup);
 
             Assert.That(header, Does.Not.Contain("Intensity_sample_A"));
             Assert.That(header, Does.Not.Contain("Intensity_sample_B"));
@@ -465,7 +465,7 @@ namespace Test.Omics.BioPolymerGroupTests
             };
             _bioPolymerGroup.PopulateSampleGroupResults();
 
-            var header = _bioPolymerGroup.GetTabSeparatedHeader();
+            var header = GroupTsv.Header(_bioPolymerGroup);
 
             Assert.That(header, Does.Contain("Intensity_sample_A"));
             Assert.That(header, Does.Contain("Intensity_sample_B"));
@@ -484,7 +484,7 @@ namespace Test.Omics.BioPolymerGroupTests
 
             _bioPolymerGroup.SamplesForQuantification = new List<ISampleInfo> { sample127, sample126, sample128 };
 
-            var header = _bioPolymerGroup.GetTabSeparatedHeader();
+            var header = GroupTsv.Header(_bioPolymerGroup);
 
             // Channels should be ordered by file path first, then by channel label
             var index126 = header.IndexOf("fileA_126");
@@ -530,7 +530,7 @@ namespace Test.Omics.BioPolymerGroupTests
 
             group.CalculateSequenceCoverage();
 
-            var output = group.ToString();
+            var output = GroupTsv.Row(group);
             // N-terminal mods should appear as [ModName]- prefix
             Assert.That(output, Does.Contain("[Acetyl on P]-"));
         }
@@ -565,7 +565,7 @@ namespace Test.Omics.BioPolymerGroupTests
 
             group.CalculateSequenceCoverage();
 
-            var output = group.ToString();
+            var output = GroupTsv.Row(group);
             // C-terminal mods should appear as -[ModName] suffix
             Assert.That(output, Does.Contain("-[Amidated on E]"));
         }
@@ -604,7 +604,7 @@ namespace Test.Omics.BioPolymerGroupTests
 
             group.CalculateSequenceCoverage();
 
-            var output = group.ToString();
+            var output = GroupTsv.Row(group);
             // N-terminal mod occupancy should report position as aa1
             Assert.That(output, Does.Contain("pos0["));
             Assert.That(output, Does.Contain("fraction=1.00(1/1)"));
@@ -638,7 +638,7 @@ namespace Test.Omics.BioPolymerGroupTests
             var psm = new MockSpectralMatch(@"C:\test.raw", "PEPTIDEK-[Amidated on K]", "PEPTIDEK", 100, 1, [peptide]);
             group.AllPsmsBelowOnePercentFDR = new HashSet<ISpectralMatch> { psm };
 
-            var output = group.ToString();
+            var output = GroupTsv.Row(group);
             // C-terminal mod occupancy should report position as aa10 (protein length + 2)
             Assert.That(output, Does.Contain("pos9["));
             Assert.That(output, Does.Contain("fraction=1.00(1/1)"));
@@ -675,7 +675,7 @@ namespace Test.Omics.BioPolymerGroupTests
             // Should not throw
             Assert.DoesNotThrow(() => group.CalculateSequenceCoverage());
 
-            var output = group.ToString();
+            var output = GroupTsv.Row(group);
             // Unknown location restriction mods should not appear in occupancy info
             Assert.That(output, Does.Not.Contain("UnknownMod"));
         }
@@ -751,7 +751,7 @@ namespace Test.Omics.BioPolymerGroupTests
             // Enable modification display
             group.DisplayModsOnPeptides = true;
 
-            var output = group.ToString();
+            var output = GroupTsv.Row(group);
 
             // Unique sequences column should contain the full modified sequence
             Assert.That(output, Does.Contain("PEP[Phospho]TIDE"));
@@ -792,7 +792,7 @@ namespace Test.Omics.BioPolymerGroupTests
 
             group.CalculateSequenceCoverage();
 
-            var output = group.ToString();
+            var output = GroupTsv.Row(group);
             // The modification should appear after the T (4th residue)
             Assert.That(output, Does.Contain("[Phospho on T]"));
         }
@@ -808,29 +808,29 @@ namespace Test.Omics.BioPolymerGroupTests
         [Test]
         public void MaxStringLength_ControlsTruncation()
         {
-            var originalMax = BioPolymerGroup.MaxStringLength;
+            var originalMax = BioPolymerGroupTsvSchema.MaxStringLength;
             try
             {
                 // Test with custom limit
-                BioPolymerGroup.MaxStringLength = 100;
+                BioPolymerGroupTsvSchema.MaxStringLength = 100;
                 var longName = new string('X', 200);
                 var bioPolymer = new MockBioPolymer("SEQ", "P00001", fullName: longName);
                 var bg = new BioPolymerGroup(new HashSet<IBioPolymer> { bioPolymer }, _allSequences, _uniqueSequences);
 
-                var result = bg.ToString();
+                var result = GroupTsv.Row(bg);
 
                 // Full name column should be truncated
                 Assert.That(result, Does.Not.Contain(longName));
                 Assert.That(result.Contains(new string('X', 100)), Is.True);
 
                 // Test disabling truncation (0 or negative)
-                BioPolymerGroup.MaxStringLength = 0;
-                var result2 = bg.ToString();
+                BioPolymerGroupTsvSchema.MaxStringLength = 0;
+                var result2 = GroupTsv.Row(bg);
                 Assert.That(result2, Does.Contain(longName), "MaxStringLength=0 should disable truncation");
             }
             finally
             {
-                BioPolymerGroup.MaxStringLength = originalMax;
+                BioPolymerGroupTsvSchema.MaxStringLength = originalMax;
             }
         }
 
@@ -845,13 +845,13 @@ namespace Test.Omics.BioPolymerGroupTests
             var bg = new BioPolymerGroup(new HashSet<IBioPolymer> { bioPolymer }, _allSequences, _uniqueSequences);
 
             // Should not throw with null fullName
-            Assert.DoesNotThrow(() => bg.ToString());
+            Assert.DoesNotThrow(() => GroupTsv.Row(bg));
 
             var bioPolymer2 = new MockBioPolymer("SEQ", "P00002", fullName: "");
             var bg2 = new BioPolymerGroup(new HashSet<IBioPolymer> { bioPolymer2 }, _allSequences, _uniqueSequences);
 
             // Should not throw with empty fullName
-            Assert.DoesNotThrow(() => bg2.ToString());
+            Assert.DoesNotThrow(() => GroupTsv.Row(bg2));
         }
 
         #endregion

--- a/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupTests.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupTests.cs
@@ -808,11 +808,11 @@ namespace Test.Omics.BioPolymerGroupTests
         [Test]
         public void MaxStringLength_ControlsTruncation()
         {
-            var originalMax = BioPolymerGroupTsvSchema.MaxStringLength;
+            var originalMax = TsvWriter.MaxFieldLength;
             try
             {
                 // Test with custom limit
-                BioPolymerGroupTsvSchema.MaxStringLength = 100;
+                TsvWriter.MaxFieldLength = 100;
                 var longName = new string('X', 200);
                 var bioPolymer = new MockBioPolymer("SEQ", "P00001", fullName: longName);
                 var bg = new BioPolymerGroup(new HashSet<IBioPolymer> { bioPolymer }, _allSequences, _uniqueSequences);
@@ -824,13 +824,13 @@ namespace Test.Omics.BioPolymerGroupTests
                 Assert.That(result.Contains(new string('X', 100)), Is.True);
 
                 // Test disabling truncation (0 or negative)
-                BioPolymerGroupTsvSchema.MaxStringLength = 0;
+                TsvWriter.MaxFieldLength = 0;
                 var result2 = GroupTsv.Row(bg);
                 Assert.That(result2, Does.Contain(longName), "MaxStringLength=0 should disable truncation");
             }
             finally
             {
-                BioPolymerGroupTsvSchema.MaxStringLength = originalMax;
+                TsvWriter.MaxFieldLength = originalMax;
             }
         }
 

--- a/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupTsvGoldenTests.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupTsvGoldenTests.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using MassSpectrometry;
+using NUnit.Framework;
+using Omics;
+using Omics.BioPolymerGroup;
+using Omics.Modifications;
+using Omics.SpectralMatch;
+
+namespace Test.Omics.BioPolymerGroupTests
+{
+    /// <summary>
+    /// Locks the exact tab-separated header and row emitted by <see cref="BioPolymerGroup"/>.
+    /// Other tests in this folder assert with substrings; these compare every field, so a change
+    /// to column order, count, naming, or value formatting fails here rather than silently
+    /// reshaping output files.
+    ///
+    /// To regenerate after an intentional column change, run the Explicit DumpGoldenStrings test.
+    /// </summary>
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class BioPolymerGroupTsvGoldenTests
+    {
+        private const string FileA = @"C:\goldenA.raw";
+        private const string FileB = @"C:\goldenB.raw";
+
+        private static readonly string[] StaticHeader =
+        [
+            "BioPolymer Accession", "Gene", "Organism", "BioPolymer Full Name",
+            "BioPolymer Unmodified Mass", "Number of BioPolymers in Group",
+            "Unique Sequences", "Shared Sequences", "Number of Sequences",
+            "Number of Unique Sequences", "Sequence Coverage Fraction", "Sequence Coverage",
+            "Sequence Coverage with Mods", "Fragment Sequence Coverage"
+        ];
+
+        private static readonly string[] TrailingHeader =
+        [
+            "Number of PSMs", "BioPolymer Decoy/Contaminant/Target",
+            "BioPolymer Cumulative Target", "BioPolymer Cumulative Decoy",
+            "BioPolymer QValue", "Best Sequence Score", "Best Sequence Notch QValue"
+        ];
+
+        private static readonly string[] StaticRow =
+        [
+            "P00001", "GENE1", "Homo sapiens", "Test Protein", "NaN", "1",
+            "GHIK", "ACDEF", "2", "1", "1", "ACDEFGHIK",
+            "ACD[Phosphorylation on D]EFGHIK", "acdefghik"
+        ];
+
+        private static readonly string[] TrailingRow =
+        [
+            "3", "T", "7", "2", "0.01", "10", "0.005"
+        ];
+
+        private const string CountOccupancy = "pos3[Phosphorylation on D,info:fraction=0.50(1/2)]";
+        private const string IntensityOccupancy = "pos3[Phosphorylation on D,info:fraction=0.2500(100/400)]";
+
+        /// <summary>
+        /// Builds a deterministic group: one protein, one shared modified sequence, one unique
+        /// sequence, and three PSMs (modified ACDEF, unmodified ACDEF, and GHIK).
+        /// Each sequence set yields a single element per pipe-joined field, so HashSet iteration
+        /// order cannot affect the output being locked.
+        /// </summary>
+        private static BioPolymerGroup BuildGroup(string[] psmFilePaths, double[] psmIntensities = null)
+        {
+            var protein = new MockBioPolymer("ACDEFGHIK", "P00001",
+                organism: "Homo sapiens",
+                name: "TestName",
+                fullName: "Test Protein",
+                geneNames: new List<Tuple<string, string>> { new("primary", "GENE1") });
+
+            ModificationMotif.TryGetMotif("D", out var motif);
+            var phospho = new Modification("Phosphorylation", null, "Biological", null, motif, "Anywhere.", null, 79.966);
+
+            var modifiedForm = new MockBioPolymerWithSetMods("ACDEF", "ACD[Phosphorylation]EF", protein, 1, 5,
+                new Dictionary<int, Modification> { { 4, phospho } });
+            var unmodifiedForm = new MockBioPolymerWithSetMods("ACDEF", "ACDEF", protein, 1, 5);
+            var uniqueForm = new MockBioPolymerWithSetMods("GHIK", "GHIK", protein, 6, 9);
+
+            var group = new BioPolymerGroup(
+                new HashSet<IBioPolymer> { protein },
+                new HashSet<IBioPolymerWithSetMods> { modifiedForm, uniqueForm },
+                new HashSet<IBioPolymerWithSetMods> { uniqueForm });
+
+            var psms = new List<ISpectralMatch>
+            {
+                new MockSpectralMatch(psmFilePaths[0], "ACD[Phosphorylation]EF", "ACDEF", 10.0, 1, new[] { modifiedForm }),
+                new MockSpectralMatch(psmFilePaths[1], "ACDEF", "ACDEF", 8.0, 2, new[] { unmodifiedForm }),
+                new MockSpectralMatch(psmFilePaths[2], "GHIK", "GHIK", 6.0, 3, new[] { uniqueForm })
+            };
+
+            if (psmIntensities != null)
+            {
+                for (int i = 0; i < psms.Count; i++)
+                {
+                    ((MockSpectralMatch)psms[i]).Intensities = [psmIntensities[i]];
+                }
+            }
+
+            group.AllPsmsBelowOnePercentFDR = [.. psms];
+            group.CumulativeTarget = 7;
+            group.CumulativeDecoy = 2;
+            group.QValue = 0.01;
+            group.BestBioPolymerWithSetModsScore = 10.0;
+            group.BestBioPolymerWithSetModsQValue = 0.005;
+            group.CalculateSequenceCoverage();
+
+            return group;
+        }
+
+        private static BioPolymerGroup BuildNoDesignGroup() =>
+            BuildGroup([FileA, FileA, FileA]);
+
+        private static BioPolymerGroup BuildLabelFreeGroup()
+        {
+            var group = BuildGroup([FileA, FileA, FileB], [100.0, 300.0, 50.0]);
+            var fileA = new SpectraFileInfo(FileA, "Control", 0, 0, 0);
+            var fileB = new SpectraFileInfo(FileB, "Treatment", 0, 0, 0);
+
+            group.SamplesForQuantification = [fileA, fileB];
+            group.IntensitiesBySample = new Dictionary<ISampleInfo, double>
+            {
+                { fileA, 1000.0 },
+                { fileB, 2000.0 }
+            };
+            return group;
+        }
+
+        private static BioPolymerGroup BuildIsobaricGroup()
+        {
+            var group = BuildGroup([FileA, FileA, FileA], [100.0, 300.0, 50.0]);
+            var channel126 = new IsobaricQuantSampleInfo(FileA, "Control", 1, 1, 0, 1, "126", 126.0, false);
+            var channel127 = new IsobaricQuantSampleInfo(FileA, "Control", 1, 1, 0, 2, "127N", 127.0, false);
+
+            group.SamplesForQuantification = [channel126, channel127];
+            group.IntensitiesBySample = new Dictionary<ISampleInfo, double>
+            {
+                { channel126, 500.0 },
+                { channel127, 750.0 }
+            };
+            return group;
+        }
+
+        private static string[] Compose(string[] middle) =>
+            [.. StaticHeader, .. middle, .. TrailingHeader];
+
+        private static string[] ComposeRow(string[] middle) =>
+            [.. StaticRow, .. middle, .. TrailingRow];
+
+        private static void AssertTsv(BioPolymerGroup group, string[] expectedHeader, string[] expectedRow)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(GroupTsv.Header(group).Split('\t'), Is.EqualTo(expectedHeader), "header");
+                Assert.That(GroupTsv.Row(group).Split('\t'), Is.EqualTo(expectedRow), "row");
+            });
+        }
+
+        /// <summary>
+        /// No experimental design: PSMs are grouped by their own file path and only spectral
+        /// count and count-based occupancy are emitted (no intensity columns).
+        /// </summary>
+        [Test]
+        public void NoExperimentalDesign_HeaderAndRowAreUnchanged()
+        {
+            AssertTsv(BuildNoDesignGroup(),
+                Compose(["SpectralCount_goldenA", "CountOccupancy_goldenA"]),
+                ComposeRow(["3", CountOccupancy]));
+        }
+
+        /// <summary>
+        /// Label-free with two conditions and intensities: four columns per sample group.
+        /// goldenB's occupancy fields are empty because its only PSM carries no modification.
+        /// </summary>
+        [Test]
+        public void LabelFreeWithIntensities_HeaderAndRowAreUnchanged()
+        {
+            AssertTsv(BuildLabelFreeGroup(),
+                Compose([
+                    "SpectralCount_goldenA", "Intensity_goldenA", "CountOccupancy_goldenA", "IntensityOccupancy_goldenA",
+                    "SpectralCount_goldenB", "Intensity_goldenB", "CountOccupancy_goldenB", "IntensityOccupancy_goldenB"
+                ]),
+                ComposeRow([
+                    "2", "1000", CountOccupancy, IntensityOccupancy,
+                    "1", "2000", "", ""
+                ]));
+        }
+
+        /// <summary>
+        /// Isobaric (TMT/iTRAQ): one four-column block per channel, ordered by file then channel label.
+        /// Spectral count is per file, so both channels report all three PSMs.
+        /// </summary>
+        [Test]
+        public void Isobaric_HeaderAndRowAreUnchanged()
+        {
+            AssertTsv(BuildIsobaricGroup(),
+                Compose([
+                    "SpectralCount_goldenA_126", "Intensity_goldenA_126", "CountOccupancy_goldenA_126", "IntensityOccupancy_goldenA_126",
+                    "SpectralCount_goldenA_127N", "Intensity_goldenA_127N", "CountOccupancy_goldenA_127N", "IntensityOccupancy_goldenA_127N"
+                ]),
+                ComposeRow([
+                    "3", "500", CountOccupancy, IntensityOccupancy,
+                    "3", "750", CountOccupancy, IntensityOccupancy
+                ]));
+        }
+
+        /// <summary>
+        /// The invariant the column-schema refactor exists to guarantee: header and row always
+        /// carry the same number of fields, for every experimental design.
+        /// </summary>
+        [Test]
+        public void HeaderAndRowFieldCountsAgree(
+            [Values("none", "labelfree", "isobaric")] string design)
+        {
+            var group = design switch
+            {
+                "labelfree" => BuildLabelFreeGroup(),
+                "isobaric" => BuildIsobaricGroup(),
+                _ => BuildNoDesignGroup()
+            };
+
+            Assert.That(GroupTsv.Row(group).Split('\t'), Has.Length.EqualTo(GroupTsv.Header(group).Split('\t').Length),
+                $"Header/row column count mismatch for '{design}' design.");
+        }
+
+        /// <summary>
+        /// A group quantified in only some conditions must still fill the full width of the header.
+        ///
+        /// When each group rendered its own columns, a group with no measured intensity in a
+        /// condition emitted two columns where the header had four, shifting every later field on
+        /// that row. Deriving one schema from the whole dataset makes the widths agree by
+        /// construction: the unquantified condition contributes empty fields instead of vanishing.
+        /// </summary>
+        [Test]
+        public void GroupMissingIntensityInOneCondition_StillMatchesHeaderWidth()
+        {
+            var fileA = new SpectraFileInfo(FileA, "Control", 0, 0, 0);
+            var fileB = new SpectraFileInfo(FileB, "Treatment", 0, 0, 0);
+            var samples = new List<ISampleInfo> { fileA, fileB };
+
+            // Quantified in both conditions.
+            var quantifiedInBoth = BuildGroup([FileA, FileA, FileB], [100.0, 300.0, 50.0]);
+            quantifiedInBoth.SamplesForQuantification = samples;
+            quantifiedInBoth.IntensitiesBySample = new Dictionary<ISampleInfo, double>
+            {
+                { fileA, 1000.0 },
+                { fileB, 2000.0 }
+            };
+
+            // Quantified in Control only — no feature found in Treatment.
+            var quantifiedInOne = BuildGroup([FileA, FileA, FileB], [100.0, 300.0, 50.0]);
+            quantifiedInOne.SamplesForQuantification = samples;
+            quantifiedInOne.IntensitiesBySample = new Dictionary<ISampleInfo, double>
+            {
+                { fileA, 500.0 }
+            };
+
+            BioPolymerGroup[] dataset = [quantifiedInBoth, quantifiedInOne];
+            int headerWidth = GroupTsv.Header(dataset).Split('\t').Length;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(GroupTsv.RowInDataset(quantifiedInBoth, dataset).Split('\t'),
+                    Has.Length.EqualTo(headerWidth), "fully quantified group");
+                Assert.That(GroupTsv.RowInDataset(quantifiedInOne, dataset).Split('\t'),
+                    Has.Length.EqualTo(headerWidth), "partially quantified group");
+            });
+
+            // The Treatment intensity field is present but empty rather than absent.
+            var fields = GroupTsv.RowInDataset(quantifiedInOne, dataset).Split('\t');
+            var headers = GroupTsv.Header(dataset).Split('\t');
+            int treatmentIntensity = Array.IndexOf(headers, "Intensity_goldenB");
+
+            Assert.That(treatmentIntensity, Is.GreaterThan(-1), "Intensity_goldenB column should exist");
+            Assert.That(fields[treatmentIntensity], Is.Empty);
+        }
+
+        /// <summary>
+        /// Maintenance tool, not a check: prints current output so the constants above can be
+        /// regenerated after a deliberate column change.
+        /// </summary>
+        [Test]
+        [Explicit("Harvests current output to re-author the golden constants.")]
+        public void DumpGoldenStrings()
+        {
+            foreach (var (name, group) in new (string, BioPolymerGroup)[]
+                     {
+                         ("NO_DESIGN", BuildNoDesignGroup()),
+                         ("LABEL_FREE", BuildLabelFreeGroup()),
+                         ("ISOBARIC", BuildIsobaricGroup())
+                     })
+            {
+                TestContext.Out.WriteLine($"===={name}_HEADER====");
+                TestContext.Out.WriteLine(GroupTsv.Header(group));
+                TestContext.Out.WriteLine($"===={name}_ROW====");
+                TestContext.Out.WriteLine(GroupTsv.Row(group));
+            }
+        }
+    }
+}

--- a/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerWithSetModsGroupTests.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerWithSetModsGroupTests.cs
@@ -1,0 +1,566 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using MassSpectrometry;
+using NUnit.Framework;
+using Omics;
+using Omics.BioPolymerGroup;
+using Omics.Modifications;
+using Omics.SpectralMatch;
+
+namespace Test.Omics.BioPolymerGroupTests
+{
+    /// <summary>
+    /// Tests for the digestion-product-level group: base-sequence identity, peptide-local
+    /// occupancy, and its TSV schema.
+    /// </summary>
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class BioPolymerWithSetModsGroupTests
+    {
+        private const string File1 = @"C:\pepgroupA.raw";
+        private const string Sequence = "ACDEFK";
+
+        private static MockBioPolymer Parent(string accession = "P00001") =>
+            new("MMMACDEFKGGG", accession);
+
+        private static Modification Mod(string residue, string id, string location)
+        {
+            ModificationMotif.TryGetMotif(residue, out var motif);
+            return new Modification(id, null, "Biological", null, motif, location, null, 79.966);
+        }
+
+        /// <summary>
+        /// ACDEFK sits at residues 4-9 of the parent. Peptide-local mod keys follow the
+        /// AllModsOneIsNterminus convention: 1 is the N-terminus, 2 is residue A, and so on.
+        /// </summary>
+        private static MockBioPolymerWithSetMods Form(
+            IBioPolymer parent, string fullSequence, Dictionary<int, Modification> mods = null) =>
+            new(Sequence, fullSequence, parent, 4, 9, mods);
+
+        private static MockSpectralMatch Psm(
+            string fullSequence, IBioPolymerWithSetMods form, int scan, double? intensity = null)
+        {
+            var psm = new MockSpectralMatch(File1, fullSequence, Sequence, 10.0, scan, new[] { form });
+            if (intensity.HasValue)
+                psm.Intensities = [intensity.Value];
+            return psm;
+        }
+
+        #region Identity and construction
+
+        [Test]
+        public void DistinctPeptidoformsOfOneSequenceAreKeptTogether()
+        {
+            var parent = Parent();
+            var unmodified = Form(parent, "ACDEFK");
+            var phosphorylated = Form(parent, "ACD[Phospho]EFK",
+                new Dictionary<int, Modification> { { 4, Mod("D", "Phospho", "Anywhere.") } });
+
+            var group = new BioPolymerWithSetModsGroup(Sequence, [unmodified, phosphorylated]);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(group.BaseSequence, Is.EqualTo(Sequence));
+                Assert.That(group.Peptidoforms, Has.Count.EqualTo(2),
+                    "both forms should survive; dedup is by FullSequence, not by the element's Equals");
+                Assert.That(group.ParentBioPolymers, Has.Count.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public void RepeatedPeptidoformIsRecordedOnce()
+        {
+            var parent = Parent();
+            var group = new BioPolymerWithSetModsGroup(Sequence,
+                [Form(parent, "ACDEFK"), Form(parent, "ACDEFK")]);
+
+            Assert.That(group.Peptidoforms, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public void SequenceSharedAcrossParentsGivesOneGroupWithBothParents()
+        {
+            var group = new BioPolymerWithSetModsGroup(Sequence,
+                [Form(Parent("P00002"), "ACDEFK"), Form(Parent("P00001"), "ACDEFK")]);
+
+            Assert.That(group.ListOfParentsOrderedByAccession.Select(p => p.Accession).ToArray(),
+                Is.EqualTo(new[] { "P00001", "P00002" }), "parents should be accession-ordered");
+        }
+
+        [Test]
+        public void FormWithDifferentBaseSequenceIsRejected()
+        {
+            var parent = Parent();
+            var wrongForm = new MockBioPolymerWithSetMods("MMMMM", "MMMMM", parent, 1, 5);
+
+            var ex = Assert.Throws<ArgumentException>(
+                () => new BioPolymerWithSetModsGroup(Sequence, [wrongForm]));
+
+            Assert.That(ex.Message, Does.Contain(Sequence).And.Contain("MMMMM"),
+                "message should name both the group's sequence and the offending one");
+        }
+
+        [Test]
+        public void PsmForDifferentSequenceIsRejected()
+        {
+            var parent = Parent();
+            var group = new BioPolymerWithSetModsGroup(Sequence, [Form(parent, "ACDEFK")]);
+            var foreignForm = new MockBioPolymerWithSetMods("MMMMM", "MMMMM", parent, 1, 5);
+            var foreignPsm = new MockSpectralMatch(File1, "MMMMM", "MMMMM", 5.0, 9, new[] { foreignForm });
+
+            Assert.Throws<ArgumentException>(
+                () => group.AllPsmsBelowOnePercentFDR = [foreignPsm]);
+        }
+
+        [Test]
+        public void AmbiguousPsmIsAccepted()
+        {
+            var parent = Parent();
+            var group = new BioPolymerWithSetModsGroup(Sequence, [Form(parent, "ACDEFK")]);
+            var ambiguous = new MockSpectralMatch(File1, null, null, 5.0, 9, Array.Empty<IBioPolymerWithSetMods>());
+
+            Assert.DoesNotThrow(() => group.AllPsmsBelowOnePercentFDR = [ambiguous],
+                "a PSM with no resolved base sequence should not be treated as a mismatch");
+        }
+
+        [Test]
+        public void GroupsAreEqualOnBaseSequence()
+        {
+            var a = new BioPolymerWithSetModsGroup(Sequence, [Form(Parent("P00001"), "ACDEFK")]);
+            var b = new BioPolymerWithSetModsGroup(Sequence, [Form(Parent("P00002"), "ACD[Phospho]EFK")]);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(a, Is.EqualTo(b));
+                Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+            });
+        }
+
+        [Test]
+        public void CreateGroupsBucketsPsmsByBaseSequence()
+        {
+            var parent = Parent();
+            var acdefk = Form(parent, "ACDEFK");
+            var other = new MockBioPolymerWithSetMods("GGG", "GGG", parent, 10, 12);
+
+            var groups = BioPolymerWithSetModsGroup.CreateGroups([
+                Psm("ACDEFK", acdefk, 1),
+                Psm("ACDEFK", acdefk, 2),
+                new MockSpectralMatch(File1, "GGG", "GGG", 4.0, 3, new[] { other })
+            ]);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(groups, Has.Count.EqualTo(2));
+                Assert.That(groups.Single(g => g.BaseSequence == Sequence).AllPsmsBelowOnePercentFDR,
+                    Has.Count.EqualTo(2));
+            });
+        }
+
+        /// <summary>
+        /// An unresolved PSM has an empty base sequence rather than null, so it must be filtered
+        /// out explicitly — otherwise it forms a group keyed on the empty string.
+        /// </summary>
+        [Test]
+        public void CreateGroupsSkipsPsmsWithNoResolvedSequence()
+        {
+            var parent = Parent();
+            var acdefk = Form(parent, "ACDEFK");
+
+            var groups = BioPolymerWithSetModsGroup.CreateGroups([
+                Psm("ACDEFK", acdefk, 1),
+                new MockSpectralMatch(File1, null, null, 3.0, 2, Array.Empty<IBioPolymerWithSetMods>())
+            ]);
+
+            Assert.That(groups.Select(g => g.BaseSequence).ToArray(), Is.EqualTo(new[] { Sequence }));
+        }
+
+        /// <summary>
+        /// A group holding both a confident and an unresolved PSM must still compute occupancy;
+        /// the unresolved one is not evidence for or against a modification at any position.
+        /// </summary>
+        [Test]
+        public void UnresolvedPsmDoesNotBreakOccupancy()
+        {
+            var parent = Parent();
+            var modified = Form(parent, "ACD[Phospho]EFK",
+                new Dictionary<int, Modification> { { 4, Mod("D", "Phospho", "Anywhere.") } });
+
+            var group = new BioPolymerWithSetModsGroup(Sequence, [modified])
+            {
+                AllPsmsBelowOnePercentFDR =
+                [
+                    Psm("ACD[Phospho]EFK", modified, 1),
+                    new MockSpectralMatch(File1, null, null, 3.0, 2, Array.Empty<IBioPolymerWithSetMods>())
+                ]
+            };
+
+            group.PopulateSampleGroupResults();
+            var occupancy = group.SampleGroupResults.Single().DigestionProductOccupancy[Sequence];
+
+            Assert.That(occupancy[4].Single().ToModInfoString(), Does.Contain("1/1"),
+                "the unresolved PSM should not inflate the denominator");
+        }
+
+        #endregion
+
+        #region Occupancy in peptide-local coordinates
+
+        /// <summary>
+        /// Positions are relative to the peptide, not the parent. ACDEFK starts at residue 4 of the
+        /// parent, so a protein-level report would place these mods 3 residues higher.
+        /// </summary>
+        [Test]
+        [TestCase(1, "pos0", TestName = "Occupancy_NTerminalModReportsPos0")]
+        [TestCase(4, "pos3", TestName = "Occupancy_InternalModReportsPeptideResidue")]
+        [TestCase(8, "pos7", TestName = "Occupancy_CTerminalModReportsPastLastResidue")]
+        public void OccupancyUsesPeptideLocalPositions(int modKey, string expectedPosition)
+        {
+            var parent = Parent();
+            var modified = Form(parent, $"modified{modKey}",
+                new Dictionary<int, Modification> { { modKey, Mod("D", "Phospho", "Anywhere.") } });
+            var unmodified = Form(parent, "ACDEFK");
+
+            var group = new BioPolymerWithSetModsGroup(Sequence, [modified, unmodified])
+            {
+                AllPsmsBelowOnePercentFDR =
+                [
+                    Psm($"modified{modKey}", modified, 1),
+                    Psm("ACDEFK", unmodified, 2)
+                ]
+            };
+
+            group.PopulateSampleGroupResults();
+            var occupancy = group.SampleGroupResults.Single().DigestionProductOccupancy[Sequence];
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(occupancy, Does.ContainKey(modKey));
+                Assert.That(occupancy[modKey].Single().ToModInfoString(),
+                    Does.StartWith(expectedPosition).And.Contain("1/2"),
+                    "one of the two PSMs carries the mod");
+            });
+        }
+
+        [Test]
+        public void AllUnmodifiedYieldsNoOccupancyRatherThanZeroDivision()
+        {
+            var parent = Parent();
+            var unmodified = Form(parent, "ACDEFK");
+
+            var group = new BioPolymerWithSetModsGroup(Sequence, [unmodified])
+            {
+                AllPsmsBelowOnePercentFDR = [Psm("ACDEFK", unmodified, 1), Psm("ACDEFK", unmodified, 2)]
+            };
+
+            group.PopulateSampleGroupResults();
+
+            Assert.That(group.SampleGroupResults.Single().DigestionProductOccupancy, Is.Empty);
+        }
+
+        [Test]
+        public void PsmWhoseFormCannotBeResolvedStillCountsTowardTheDenominator()
+        {
+            var parent = Parent();
+            var modified = Form(parent, "ACD[Phospho]EFK",
+                new Dictionary<int, Modification> { { 4, Mod("D", "Phospho", "Anywhere.") } });
+
+            // Second PSM reports a full sequence that matches none of the group's forms, so it
+            // cannot contribute a modification — but it is still an observation of this sequence.
+            var unresolvable = new MockSpectralMatch(File1, "ACD[Unknown]EFK", Sequence, 9.0, 2,
+                Array.Empty<IBioPolymerWithSetMods>());
+
+            var group = new BioPolymerWithSetModsGroup(Sequence, [modified])
+            {
+                AllPsmsBelowOnePercentFDR = [Psm("ACD[Phospho]EFK", modified, 1), unresolvable]
+            };
+
+            group.PopulateSampleGroupResults();
+            var occupancy = group.SampleGroupResults.Single().DigestionProductOccupancy[Sequence];
+
+            Assert.That(occupancy[4].Single().ToModInfoString(), Does.Contain("1/2"));
+        }
+
+        /// <summary>
+        /// A sample group containing only unresolved PSMs has nothing to attribute a modification
+        /// to, which is not an error. Occupancy runs per sample group, so with no experimental
+        /// design a single unresolved PSM alone in its own file forms such a bucket — and throwing
+        /// there would take down report generation for the whole file.
+        /// </summary>
+        [Test]
+        public void SampleGroupOfOnlyUnresolvedPsmsYieldsNoOccupancy()
+        {
+            var parent = Parent();
+            var modified = Form(parent, "ACD[Phospho]EFK",
+                new Dictionary<int, Modification> { { 4, Mod("D", "Phospho", "Anywhere.") } });
+
+            var group = new BioPolymerWithSetModsGroup(Sequence, [modified])
+            {
+                AllPsmsBelowOnePercentFDR =
+                [
+                    Psm("ACD[Phospho]EFK", modified, 1),
+                    // Its own source file, so it lands in a bucket by itself.
+                    new MockSpectralMatch(@"C:\other.raw", null, null, 3.0, 2, Array.Empty<IBioPolymerWithSetMods>())
+                ]
+            };
+
+            Assert.DoesNotThrow(() => group.PopulateSampleGroupResults());
+
+            var buckets = group.SampleGroupResults;
+            Assert.Multiple(() =>
+            {
+                Assert.That(buckets, Has.Count.EqualTo(2), "one bucket per source file");
+                Assert.That(buckets.Single(b => b.Label == "other").DigestionProductOccupancy, Is.Empty);
+                Assert.That(buckets.Single(b => b.Label == "pepgroupA").DigestionProductOccupancy, Is.Not.Empty);
+            });
+        }
+
+        /// <summary>
+        /// Directly: an all-unresolved list is an empty result, not an exception.
+        /// </summary>
+        [Test]
+        public void CalculatorReturnsEmptyForUnresolvedOnlyInput()
+        {
+            var unresolved = new MockSpectralMatch(@"C:\x.raw", null, null, 1.0, 1, Array.Empty<IBioPolymerWithSetMods>());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ModificationOccupancyCalculator.CalculateDigestionProductLevelOccupancy([unresolved]), Is.Empty);
+                Assert.That(ModificationOccupancyCalculator.CalculateDigestionProductLevelOccupancy([]), Is.Empty);
+            });
+        }
+
+        /// <summary>
+        /// The setter validates its input, so it must not then hold a reference the caller can keep
+        /// mutating — otherwise a foreign PSM added afterwards is filed under this group's sequence
+        /// and reports a modification at a residue that sequence does not have.
+        /// </summary>
+        [Test]
+        public void PsmsAreCopiedSoLaterCallerMutationCannotBypassValidation()
+        {
+            var parent = Parent();
+            var form = Form(parent, "ACDEFK");
+            var callersSet = new HashSet<ISpectralMatch> { Psm("ACDEFK", form, 1) };
+
+            var group = new BioPolymerWithSetModsGroup(Sequence, [form])
+            {
+                AllPsmsBelowOnePercentFDR = callersSet
+            };
+
+            var foreignForm = new MockBioPolymerWithSetMods("MMMMM", "MMMMM", parent, 1, 5);
+            callersSet.Add(new MockSpectralMatch(File1, "MMMMM", "MMMMM", 5.0, 9, new[] { foreignForm }));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(group.AllPsmsBelowOnePercentFDR, Has.Count.EqualTo(1),
+                    "the group must not see the PSM added to the caller's set after assignment");
+                Assert.That(group.AllPsmsBelowOnePercentFDR.Select(p => p.BaseSequence), Is.All.EqualTo(Sequence));
+            });
+        }
+
+        [Test]
+        public void EmptyPsmSetProducesNoSampleGroups()
+        {
+            var group = new BioPolymerWithSetModsGroup(Sequence, [Form(Parent(), "ACDEFK")]);
+
+            group.PopulateSampleGroupResults();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(group.SampleGroupResults, Is.Empty);
+                Assert.That(() => GroupTsv.PeptideRow(group), Throws.Nothing);
+            });
+        }
+
+        [Test]
+        public void SinglePsmGivesFullOccupancy()
+        {
+            var parent = Parent();
+            var modified = Form(parent, "ACD[Phospho]EFK",
+                new Dictionary<int, Modification> { { 4, Mod("D", "Phospho", "Anywhere.") } });
+
+            var group = new BioPolymerWithSetModsGroup(Sequence, [modified])
+            {
+                AllPsmsBelowOnePercentFDR = [Psm("ACD[Phospho]EFK", modified, 1)]
+            };
+
+            group.PopulateSampleGroupResults();
+            var occupancy = group.SampleGroupResults.Single().DigestionProductOccupancy[Sequence];
+
+            Assert.That(occupancy[4].Single().CountBasedOccupancy, Is.EqualTo(1.0));
+        }
+
+        [Test]
+        public void ScoreTakesTheBestPsm()
+        {
+            var parent = Parent();
+            var form = Form(parent, "ACDEFK");
+            var group = new BioPolymerWithSetModsGroup(Sequence, [form]);
+
+            group.AllPsmsBelowOnePercentFDR =
+            [
+                new MockSpectralMatch(File1, "ACDEFK", Sequence, 4.0, 1, new[] { form }),
+                new MockSpectralMatch(File1, "ACDEFK", Sequence, 12.0, 2, new[] { form })
+            ];
+            group.Score();
+
+            Assert.That(group.BestPsmScore, Is.EqualTo(12.0));
+        }
+
+        [Test]
+        public void ScoreOnEmptyGroupIsZero()
+        {
+            var group = new BioPolymerWithSetModsGroup(Sequence, [Form(Parent(), "ACDEFK")]);
+
+            group.Score();
+
+            Assert.That(group.BestPsmScore, Is.Zero);
+        }
+
+        #endregion
+
+        #region Schema
+
+        private static BioPolymerWithSetModsGroup QuantifiedGroup(
+            string accession, IReadOnlyDictionary<ISampleInfo, double> intensities, List<ISampleInfo> samples)
+        {
+            var parent = Parent(accession);
+            var modified = Form(parent, "ACD[Phospho]EFK",
+                new Dictionary<int, Modification> { { 4, Mod("D", "Phospho", "Anywhere.") } });
+
+            return new BioPolymerWithSetModsGroup(Sequence, [modified])
+            {
+                AllPsmsBelowOnePercentFDR = [Psm("ACD[Phospho]EFK", modified, 1, 100.0)],
+                SamplesForQuantification = samples,
+                IntensitiesBySample = intensities.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
+            };
+        }
+
+        [Test]
+        public void SchemaOmitsParentLevelColumns()
+        {
+            var group = new BioPolymerWithSetModsGroup(Sequence, [Form(Parent(), "ACDEFK")]);
+            var headers = GroupTsv.PeptideHeader(group).Split('\t');
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(headers, Does.Contain("Base Sequence"));
+                Assert.That(headers, Does.Contain("Peptidoforms"));
+                Assert.That(headers, Does.Not.Contain("Gene"));
+                Assert.That(headers, Does.Not.Contain("Organism"));
+                Assert.That(headers, Does.Not.Contain("Sequence Coverage"));
+            });
+        }
+
+        [Test]
+        public void ParentAccessionsAndResidueColumnsLineUp()
+        {
+            var group = new BioPolymerWithSetModsGroup(Sequence,
+                [Form(Parent("P00002"), "ACDEFK"), Form(Parent("P00001"), "ACDEFK")]);
+
+            var headers = GroupTsv.PeptideHeader(group).Split('\t');
+            var fields = GroupTsv.PeptideRow(group).Split('\t');
+
+            string Field(string header) => fields[Array.IndexOf(headers, header)];
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(Field("Parent Accessions"), Is.EqualTo("P00001|P00002"));
+                Assert.That(Field("Start Residue in Parent"), Is.EqualTo("4|4"));
+                Assert.That(Field("End Residue in Parent"), Is.EqualTo("9|9"));
+            });
+        }
+
+        /// <summary>
+        /// A sequence can occur more than once in the same protein — repeat domains in histones,
+        /// collagens and mucins are ordinary, and repeats are exactly where site-level occupancy
+        /// interpretation matters most. Deduplicating on (form, parent) alone kept whichever
+        /// occurrence was seen first and dropped the rest from the provenance columns silently.
+        /// </summary>
+        [Test]
+        public void SequenceRepeatedWithinOneParentReportsEveryOccurrence()
+        {
+            // ACDEFK sits at residues 4-9 and again at 13-18.
+            var parent = new MockBioPolymer("MMMACDEFKGGGACDEFKGGG", "P00001");
+            var atFirst = new MockBioPolymerWithSetMods(Sequence, Sequence, parent, 4, 9);
+            var atSecond = new MockBioPolymerWithSetMods(Sequence, Sequence, parent, 13, 18);
+
+            var group = new BioPolymerWithSetModsGroup(Sequence, [atFirst, atSecond]);
+
+            var headers = GroupTsv.PeptideHeader(group).Split('\t');
+            var fields = GroupTsv.PeptideRow(group).Split('\t');
+            string Field(string header) => fields[Array.IndexOf(headers, header)];
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(group.Peptidoforms, Has.Count.EqualTo(2), "both occurrences are distinct observations");
+
+                // The accession repeats so the three lists stay readable entry-for-entry.
+                Assert.That(Field("Parent Accessions"), Is.EqualTo("P00001|P00001"));
+                Assert.That(Field("Start Residue in Parent"), Is.EqualTo("4|13"));
+                Assert.That(Field("End Residue in Parent"), Is.EqualTo("9|18"));
+
+                // Still one distinct parent.
+                Assert.That(Field("Number of Parents"), Is.EqualTo("1"));
+            });
+        }
+
+        [Test]
+        public void HeaderAndRowFieldCountsAgree()
+        {
+            var file = new SpectraFileInfo(File1, "Control", 0, 0, 0);
+            var samples = new List<ISampleInfo> { file };
+            var group = QuantifiedGroup("P00001",
+                new Dictionary<ISampleInfo, double> { { file, 1000.0 } }, samples);
+
+            Assert.That(GroupTsv.PeptideRow(group).Split('\t'),
+                Has.Length.EqualTo(GroupTsv.PeptideHeader(group).Split('\t').Length));
+        }
+
+        /// <summary>
+        /// The same dataset-level guarantee the parent-level report has: a group quantified in only
+        /// some conditions still fills the header's width.
+        /// </summary>
+        [Test]
+        public void GroupMissingIntensityInOneConditionStillMatchesHeaderWidth()
+        {
+            var fileA = new SpectraFileInfo(File1, "Control", 0, 0, 0);
+            var fileB = new SpectraFileInfo(@"C:\pepgroupB.raw", "Treatment", 0, 0, 0);
+            var samples = new List<ISampleInfo> { fileA, fileB };
+
+            var inBoth = QuantifiedGroup("P00001",
+                new Dictionary<ISampleInfo, double> { { fileA, 1000.0 }, { fileB, 2000.0 } }, samples);
+            var inOne = QuantifiedGroup("P00002",
+                new Dictionary<ISampleInfo, double> { { fileA, 500.0 } }, samples);
+
+            BioPolymerWithSetModsGroup[] dataset = [inBoth, inOne];
+            int headerWidth = GroupTsv.PeptideHeader(dataset).Split('\t').Length;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(GroupTsv.PeptideRowInDataset(inBoth, dataset).Split('\t'), Has.Length.EqualTo(headerWidth));
+                Assert.That(GroupTsv.PeptideRowInDataset(inOne, dataset).Split('\t'), Has.Length.EqualTo(headerWidth));
+            });
+        }
+
+        [Test]
+        public void OccupancyColumnCarriesPeptideLocalPosition()
+        {
+            var file = new SpectraFileInfo(File1, "Control", 0, 0, 0);
+            var samples = new List<ISampleInfo> { file };
+            var group = QuantifiedGroup("P00001",
+                new Dictionary<ISampleInfo, double> { { file, 1000.0 } }, samples);
+
+            var headers = GroupTsv.PeptideHeader(group).Split('\t');
+            var fields = GroupTsv.PeptideRow(group).Split('\t');
+            var occupancy = fields[Array.IndexOf(headers, "CountOccupancy_pepgroupA")];
+
+            // Peptide residue 3, not parent residue 6.
+            Assert.That(occupancy, Does.StartWith("pos3").And.Contain("Phospho"));
+        }
+
+        #endregion
+    }
+}

--- a/mzLib/Test/Omics/BioPolymerGroupTests/ExternalProteinGroupTests.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/ExternalProteinGroupTests.cs
@@ -43,7 +43,7 @@ namespace Test.Omics.BioPolymerGroupTests
 
             group.CalculateSequenceCoverage();
 
-            var output = group.ToString();
+            var output = GroupTsv.Row(group);
             // Full coverage should show 1.0 (or 100%)
             Assert.That(output, Does.Contain("1"));
         }
@@ -68,7 +68,7 @@ namespace Test.Omics.BioPolymerGroupTests
 
             group.CalculateSequenceCoverage();
 
-            var output = group.ToString();
+            var output = GroupTsv.Row(group);
             Assert.That(output, Does.Contain("MEDEEK"));  // Covered = uppercase
             Assert.That(output, Does.Contain("peptide")); // Uncovered = lowercase
         }
@@ -133,8 +133,8 @@ namespace Test.Omics.BioPolymerGroupTests
             group.SamplesForQuantification = new List<ISampleInfo> { sample };
             group.IntensitiesBySample = new Dictionary<ISampleInfo, double> { { sample, 12345.67 } };
 
-            var header = group.GetTabSeparatedHeader();
-            var output = group.ToString();
+            var header = GroupTsv.Header(group);
+            var output = GroupTsv.Row(group);
 
             Assert.Multiple(() =>
             {
@@ -161,18 +161,18 @@ namespace Test.Omics.BioPolymerGroupTests
                 new HashSet<IBioPolymerWithSetMods>(),
                 new HashSet<IBioPolymerWithSetMods>());
 
-            var originalMaxLength = BioPolymerGroup.MaxStringLength;
+            var originalMaxLength = BioPolymerGroupTsvSchema.MaxStringLength;
             try
             {
-                BioPolymerGroup.MaxStringLength = 100;
-                var output = group.ToString();
+                BioPolymerGroupTsvSchema.MaxStringLength = 100;
+                var output = GroupTsv.Row(group);
 
                 // Output should not contain the full 50,000 character sequence
                 Assert.That(output.Length, Is.LessThan(longSequence.Length));
             }
             finally
             {
-                BioPolymerGroup.MaxStringLength = originalMaxLength;
+                BioPolymerGroupTsvSchema.MaxStringLength = originalMaxLength;
             }
         }
 
@@ -189,15 +189,15 @@ namespace Test.Omics.BioPolymerGroupTests
                 new HashSet<IBioPolymerWithSetMods>(),
                 new HashSet<IBioPolymerWithSetMods>());
 
-            var originalMaxLength = BioPolymerGroup.MaxStringLength;
+            var originalMaxLength = BioPolymerGroupTsvSchema.MaxStringLength;
             try
             {
-                BioPolymerGroup.MaxStringLength = 0;
-                Assert.DoesNotThrow(() => group.ToString());
+                BioPolymerGroupTsvSchema.MaxStringLength = 0;
+                Assert.DoesNotThrow(() => GroupTsv.Row(group));
             }
             finally
             {
-                BioPolymerGroup.MaxStringLength = originalMaxLength;
+                BioPolymerGroupTsvSchema.MaxStringLength = originalMaxLength;
             }
         }
 

--- a/mzLib/Test/Omics/BioPolymerGroupTests/ExternalProteinGroupTests.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/ExternalProteinGroupTests.cs
@@ -161,10 +161,10 @@ namespace Test.Omics.BioPolymerGroupTests
                 new HashSet<IBioPolymerWithSetMods>(),
                 new HashSet<IBioPolymerWithSetMods>());
 
-            var originalMaxLength = BioPolymerGroupTsvSchema.MaxStringLength;
+            var originalMaxLength = TsvWriter.MaxFieldLength;
             try
             {
-                BioPolymerGroupTsvSchema.MaxStringLength = 100;
+                TsvWriter.MaxFieldLength = 100;
                 var output = GroupTsv.Row(group);
 
                 // Output should not contain the full 50,000 character sequence
@@ -172,7 +172,7 @@ namespace Test.Omics.BioPolymerGroupTests
             }
             finally
             {
-                BioPolymerGroupTsvSchema.MaxStringLength = originalMaxLength;
+                TsvWriter.MaxFieldLength = originalMaxLength;
             }
         }
 
@@ -189,15 +189,15 @@ namespace Test.Omics.BioPolymerGroupTests
                 new HashSet<IBioPolymerWithSetMods>(),
                 new HashSet<IBioPolymerWithSetMods>());
 
-            var originalMaxLength = BioPolymerGroupTsvSchema.MaxStringLength;
+            var originalMaxLength = TsvWriter.MaxFieldLength;
             try
             {
-                BioPolymerGroupTsvSchema.MaxStringLength = 0;
+                TsvWriter.MaxFieldLength = 0;
                 Assert.DoesNotThrow(() => GroupTsv.Row(group));
             }
             finally
             {
-                BioPolymerGroupTsvSchema.MaxStringLength = originalMaxLength;
+                TsvWriter.MaxFieldLength = originalMaxLength;
             }
         }
 

--- a/mzLib/Test/Omics/BioPolymerGroupTests/GroupTsv.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/GroupTsv.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Omics.BioPolymerGroup;
+
+namespace Test.Omics.BioPolymerGroupTests
+{
+    /// <summary>
+    /// Renders groups through the production schema and writer.
+    ///
+    /// Groups no longer format themselves, so tests go through the same path real output does.
+    /// The single-group overloads build a schema from just that group, which matches how these
+    /// tests were originally written; <see cref="RowInDataset"/> exists for the cases that need a
+    /// row rendered against a schema derived from several groups.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    internal static class GroupTsv
+    {
+        /// <summary>Header line for a file containing the given groups.</summary>
+        public static string Header(params BioPolymerGroup[] groups) =>
+            TsvWriter.HeaderLine(BioPolymerGroupTsvSchema.For(groups));
+
+        /// <summary>Row for a group written on its own.</summary>
+        public static string Row(BioPolymerGroup group) =>
+            TsvWriter.RowLine(BioPolymerGroupTsvSchema.For([group]), group);
+
+        /// <summary>Row for one group rendered against the schema of the whole dataset.</summary>
+        public static string RowInDataset(BioPolymerGroup group, IReadOnlyCollection<BioPolymerGroup> dataset) =>
+            TsvWriter.RowLine(BioPolymerGroupTsvSchema.For(dataset), group);
+    }
+}

--- a/mzLib/Test/Omics/BioPolymerGroupTests/GroupTsv.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/GroupTsv.cs
@@ -26,5 +26,18 @@ namespace Test.Omics.BioPolymerGroupTests
         /// <summary>Row for one group rendered against the schema of the whole dataset.</summary>
         public static string RowInDataset(BioPolymerGroup group, IReadOnlyCollection<BioPolymerGroup> dataset) =>
             TsvWriter.RowLine(BioPolymerGroupTsvSchema.For(dataset), group);
+
+        /// <summary>Header line for a file containing the given digestion-product groups.</summary>
+        public static string PeptideHeader(params BioPolymerWithSetModsGroup[] groups) =>
+            TsvWriter.HeaderLine(BioPolymerWithSetModsGroupTsvSchema.For(groups));
+
+        /// <summary>Row for a digestion-product group written on its own.</summary>
+        public static string PeptideRow(BioPolymerWithSetModsGroup group) =>
+            TsvWriter.RowLine(BioPolymerWithSetModsGroupTsvSchema.For([group]), group);
+
+        /// <summary>Row for one digestion-product group rendered against the whole dataset's schema.</summary>
+        public static string PeptideRowInDataset(
+            BioPolymerWithSetModsGroup group, IReadOnlyCollection<BioPolymerWithSetModsGroup> dataset) =>
+            TsvWriter.RowLine(BioPolymerWithSetModsGroupTsvSchema.For(dataset), group);
     }
 }

--- a/mzLib/Test/Omics/BioPolymerGroupTests/SampleGroupColumnTests.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/SampleGroupColumnTests.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using MassSpectrometry;
+using NUnit.Framework;
+using Omics;
+using Omics.BioPolymerGroup;
+using Omics.Modifications;
+using Omics.SpectralMatch;
+
+namespace Test.Omics.BioPolymerGroupTests
+{
+    /// <summary>
+    /// Tests for how the dataset's sample groups become quantification columns.
+    /// </summary>
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class SampleGroupColumnTests
+    {
+        private static BioPolymerGroup Group(string accession, params string[] psmFiles)
+        {
+            var protein = new MockBioPolymer("ACDEFGHIK", accession);
+            var form = new MockBioPolymerWithSetMods("ACDEF", "ACDEF", protein, 1, 5);
+
+            var group = new BioPolymerGroup(
+                new HashSet<IBioPolymer> { protein },
+                new HashSet<IBioPolymerWithSetMods> { form },
+                new HashSet<IBioPolymerWithSetMods> { form });
+
+            group.AllPsmsBelowOnePercentFDR = [.. psmFiles.Select((f, i) =>
+                (ISpectralMatch)new MockSpectralMatch(f, "ACDEF", "ACDEF", 10.0, i + 1, new[] { form }))];
+
+            return group;
+        }
+
+        /// <summary>
+        /// Sample group labels are not unique. SampleGroupBuilder names a group after its first file
+        /// whenever conditions are undefined or the design looks like SILAC, so two files sharing a
+        /// filename in different directories produce two sample groups with the same label.
+        ///
+        /// Each must still get its own column, carrying its own values. Collapsing them by label
+        /// would drop the second group's counts and intensities without any sign in the output.
+        /// </summary>
+        [Test]
+        public void SampleGroupsSharingALabelEachKeepTheirOwnColumns()
+        {
+            var run1 = new SpectraFileInfo(@"C:\run1\sample.raw", "Control", 0, 0, 0);
+            var run2 = new SpectraFileInfo(@"C:\run2\sample.raw", "Treatment", 0, 0, 0);
+
+            var group = Group("P00001", @"C:\run1\sample.raw", @"C:\run2\sample.raw", @"C:\run2\sample.raw");
+            group.SamplesForQuantification = [run1, run2];
+            group.IntensitiesBySample = new Dictionary<ISampleInfo, double> { { run1, 111.0 }, { run2, 999.0 } };
+
+            var headers = GroupTsv.Header(group).Split('\t');
+            var fields = GroupTsv.Row(group).Split('\t');
+
+            string Field(string columnName) => fields[Array.IndexOf(headers, columnName)];
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(fields, Has.Length.EqualTo(headers.Length));
+
+                Assert.That(Field("SpectralCount_run1_sample"), Is.EqualTo("1"));
+                Assert.That(Field("SpectralCount_run2_sample"), Is.EqualTo("2"));
+                Assert.That(Field("Intensity_run1_sample"), Is.EqualTo("111"));
+                Assert.That(Field("Intensity_run2_sample"), Is.EqualTo("999"));
+            });
+        }
+
+        /// <summary>
+        /// The case a single-group test cannot reach: two records observed in DIFFERENT subsets of
+        /// same-named files.
+        ///
+        /// Matching sample groups to columns by position within a record is wrong, because a record
+        /// only has sample groups for the files it was observed in. A record seen only in runB has
+        /// runB at index 0, where a record seen in both has runA — so runB's counts get filed under
+        /// runA's column. Matching on file identity is what makes this correct.
+        /// </summary>
+        [Test]
+        public void RecordsObservedInDifferentFilesAreNotCrossAttributed()
+        {
+            const string RunA = @"C:\runA\sample.raw";
+            const string RunB = @"C:\runB\sample.raw";
+
+            // Seen in both files; seen only in runB.
+            var inBoth = Group("P00001", RunA, RunA, RunB);
+            var runBOnly = Group("P00002", RunB, RunB, RunB, RunB);
+
+            BioPolymerGroup[] dataset = [inBoth, runBOnly];
+            var headers = GroupTsv.Header(dataset).Split('\t');
+
+            string CountFor(BioPolymerGroup g, string columnName)
+            {
+                var fields = GroupTsv.RowInDataset(g, dataset).Split('\t');
+                return fields[Array.IndexOf(headers, columnName)];
+            }
+
+            Assert.Multiple(() =>
+            {
+                // Colliding labels are widened by parent directory, so the columns are tellable apart.
+                Assert.That(headers, Does.Contain("SpectralCount_runA_sample"));
+                Assert.That(headers, Does.Contain("SpectralCount_runB_sample"));
+
+                Assert.That(CountFor(inBoth, "SpectralCount_runA_sample"), Is.EqualTo("2"));
+                Assert.That(CountFor(inBoth, "SpectralCount_runB_sample"), Is.EqualTo("1"));
+
+                // The regression: these were "4" and "" — runB's spectra filed under runA.
+                Assert.That(CountFor(runBOnly, "SpectralCount_runA_sample"), Is.Empty,
+                    "not observed in runA, so its runA cell must be blank");
+                Assert.That(CountFor(runBOnly, "SpectralCount_runB_sample"), Is.EqualTo("4"));
+            });
+        }
+
+        /// <summary>
+        /// Column names must be unique within a file, or a consumer reading by name cannot tell two
+        /// samples apart — and different tools disagree about how to mangle duplicates.
+        /// </summary>
+        [Test]
+        public void CollidingLabelsProduceDistinctColumnNames()
+        {
+            var dataset = new[]
+            {
+                Group("P00001", @"C:\runA\sample.raw", @"C:\runB\sample.raw")
+            };
+
+            var headers = GroupTsv.Header(dataset).Split('\t');
+            var quantHeaders = headers.Where(h => h.StartsWith("SpectralCount_")).ToArray();
+
+            Assert.That(quantHeaders, Is.Unique);
+            Assert.That(quantHeaders, Is.EqualTo(new[] { "SpectralCount_runA_sample", "SpectralCount_runB_sample" }));
+        }
+
+        /// <summary>
+        /// A sample group spans fractions and technical replicates, which are routinely stored one
+        /// per directory under the same file name. Keying the group's per-file collections by file
+        /// name therefore collides: the intensity dictionary silently kept one of the two, and
+        /// FilesInGroup threw outright, taking down report generation.
+        /// </summary>
+        [Test]
+        public void FractionsSharingAFileNameDoNotCollide()
+        {
+            var protein = new MockBioPolymer("ACDEFGHIK", "P00001");
+            var form = new MockBioPolymerWithSetMods("ACDEF", "ACDEF", protein, 1, 5);
+            var group = new BioPolymerGroup([protein], [form], [form]);
+
+            // (path, condition, biorep, techrep, fraction) — one sample, two fractions, same name.
+            var fraction1 = new SpectraFileInfo(@"C:\frac1\sample.raw", "", 0, 0, 0);
+            var fraction2 = new SpectraFileInfo(@"C:\frac2\sample.raw", "", 0, 0, 1);
+
+            group.AllPsmsBelowOnePercentFDR =
+            [
+                new MockSpectralMatch(fraction1.FullFilePathWithExtension, "ACDEF", "ACDEF", 10.0, 1, new[] { form }),
+                new MockSpectralMatch(fraction2.FullFilePathWithExtension, "ACDEF", "ACDEF", 10.0, 2, new[] { form })
+            ];
+            group.SamplesForQuantification = [fraction1, fraction2];
+            group.IntensitiesBySample = new Dictionary<ISampleInfo, double> { { fraction1, 111.0 }, { fraction2, 999.0 } };
+
+            Assert.DoesNotThrow(() => group.PopulateSampleGroupResults());
+
+            var result = group.SampleGroupResults.Single();
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.FilesInGroup, Has.Count.EqualTo(2), "both fractions belong to the group");
+                Assert.That(result.Intensity, Is.EqualTo(1110.0), "fraction intensities sum rather than overwrite");
+            });
+        }
+
+        /// <summary>
+        /// Intensity-based stoichiometry needs measured intensity behind it. A site with none has a
+        /// zero denominator, and printing it produced "fraction=0.0000(0/0)" — a measured-looking
+        /// zero — in rows whose Intensity cell was blank, so the two columns contradicted each other.
+        /// Count-based occupancy is unaffected: its denominator is the observation count.
+        /// </summary>
+        [Test]
+        public void IntensityOccupancyIsBlankWithoutMeasuredIntensity()
+        {
+            ModificationMotif.TryGetMotif("D", out var motif);
+            var phospho = new Modification("Phospho", null, "Biological", null, motif, "Anywhere.", null, 79.966);
+            var file = new SpectraFileInfo(@"C:\d\a.raw", "Control", 0, 0, 0);
+
+            BioPolymerGroup Modified(string accession, double? psmIntensity, double? sampleIntensity)
+            {
+                var protein = new MockBioPolymer("ACDEFGHIK", accession);
+                var form = new MockBioPolymerWithSetMods("ACDEF", "ACD[Phospho]EF", protein, 1, 5,
+                    new Dictionary<int, Modification> { { 4, phospho } });
+
+                var group = new BioPolymerGroup([protein], [form], [form]);
+                var psm = new MockSpectralMatch(file.FullFilePathWithExtension, "ACD[Phospho]EF", "ACDEF", 10.0, 1, new[] { form });
+                if (psmIntensity.HasValue) psm.Intensities = [psmIntensity.Value];
+
+                group.AllPsmsBelowOnePercentFDR = [psm];
+                group.SamplesForQuantification = [file];
+                if (sampleIntensity.HasValue)
+                    group.IntensitiesBySample = new Dictionary<ISampleInfo, double> { { file, sampleIntensity.Value } };
+
+                return group;
+            }
+
+            // One group carries intensity, so the dataset gets intensity columns; the other has none.
+            var quantified = Modified("P00001", 500.0, 1000.0);
+            var unquantified = Modified("P00002", null, null);
+
+            BioPolymerGroup[] dataset = [quantified, unquantified];
+            var headers = GroupTsv.Header(dataset).Split('\t');
+
+            string Field(BioPolymerGroup g, string column) =>
+                GroupTsv.RowInDataset(g, dataset).Split('\t')[Array.IndexOf(headers, column)];
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(Field(unquantified, "Intensity_a"), Is.Empty);
+                Assert.That(Field(unquantified, "IntensityOccupancy_a"), Is.Empty,
+                    "no measured intensity means no stoichiometry to report");
+
+                // Count-based occupancy is still reported — the observation is real.
+                Assert.That(Field(unquantified, "CountOccupancy_a"), Does.Contain("1/1"));
+
+                // The quantified group is untouched.
+                Assert.That(Field(quantified, "IntensityOccupancy_a"), Does.Contain("Phospho"));
+            });
+        }
+
+        /// <summary>
+        /// Widening is itself a source of collisions: the name a widened column takes can be the
+        /// plain label of a different file that was never part of that collision. Resolving each
+        /// label group in isolation therefore reintroduces the duplicate it set out to remove.
+        /// </summary>
+        [Test]
+        public void WidenedNameDoesNotCollideWithAnotherFilesPlainLabel()
+        {
+            // run1\sample.raw and run2\sample.raw collide and widen to run1_sample / run2_sample.
+            // x\run1_sample.raw is not part of that collision and would otherwise stay run1_sample.
+            var dataset = new[]
+            {
+                Group("P00001", @"C:\run1\sample.raw", @"C:\run2\sample.raw", @"C:\x\run1_sample.raw")
+            };
+
+            var quantHeaders = GroupTsv.Header(dataset).Split('\t')
+                .Where(h => h.StartsWith("SpectralCount_"))
+                .ToArray();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(quantHeaders, Is.Unique);
+                Assert.That(quantHeaders, Has.Length.EqualTo(3));
+            });
+        }
+
+        /// <summary>
+        /// Widening applies only where it is needed: labels that were already unique are untouched,
+        /// so output does not change for datasets that were never ambiguous.
+        /// </summary>
+        [Test]
+        public void NonCollidingLabelsAreLeftAlone()
+        {
+            var dataset = new[]
+            {
+                Group("P00001", @"C:\runA\alpha.raw", @"C:\runB\beta.raw")
+            };
+
+            var headers = GroupTsv.Header(dataset).Split('\t');
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(headers, Does.Contain("SpectralCount_alpha"));
+                Assert.That(headers, Does.Contain("SpectralCount_beta"));
+            });
+        }
+
+        /// <summary>
+        /// The schema is a snapshot of the dataset's experimental design, so it has to be built
+        /// after quantification state is final. Changing samples afterwards cannot corrupt row
+        /// width — rows stay aligned to the schema they are rendered against — but the new sample
+        /// simply has no column, so build the schema last.
+        /// </summary>
+        [Test]
+        public void RowStaysAlignedWhenQuantificationChangesAfterSchemaIsBuilt()
+        {
+            var fileA = new SpectraFileInfo(@"C:\a.raw", "Control", 0, 0, 0);
+            var fileB = new SpectraFileInfo(@"C:\b.raw", "Treatment", 0, 0, 0);
+
+            var group = Group("P00001", @"C:\a.raw");
+            group.SamplesForQuantification = [fileA];
+
+            var schema = BioPolymerGroupTsvSchema.For([group]);
+            int headerWidth = TsvWriter.HeaderLine(schema).Split('\t').Length;
+
+            group.SamplesForQuantification = [fileA, fileB];
+
+            Assert.That(TsvWriter.RowLine(schema, group).Split('\t'), Has.Length.EqualTo(headerWidth));
+        }
+    }
+}

--- a/mzLib/Test/Omics/BioPolymerGroupTests/SequenceCoverageResultTests.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/SequenceCoverageResultTests.cs
@@ -283,13 +283,13 @@ namespace Test.Omics.BioPolymerGroupTests
             var group = new BioPolymerGroup(bioPolymers, sequences, uniqueSequences);
 
             // Before CalculateSequenceCoverage, ToString should not throw
-            Assert.DoesNotThrow(() => group.ToString());
+            Assert.DoesNotThrow(() => GroupTsv.Row(group));
 
             // After CalculateSequenceCoverage, ToString should include coverage data
             group.AllPsmsBelowOnePercentFDR = new HashSet<ISpectralMatch>();
             group.CalculateSequenceCoverage();
 
-            var output = group.ToString();
+            var output = GroupTsv.Row(group);
             Assert.That(output, Is.Not.Null);
             Assert.That(output, Is.Not.Empty);
         }
@@ -312,7 +312,7 @@ namespace Test.Omics.BioPolymerGroupTests
             group.CalculateSequenceCoverage();
 
             // Verify coverage is reflected in ToString output
-            var output = group.ToString();
+            var output = GroupTsv.Row(group);
 
             // Coverage fraction should be 5/9 ≈ 0.556
             Assert.That(output, Does.Contain("0.5")); // Partial match on fraction
@@ -337,10 +337,10 @@ namespace Test.Omics.BioPolymerGroupTests
             group.AllPsmsBelowOnePercentFDR = new HashSet<ISpectralMatch> { psm };
 
             group.CalculateSequenceCoverage();
-            var output1 = group.ToString();
+            var output1 = GroupTsv.Row(group);
 
             group.CalculateSequenceCoverage();
-            var output2 = group.ToString();
+            var output2 = GroupTsv.Row(group);
 
             // Results should be identical (replaced, not appended)
             Assert.That(output1, Is.EqualTo(output2));

--- a/mzLib/Test/Omics/Occupancy/ModificationOccupancyCalculatorTests.cs
+++ b/mzLib/Test/Omics/Occupancy/ModificationOccupancyCalculatorTests.cs
@@ -16,6 +16,31 @@ public class ModificationOccupancyCalculatorTests
     #region CalculateProteinLevelOccupancy Tests
 
     [Test]
+    public void DigestionProductLevelAcceptsPsmsThatCompareEqual()
+    {
+        var protein = new MockBioPolymer("ACDEFGHIK", "P00001");
+        ModificationMotif.TryGetMotif("D", out var motif);
+        var mod = new Modification("Phosphorylation", null, "Biological", null, motif, "Anywhere.", null, 79.966);
+
+        var form = new MockBioPolymerWithSetMods("ACDEF", "ACD[Phosphorylation]EF", protein, 1, 5,
+            new Dictionary<int, Modification> { { 4, mod } });
+
+        // BaseSpectralMatch compares on (FullFilePath, OneBasedScanNumber, FullSequence), so these two
+        // are equal without being the same object. A chimeric search produces exactly this.
+        var first = new MockSpectralMatch("test.raw", "ACD[Phosphorylation]EF", "ACDEF", 1.0, 1, [form]);
+        var second = new MockSpectralMatch("test.raw", "ACD[Phosphorylation]EF", "ACDEF", 1.0, 1, [form]);
+        Assert.That(first, Is.EqualTo(second), "precondition: the two matches compare equal");
+
+        var result = ModificationOccupancyCalculator.CalculateDigestionProductLevelOccupancy(
+            new List<ISpectralMatch> { first, second });
+
+        Assert.That(result.ContainsKey(4), Is.True);
+        Assert.That(result[4][0].ModifiedCount, Is.EqualTo(2));
+        Assert.That(result[4][0].TotalCount, Is.EqualTo(2));
+    }
+
+
+    [Test]
     public void ProteinLevelWithSingleModOnSinglePeptide()
     {
         var protein = new MockBioPolymer("ACDEFGHIK", "P00001");

--- a/mzLib/Test/Quantification/QuantificationDeliveryTests.cs
+++ b/mzLib/Test/Quantification/QuantificationDeliveryTests.cs
@@ -1,4 +1,4 @@
-﻿using MassSpectrometry;
+using MassSpectrometry;
 using NUnit.Framework;
 using Omics;
 using Omics.BioPolymerGroup;
@@ -14,6 +14,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using Test.Omics;
+using Test.Omics.BioPolymerGroupTests;
 
 namespace Test.Quantification;
 
@@ -617,8 +618,8 @@ public class QuantificationDeliveryTests
 
         // Render the table the way a writer does: one header, taken from the first group, then a row
         // per group from its own ToString().
-        string header = proteinGroups.First().GetTabSeparatedHeader();
-        var rows = proteinGroups.Select(g => g.ToString()).ToList();
+        string header = GroupTsv.Header(proteinGroups.Cast<BioPolymerGroup>().ToList().ToArray());
+        var rows = proteinGroups.Cast<BioPolymerGroup>().ToList().Select(g => GroupTsv.RowInDataset(g, proteinGroups.Cast<BioPolymerGroup>().ToList())).ToList();
 
         int headerFields = header.Split('\t').Length;
         Assert.Multiple(() =>
@@ -663,19 +664,19 @@ public class QuantificationDeliveryTests
         Assert.That(p003.IntensitiesBySample, Is.Empty,
             "nothing was observed for it, so no sample carries a value");
 
-        string header = proteinGroups.First().GetTabSeparatedHeader();
+        string header = GroupTsv.Header(proteinGroups.Cast<BioPolymerGroup>().ToList().ToArray());
         int headerFields = header.Split('\t').Length;
 
         Assert.Multiple(() =>
         {
             foreach (var group in proteinGroups)
-                Assert.That(group.ToString().Split('\t'), Has.Length.EqualTo(headerFields),
+                Assert.That(GroupTsv.RowInDataset((BioPolymerGroup)group, proteinGroups.Cast<BioPolymerGroup>().ToList()).Split('\t'), Has.Length.EqualTo(headerFields),
                     $"{group.BioPolymerGroupName} does not line up with the header");
         });
 
         // And the header must be the same whichever group happens to be first -- the writer takes it
         // from proteinGroups.First(), which is not necessarily a quantified one.
-        Assert.That(p003.GetTabSeparatedHeader(), Is.EqualTo(header),
+        Assert.That(GroupTsv.Header((BioPolymerGroup)p003), Is.EqualTo(header),
             "an unquantified group must describe the same columns as a quantified one");
     }
 
@@ -696,13 +697,13 @@ public class QuantificationDeliveryTests
         var unquantified = proteinGroups.First();
         Assert.That(unquantified.SamplesForQuantification, Is.Null, "fixture starts unquantified");
 
-        string header = unquantified.GetTabSeparatedHeader();
+        string header = GroupTsv.Header((BioPolymerGroup)unquantified);
         Assert.Multiple(() =>
         {
             Assert.That(header, Does.Not.Contain("Intensity_"),
                 "no quantification ran, so there is nothing for an intensity column to hold");
             Assert.That(header, Does.Not.Contain("IntensityOccupancy_"));
-            Assert.That(unquantified.ToString().Split('\t'), Has.Length.EqualTo(header.Split('\t').Length));
+            Assert.That(GroupTsv.Row((BioPolymerGroup)unquantified).Split('\t'), Has.Length.EqualTo(header.Split('\t').Length));
         });
     }
 
@@ -726,8 +727,8 @@ public class QuantificationDeliveryTests
         new QuantificationEngine(SimpleParameters(), design, spectralMatches, peptides, proteinGroups).Run();
 
         var p002 = proteinGroups.Single(g => g.BioPolymerGroupName.Contains("P002"));
-        var header = p002.GetTabSeparatedHeader().Split('	');
-        var row = p002.ToString().Split('	');
+        var header = GroupTsv.Header(proteinGroups.Cast<BioPolymerGroup>().ToList().ToArray()).Split('	');
+        var row = GroupTsv.RowInDataset((BioPolymerGroup)p002, proteinGroups.Cast<BioPolymerGroup>().ToList()).Split('	');
 
         // The three file2 channels are unobserved for P002; the three file1 channels are not.
         var absent = header
@@ -780,12 +781,12 @@ public class QuantificationDeliveryTests
         Assert.That(subset.IntensitiesBySample, Is.Not.Null.And.Empty,
             "the subset still gets a dictionary, which is why the dictionary alone cannot be the gate");
 
-        string header = subset.GetTabSeparatedHeader();
+        string header = GroupTsv.Header((BioPolymerGroup)subset);
         Assert.Multiple(() =>
         {
             Assert.That(header, Does.Not.Contain("Intensity_"),
                 "nothing can fill these, so they must not be advertised");
-            Assert.That(subset.ToString().Split('	'), Has.Length.EqualTo(header.Split('	').Length));
+            Assert.That(GroupTsv.Row((BioPolymerGroup)subset).Split('	'), Has.Length.EqualTo(header.Split('	').Length));
         });
     }
 }


### PR DESCRIPTION
Third of four related PRs. **This diff also contains #1284 and #1285** — see the note on #1285 for why. The change to review here is the final commit, the one matching this PR's title. Merge #1284 and #1285 first.

Groups digestion products by base sequence, with the modified forms as members and occupancy reported at peptide-local positions — position 1 is the peptide's first residue, not the protein's. Not a subclass of `BioPolymerGroup`: once schemas are external the two share only the quantification block, which is extracted here into `SampleGroupColumnBuilder`.

`SampleGroupColumnBuilder.Build<T>` is constrained `where T : IHasSampleIntensities`. That lets it compute the run-level intensity predicate itself, and makes opting in a compile-time requirement — without it a record type is silently skipped by `QuantificationEngine.OverwriteSampleIntensities` and its intensity columns are dead on arrival, which is what happened to this class while it sat on an older base.

Dedup is explicit on `(FullSequence, Parent.Accession, OneBasedStartResidue, OneBasedEndResidue)` rather than the element type's `Equals`, several of which compare on base sequence alone and would collapse the forms this exists to hold. The residue range is in the key because digestion emits a distinct product per occurrence; those columns report ambiguity, not independent observations, since bottom-up cannot say which copy was seen.

One change outside the stated scope: `CalculateDigestionProductLevelOccupancy`'s filter moves from `!= null` to `!IsNullOrEmpty` with an early return. The null check was not dead — MetaMorpheus sets `BaseSequence` to null for a PSM ambiguous across base sequences — but filtering those out left an empty list where `AllSame()` threw.

**Out of scope:** nothing consumes this yet. It is staged for a peptide-group report; the aggregation from FlashLFQ peptidoform intensities to base-sequence groups is undecided.

Ran: 25 new tests plus the existing suite, green.
