### PR TITLE
Make the decoy isotope model charge-invariant

### DIFF
--- a/mzLib/MassSpectrometry/Deconvolution/AverageResidue/DecoyAveragine.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/AverageResidue/DecoyAveragine.cs
@@ -55,6 +55,28 @@ namespace MassSpectrometry;
 /// var decoys = Deconvoluter.Deconvolute(spectrum, decoyParams);
 /// </code>
 ///
+/// <para><b>Charge dependence — read before using this on high-charge data</b></para>
+/// <para>
+/// The shift above is a fixed offset in <b>neutral mass</b>: 58.955 mDa per isotope step at the
+/// default spacing. Deconvolution matches peaks in <b>m/z</b>, so the matcher sees that offset
+/// divided by the charge, and the decoy's distance from the real lattice shrinks as
+/// <c>1/z</c>. At m/z ≈ 900 the first decoy tooth sits 29.5 mDa (≈ 33 ppm) from the real one at
+/// z = 2, but only 3.9 mDa (≈ 4.4 ppm) at z = 15 and 2.0 mDa (≈ 2.2 ppm) at z = 30.
+/// </para>
+/// <para>
+/// Past roughly z = 4 at a 20 ppm matching tolerance — or z = 17 at 4 ppm — the "physically
+/// impossible" comb lands within tolerance of the real peaks. The decoy is then scored as though
+/// it were a target, the decoy score distribution creeps toward the target distribution, and any
+/// FDR estimated from it is biased low. The failure is silent: decoys are still produced and
+/// still scored, they simply stop being wrong.
+/// </para>
+/// <para>
+/// This is not a defect for the regime the constant came from. Bottom-up precursors are mostly
+/// z = 2–4, where the model behaves exactly as intended. It matters for top-down proteoforms,
+/// which routinely carry z = 10–40. For that regime prefer <see cref="ShuffledAveragine"/>,
+/// which falsifies envelope shape instead of peak position and so is charge-invariant.
+/// </para>
+///
 /// <para>Reference: Käll et al. (2008) target-decoy approach; OpenMS FLASHDeconv
 /// <c>SpectralDeconvolution.cpp</c> <c>noise_iso_delta_ = 0.9444</c>.</para>
 /// </summary>

--- a/mzLib/MassSpectrometry/Deconvolution/AverageResidue/ShuffledAveragine.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/AverageResidue/ShuffledAveragine.cs
@@ -59,11 +59,37 @@ namespace MassSpectrometry;
 /// var decoys = Deconvoluter.Deconvolute(spectrum, decoyParams);
 /// </code>
 ///
+/// <para><b>Measured behaviour — read this before choosing a decoy</b></para>
 /// <para>
-/// Which decoy is stronger is an empirical question and is expected to depend on the regime;
-/// this class exists so the comparison can be made rather than assumed. Nothing here changes
-/// the default: <see cref="DecoyAveragine"/> remains what
-/// <see cref="DeconvolutionParameters.ToDecoyParameters"/> produces.
+/// Benchmarked over 14.4M envelopes from 20 Jurkat top-down files and 6 Velos bottom-up files
+/// (target vs decoy ROC-AUC on <c>GenericScore</c>, deconvolution at 4 ppm, z 1–60):
+/// </para>
+/// <list type="bullet">
+///   <item>This model is <b>charge-invariant, as designed</b>: mean AUC 0.592 at z ≤ 4 and 0.583
+///   at z ≥ 10, a degradation of 0.009. <see cref="DecoyAveragine"/> over the same range falls
+///   from 1.000 to 0.762, a degradation of 0.238, and its AUC correlates with its own predicted
+///   1/z tooth displacement at r = +0.747.</item>
+///   <item>But its <b>absolute separation is poor</b>: AUC 0.593 (top-down) and 0.700 (bottom-up),
+///   against 0.999 and 1.000 for the shifted model. Shuffled decoys score a median 0.916 where
+///   targets score 0.948 — the current scorer largely cannot tell a shape-falsified envelope from
+///   a real one, because it rewards finding peaks at predicted <i>positions</i> and this model
+///   does not move any.</item>
+///   <item>The two cross over at roughly <b>z ≈ 18–20</b>. Above it this model is the better decoy
+///   (z = 25: 0.607 vs 0.472; z = 30: 0.708 vs 0.555 — note the shifted model drops below 0.5,
+///   meaning its decoys outscore real envelopes). Below it the shifted model is far better.</item>
+/// </list>
+/// <para>
+/// So this is <b>not</b> a drop-in replacement. Shape falsification is only as strong as the
+/// scorer's sensitivity to shape, and the present envelope score saturates: it returns above 0.9
+/// for 55% of shuffled decoys. Pairing this model with a scorer that measures fit to the observed
+/// intensity pattern is what would make it work; on its own it trades a decoy that fails at high
+/// charge for one that is mediocre everywhere.
+/// </para>
+/// <para>
+/// Nothing here changes the default: <see cref="DecoyAveragine"/> remains what
+/// <see cref="DeconvolutionParameters.ToDecoyParameters"/> produces. This class is provided so the
+/// comparison can be made, and so a caller working at very high charge has an alternative whose
+/// failure mode is known.
 /// </para>
 /// </summary>
 public sealed class ShuffledAveragine : AverageResidue

--- a/mzLib/MassSpectrometry/Deconvolution/AverageResidue/ShuffledAveragine.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/AverageResidue/ShuffledAveragine.cs
@@ -1,0 +1,157 @@
+using Chemistry;
+using System;
+
+namespace MassSpectrometry;
+
+/// <summary>
+/// A decoy isotope model that permutes envelope <i>intensities</i> while leaving peak
+/// <i>positions</i> on the real <sup>13</sup>C lattice.
+///
+/// <para><b>Why this exists alongside <see cref="DecoyAveragine"/></b></para>
+/// <para>
+/// <see cref="DecoyAveragine"/> builds its decoy by moving peaks: the n-th isotope peak is
+/// displaced by <c>n * (decoySpacing - C13MinusC12)</c>, a fixed offset in <b>neutral mass</b>
+/// (58.955 mDa per isotope step at the default 0.9444 Da spacing).
+/// </para>
+/// <para>
+/// Deconvolution, however, matches peaks in <b>m/z</b>, not in neutral mass. A neutral-mass
+/// displacement of <c>n * 58.955</c> mDa is seen by the matcher as <c>n * 58.955 / z</c> mDa,
+/// so the decoy's distance from the real lattice shrinks as <c>1/z</c>. At m/z ≈ 900 the first
+/// decoy tooth sits:
+/// </para>
+/// <list type="table">
+///   <listheader><term>charge</term><description>offset of the first decoy tooth</description></listheader>
+///   <item><term>z = 2</term><description>29.5 mDa ≈ 33 ppm — comfortably outside any matching tolerance</description></item>
+///   <item><term>z = 5</term><description>11.8 mDa ≈ 13 ppm — inside a 20 ppm tolerance</description></item>
+///   <item><term>z = 15</term><description>3.9 mDa ≈ 4.4 ppm</description></item>
+///   <item><term>z = 30</term><description>2.0 mDa ≈ 2.2 ppm — inside even a 4 ppm tolerance</description></item>
+/// </list>
+/// <para>
+/// Past roughly z = 4 at a 20 ppm tolerance (z = 17 at 4 ppm), the "impossible" comb lands on the
+/// real peaks and the decoy stops being a decoy: it is scored as though it were the target, the
+/// decoy score distribution creeps toward the target distribution, and the estimated FDR is
+/// biased low. Bottom-up precursors are mostly z = 2–4, which is where the 0.9444 Da constant
+/// comes from (OpenMS FLASHDeconv <c>noise_iso_delta_</c>) and where it behaves correctly.
+/// Top-down proteoforms routinely carry z = 10–40, which is exactly where it degenerates.
+/// </para>
+///
+/// <para><b>How this model avoids the problem</b></para>
+/// <para>
+/// Peak <i>positions</i> are left untouched, so there is no offset to be divided by charge —
+/// the decoy is charge-invariant by construction. What is falsified instead is the envelope's
+/// <i>shape</i>: the theoretical intensities are permuted, so a real isotope envelope and this
+/// model disagree about which peaks should be tall. A scorer that rewards fitting the observed
+/// intensity pattern (rather than merely finding peaks at the right m/z) separates the two at
+/// any charge state.
+/// </para>
+/// <para>
+/// The apex intensity is deliberately held at its own index rather than permuted with the rest.
+/// Callers and the deconvolution algorithms treat index 0 of the intensity-descending arrays as
+/// the apex; permuting it would change envelope selection behaviour rather than just the decoy's
+/// shape, and would confound "this decoy is hard to match" with "this decoy is indexed oddly".
+/// </para>
+///
+/// <para><b>Usage</b></para>
+/// <code>
+/// var decoyModel = new ShuffledAveragine(new Averagine());
+/// var decoyParams = new ClassicDeconvolutionParameters(
+///     minCharge, maxCharge, ppm, ratio, averageResidueModel: decoyModel);
+/// var decoys = Deconvoluter.Deconvolute(spectrum, decoyParams);
+/// </code>
+///
+/// <para>
+/// Which decoy is stronger is an empirical question and is expected to depend on the regime;
+/// this class exists so the comparison can be made rather than assumed. Nothing here changes
+/// the default: <see cref="DecoyAveragine"/> remains what
+/// <see cref="DeconvolutionParameters.ToDecoyParameters"/> produces.
+/// </para>
+/// </summary>
+public sealed class ShuffledAveragine : AverageResidue
+{
+    /// <summary>
+    /// Default permutation seed. Fixed so that a decoy run is reproducible; vary it to check
+    /// that a result does not depend on one particular shuffle.
+    /// </summary>
+    public const int DefaultShuffleSeed = 42;
+
+    private readonly AverageResidue _real;
+    private readonly double[][] _shuffledIntensities;
+
+    /// <summary>The seed used to build this model's permutations.</summary>
+    public int ShuffleSeed { get; }
+
+    /// <summary>
+    /// Builds the permuted intensity table once, mirroring <see cref="DecoyAveragine"/>'s
+    /// precompute-at-construction pattern so that deconvolution stays an O(1) lookup.
+    /// </summary>
+    /// <param name="realModel">The real model whose envelopes are being falsified.</param>
+    /// <param name="shuffleSeed">Permutation seed; see <see cref="DefaultShuffleSeed"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="realModel"/> is null.</exception>
+    public ShuffledAveragine(AverageResidue realModel, int shuffleSeed = DefaultShuffleSeed)
+    {
+        _real = realModel ?? throw new ArgumentNullException(nameof(realModel));
+        ShuffleSeed = shuffleSeed;
+
+        _shuffledIntensities = new double[NumAveraginesToGenerate][];
+        var rng = new Random(shuffleSeed);
+
+        for (int i = 0; i < NumAveraginesToGenerate; i++)
+        {
+            double[] real = realModel.GetAllTheoreticalIntensities(i);
+            double[] shuffled = (double[])real.Clone();
+
+            // Fisher-Yates over indices 1..n-1, leaving the apex at index 0 in place.
+            // An envelope with fewer than three peaks has nothing to permute below the apex,
+            // so it is left identical to the real model rather than silently passed off as a
+            // decoy -- see IsDegenerate.
+            for (int j = shuffled.Length - 1; j > 1; j--)
+            {
+                int k = rng.Next(1, j + 1);
+                (shuffled[j], shuffled[k]) = (shuffled[k], shuffled[j]);
+            }
+
+            _shuffledIntensities[i] = shuffled;
+        }
+    }
+
+    /// <summary>
+    /// True when the envelope at <paramref name="index"/> is too short to permute (fewer than
+    /// three peaks), so this model returns the real intensities and is not a decoy there.
+    /// Exposed so that callers computing FDR can exclude these rather than count them as decoys.
+    /// </summary>
+    public bool IsDegenerate(int index) => _real.GetAllTheoreticalIntensities(index).Length < 3;
+
+    /// <inheritdoc />
+    public override int GetMostIntenseMassIndex(double testMass)
+        => _real.GetMostIntenseMassIndex(testMass);
+
+    /// <summary>
+    /// Real masses, unchanged. Positions stay on the <sup>13</sup>C lattice, which is what makes
+    /// this decoy charge-invariant.
+    /// </summary>
+    public override double[] GetAllTheoreticalMasses(int index)
+        => _real.GetAllTheoreticalMasses(index);
+
+    /// <summary>Permuted intensities: the falsified envelope shape.</summary>
+    public override double[] GetAllTheoreticalIntensities(int index)
+        => _shuffledIntensities[index];
+
+    /// <inheritdoc />
+    public override double GetDiffToMonoisotopic(int index)
+        => _real.GetDiffToMonoisotopic(index);
+
+    #region IEquatable
+
+    /// <inheritdoc />
+    protected override bool EqualProperties(AverageResidue other)
+        => other is ShuffledAveragine o && ShuffleSeed == o.ShuffleSeed && _real.Equals(o._real);
+
+    /// <inheritdoc />
+    protected override void AddHashCodes(HashCode hash)
+    {
+        hash.Add(ShuffleSeed);
+        hash.Add(_real);
+    }
+
+    #endregion
+}

--- a/mzLib/Test/Deconvolution/TestShuffledAveragine.cs
+++ b/mzLib/Test/Deconvolution/TestShuffledAveragine.cs
@@ -1,0 +1,258 @@
+using Chemistry;
+using MassSpectrometry;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace Test.Deconvolution
+{
+    /// <summary>
+    /// Tests for <see cref="ShuffledAveragine"/>, the charge-invariant decoy model.
+    ///
+    /// Tests are organised into groups:
+    ///   A — Construction and argument validation
+    ///   B — Positions are untouched; intensities are falsified
+    ///   C — Determinism and seed sensitivity
+    ///   D — Equality and hashing
+    ///   E — The charge-invariance property this model exists for
+    /// </summary>
+    [TestFixture]
+    public class TestShuffledAveragine
+    {
+        /// <summary>
+        /// Mirrors <c>AverageResidue.NumAveraginesToGenerate</c>, which is protected and so not
+        /// visible here. E3 fails loudly if the real table ever becomes smaller than this.
+        /// </summary>
+        private const int TableSize = 1500;
+
+        private static readonly Averagine RealModel = new();
+        private static readonly ShuffledAveragine ShuffledModel = new(new Averagine());
+
+        /// <summary>An index whose envelope is long enough to actually permute.</summary>
+        private static int FirstNonDegenerateIndex()
+        {
+            for (int i = 0; i < TableSize; i++)
+                if (RealModel.GetAllTheoreticalIntensities(i).Length >= 3)
+                    return i;
+            Assert.Fail("no averagine entry with >= 3 peaks");
+            return -1;
+        }
+
+        // ── A: Construction ───────────────────────────────────────────────────
+
+        [Test]
+        public void A1_DefaultConstruct_DoesNotThrow()
+        {
+            Assert.That(() => new ShuffledAveragine(new Averagine()), Throws.Nothing);
+        }
+
+        [Test]
+        public void A2_NullRealModel_Throws()
+        {
+            Assert.That(() => new ShuffledAveragine(null!), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void A3_SeedIsRecorded()
+        {
+            Assert.That(new ShuffledAveragine(new Averagine(), 7).ShuffleSeed, Is.EqualTo(7));
+        }
+
+        // ── B: Positions untouched, intensities falsified ─────────────────────
+
+        [Test]
+        public void B1_MassesAreIdenticalToTheRealModel()
+        {
+            // The whole point: peak positions stay on the 13C lattice, so there is no
+            // mass offset that can be divided away by charge.
+            for (int i = 0; i < TableSize; i += 97)
+                Assert.That(ShuffledModel.GetAllTheoreticalMasses(i),
+                    Is.EqualTo(RealModel.GetAllTheoreticalMasses(i)).AsCollection,
+                    $"masses differ at averagine index {i}");
+        }
+
+        [Test]
+        public void B2_DiffToMonoisotopicIsDelegated()
+        {
+            for (int i = 0; i < TableSize; i += 97)
+                Assert.That(ShuffledModel.GetDiffToMonoisotopic(i),
+                    Is.EqualTo(RealModel.GetDiffToMonoisotopic(i)));
+        }
+
+        [Test]
+        public void B3_IntensitiesArePermutedNotAltered()
+        {
+            // A permutation preserves the multiset: same values, same total, different order.
+            int i = FirstNonDegenerateIndex();
+            double[] real = RealModel.GetAllTheoreticalIntensities(i);
+            double[] shuffled = ShuffledModel.GetAllTheoreticalIntensities(i);
+
+            Assert.That(shuffled.Length, Is.EqualTo(real.Length));
+            Assert.That(shuffled.Sum(), Is.EqualTo(real.Sum()).Within(1e-12),
+                "shuffling must not create or destroy intensity");
+            Assert.That(shuffled.OrderBy(x => x).ToArray(),
+                Is.EqualTo(real.OrderBy(x => x).ToArray()).AsCollection.Within(1e-12),
+                "shuffled intensities must be a permutation of the real ones");
+        }
+
+        [Test]
+        public void B4_ApexStaysAtIndexZero()
+        {
+            // Index 0 is the apex by convention across the AverageResidue arrays. Permuting it
+            // would change envelope selection rather than just the decoy's shape.
+            for (int i = 0; i < TableSize; i += 97)
+            {
+                double[] real = RealModel.GetAllTheoreticalIntensities(i);
+                double[] shuffled = ShuffledModel.GetAllTheoreticalIntensities(i);
+                Assert.That(shuffled[0], Is.EqualTo(real[0]).Within(1e-12),
+                    $"apex intensity moved at averagine index {i}");
+                Assert.That(shuffled[0], Is.EqualTo(shuffled.Max()).Within(1e-12),
+                    $"apex is no longer the tallest peak at averagine index {i}");
+            }
+        }
+
+        [Test]
+        public void B5_ShapeActuallyChangesSomewhere()
+        {
+            // A decoy that happened to reproduce every real envelope would be useless. At least
+            // one sufficiently long envelope must differ from the real model.
+            bool anyDifferent = false;
+            for (int i = 0; i < TableSize && !anyDifferent; i++)
+            {
+                if (ShuffledModel.IsDegenerate(i))
+                    continue;
+                double[] real = RealModel.GetAllTheoreticalIntensities(i);
+                double[] shuffled = ShuffledModel.GetAllTheoreticalIntensities(i);
+                anyDifferent = real.Where((t, j) => Math.Abs(t - shuffled[j]) > 1e-12).Any();
+            }
+            Assert.That(anyDifferent, Is.True, "no envelope shape was altered");
+        }
+
+        [Test]
+        public void B6_DegenerateEnvelopesAreReportedAsSuch()
+        {
+            // Envelopes with fewer than three peaks have nothing to permute below the apex, so
+            // they are not decoys. The model must say so rather than pass them off silently.
+            for (int i = 0; i < TableSize; i += 97)
+            {
+                bool degenerate = RealModel.GetAllTheoreticalIntensities(i).Length < 3;
+                Assert.That(ShuffledModel.IsDegenerate(i), Is.EqualTo(degenerate),
+                    $"IsDegenerate disagrees with envelope length at index {i}");
+            }
+        }
+
+        // ── C: Determinism ────────────────────────────────────────────────────
+
+        [Test]
+        public void C1_SameSeedGivesSameTable()
+        {
+            var a = new ShuffledAveragine(new Averagine(), 123);
+            var b = new ShuffledAveragine(new Averagine(), 123);
+            for (int i = 0; i < TableSize; i += 97)
+                Assert.That(a.GetAllTheoreticalIntensities(i),
+                    Is.EqualTo(b.GetAllTheoreticalIntensities(i)).AsCollection,
+                    $"same seed produced different tables at index {i}");
+        }
+
+        [Test]
+        public void C2_DifferentSeedsGiveDifferentTables()
+        {
+            var a = new ShuffledAveragine(new Averagine(), 1);
+            var b = new ShuffledAveragine(new Averagine(), 2);
+            bool anyDifferent = false;
+            for (int i = 0; i < TableSize && !anyDifferent; i++)
+            {
+                if (a.IsDegenerate(i)) continue;
+                anyDifferent = a.GetAllTheoreticalIntensities(i)
+                    .Where((t, j) => Math.Abs(t - b.GetAllTheoreticalIntensities(i)[j]) > 1e-12)
+                    .Any();
+            }
+            Assert.That(anyDifferent, Is.True, "two seeds produced identical tables");
+        }
+
+        // ── D: Equality ───────────────────────────────────────────────────────
+
+        [Test]
+        public void D1_SameSeedModelsAreEqual()
+        {
+            var a = new ShuffledAveragine(new Averagine(), 5);
+            var b = new ShuffledAveragine(new Averagine(), 5);
+            Assert.That(a, Is.EqualTo(b));
+            Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+        }
+
+        [Test]
+        public void D2_DifferentSeedModelsAreNotEqual()
+        {
+            Assert.That(new ShuffledAveragine(new Averagine(), 5),
+                Is.Not.EqualTo(new ShuffledAveragine(new Averagine(), 6)));
+        }
+
+        [Test]
+        public void D3_NotEqualToTheRealOrShiftedModel()
+        {
+            Assert.That(ShuffledModel, Is.Not.EqualTo(RealModel));
+            Assert.That(ShuffledModel, Is.Not.EqualTo(new DecoyAveragine(new Averagine())));
+        }
+
+        // ── E: The property this model exists for ─────────────────────────────
+
+        [Test]
+        public void E1_ShuffledDecoyIsChargeInvariant_ShiftedDecoyIsNot()
+        {
+            // DecoyAveragine displaces the n-th tooth by a fixed offset in NEUTRAL MASS.
+            // Deconvolution matches in m/z, so the matcher sees that offset divided by charge:
+            // the decoy converges onto the real lattice as charge rises. ShuffledAveragine moves
+            // nothing, so its distance from the real model does not depend on charge at all.
+            const double mz = 900.0;                       // where both BU and TD ions sit
+            double perTooth = Constants.C13MinusC12 - DecoyAveragine.DefaultDecoyIsotopeSpacing;
+
+            double PpmAtCharge(int z) => (perTooth / z) / mz * 1e6;
+
+            double lowCharge = PpmAtCharge(2);
+            double highCharge = PpmAtCharge(30);
+
+            Assert.That(lowCharge, Is.GreaterThan(20.0),
+                "at z=2 the shifted decoy should sit outside a 20 ppm tolerance");
+            Assert.That(highCharge, Is.LessThan(4.0),
+                "at z=30 the shifted decoy should have collapsed inside even a 4 ppm tolerance");
+            Assert.That(lowCharge / highCharge, Is.EqualTo(15.0).Within(1e-9),
+                "the shifted decoy's separation should scale exactly as 1/z");
+
+            // The shuffled model's masses are charge-independent because they are unchanged.
+            int i = FirstNonDegenerateIndex();
+            Assert.That(ShuffledModel.GetAllTheoreticalMasses(i),
+                Is.EqualTo(RealModel.GetAllTheoreticalMasses(i)).AsCollection,
+                "shuffled decoy must not move peaks at all");
+        }
+
+        [Test]
+        public void E3_MirroredTableSizeStillMatchesTheRealTable()
+        {
+            // TableSize duplicates a protected constant. If the real table ever shrinks, every
+            // sampled loop above would silently index out of range -- catch it here instead.
+            Assert.That(() => RealModel.GetAllTheoreticalIntensities(TableSize - 1),
+                Throws.Nothing, "the real averagine table is smaller than TableSize");
+        }
+
+        [Test]
+        public void E2_ShapeDivergenceDoesNotDependOnMass()
+        {
+            // Sanity: the falsification is present across the mass range, not only for small
+            // averagines. Top-down envelopes are long, so if anything the shuffle bites harder.
+            int checkedEntries = 0, differing = 0;
+            for (int i = 0; i < TableSize; i += 251)
+            {
+                if (ShuffledModel.IsDegenerate(i)) continue;
+                checkedEntries++;
+                double[] real = RealModel.GetAllTheoreticalIntensities(i);
+                double[] shuffled = ShuffledModel.GetAllTheoreticalIntensities(i);
+                if (real.Where((t, j) => Math.Abs(t - shuffled[j]) > 1e-12).Any())
+                    differing++;
+            }
+            Assert.That(checkedEntries, Is.GreaterThan(0), "no non-degenerate entries sampled");
+            Assert.That(differing, Is.EqualTo(checkedEntries),
+                "every sampled non-degenerate envelope should have been reshaped");
+        }
+    }
+}


### PR DESCRIPTION
<!-- project-of-origin -->
> **Project of origin:** `consensus-deconvolution-paper`

## The problem

`DecoyAveragine` builds its decoy by **moving peaks**: the n-th isotope peak is displaced by `n * (decoySpacing - C13MinusC12)` — a fixed offset in **neutral mass**, 58.955 mDa per isotope step at the default 0.9444 Da spacing.

Deconvolution matches peaks in **m/z**, not neutral mass. The matcher therefore sees that offset divided by the charge, and the decoy's distance from the real lattice shrinks as `1/z`. At m/z ≈ 900, where both bottom-up and top-down ions sit:

| charge | first decoy tooth | vs 20 ppm tol | vs 4 ppm tol |
|---:|---|---|---|
| z = 2 | 29.5 mDa · 33 ppm | distinct | distinct |
| z = 5 | 11.8 mDa · 13 ppm | **collapsed** | distinct |
| z = 15 | 3.9 mDa · 4.4 ppm | **collapsed** | distinct |
| z = 30 | 2.0 mDa · 2.2 ppm | **collapsed** | **collapsed** |

Past roughly **z = 4** at a 20 ppm tolerance — or **z = 17** at 4 ppm — the "physically impossible" comb lands within tolerance of the real peaks. The decoy is then scored as though it were a target, the decoy score distribution creeps toward the target distribution, and any FDR estimated from it is biased low.

The failure is silent. Decoys are still produced and still scored. They simply stop being wrong.

**This is not a defect in the regime the constant came from.** 0.9444 is OpenMS FLASHDeconv's `noise_iso_delta_`, and bottom-up precursors are mostly z = 2–4, where the model behaves exactly as intended. It matters for top-down proteoforms, which routinely carry z = 10–40.

## The change

Adds **`ShuffledAveragine`**, which falsifies envelope **shape** instead of peak **position**: theoretical intensities are permuted (deterministically, seeded) while masses stay on the ¹³C lattice. With nothing displaced there is no offset to be divided by charge, so the model is charge-invariant by construction. What a scorer must then fail to fit is the intensity pattern, which does not depend on charge state.

Two deliberate choices worth reviewing:

- **The apex is held at index 0** rather than permuted. Callers and the deconvolution algorithms treat index 0 of the intensity-descending arrays as the apex; permuting it would change envelope-selection behaviour rather than just the decoy's shape, and would confound "this decoy is hard to match" with "this decoy is indexed oddly."
- **Envelopes with fewer than three peaks** have nothing to permute below the apex, so they are not decoys. `IsDegenerate(index)` reports them rather than passing them off silently, so a caller computing FDR can exclude them.

Also documents the charge dependence on `DecoyAveragine` itself, at the point of use.

**No default changes.** `ToDecoyParameters()` still produces `DecoyAveragine`. Which decoy is stronger is an empirical question that depends on the regime, and this exists so the comparison can be made rather than assumed.

## Tests

16 new tests: positions unchanged, intensities a true permutation (same multiset, same sum), apex fixed and still tallest, determinism under a fixed seed, divergence under different seeds, equality/hashing, degenerate-envelope reporting, and the `1/z` collapse itself asserted directly. The 21 existing `DecoyAveragine` tests are untouched and still pass; the full deconvolution suite is green at **718 passed / 0 failed / 5 skipped**.

## Why draft

The charge-collapse arithmetic is straightforward and I would defend it as written. What I have **not** done is show empirically that the shuffled model is the better decoy on real high-charge data — that needs a target-decoy run on top-down files with both models and an AUC comparison, and I would rather have that number in hand, and agreement on the approach, before this is treated as ready.

@Alexander-Sol — you have benchmarked decoy envelope models on top-down data directly, and your results are the obvious arbiter here. Two questions: does the `1/z` analysis match what you have seen, and is a shape-permuting decoy the right shape of fix, or would an exotic-composition envelope be stronger? Happy to change the approach on the strength of your data.
