### PR TITLE
Score consensus features against the spectrum and carry it to the feature file

### DIFF
--- a/mzLib/MassSpectrometry/Deconvolution/Consensus/CorrectedEnvelope.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Consensus/CorrectedEnvelope.cs
@@ -17,5 +17,12 @@ namespace MassSpectrometry.Deconvolution.Consensus
         public int Charge;
         public double Intensity;
         public bool WasCorrected;
+
+        /// <summary>
+        /// Quality score of the envelope this observation came from, carried through from
+        /// <see cref="MassTrace"/>. <see cref="double.NaN"/> when the trace was built without a
+        /// scorer; treat NaN as missing, not as a low score.
+        /// </summary>
+        public double Score = double.NaN;
     }
 }

--- a/mzLib/MassSpectrometry/Deconvolution/Consensus/MassFeature.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Consensus/MassFeature.cs
@@ -69,6 +69,22 @@ namespace MassSpectrometry.Deconvolution.Consensus
         public double SummedIntensity;
 
         /// <summary>
+        /// Intensity-weighted mean quality score over every scored envelope in the feature,
+        /// and the best single envelope score. Both are <see cref="double.NaN"/> when the
+        /// traces were built without a scorer.
+        ///
+        /// Weighting by intensity rather than taking a plain mean keeps a long tail of faint,
+        /// poorly-resolved observations from dragging down a feature whose abundant envelopes
+        /// are clean; the maximum is reported alongside because a feature with one excellent
+        /// envelope and many mediocre ones is a different object from one that is uniformly
+        /// mediocre, and the mean alone cannot distinguish them.
+        /// </summary>
+        public double QualityScore = double.NaN;
+
+        /// <inheritdoc cref="QualityScore"/>
+        public double MaxEnvelopeScore = double.NaN;
+
+        /// <summary>
         /// Populate derived fields from the current <see cref="Traces"/>
         /// list. Idempotent; safe to re-run after the trace list changes.
         /// <see cref="ConsensusMass"/> is the intensity-weighted mean of
@@ -91,6 +107,24 @@ namespace MassSpectrometry.Deconvolution.Consensus
             ConsensusMass = w == 0
                 ? Traces.Average(t => t.ConsensusMass)
                 : Traces.Sum(t => t.ConsensusMass * t.TotalIntensity) / w;
+
+            // Unscored envelopes carry NaN and are excluded rather than treated as zero.
+            var scored = Traces.SelectMany(t => t.Envelopes)
+                               .Where(e => !double.IsNaN(e.Score))
+                               .ToList();
+            if (scored.Count == 0)
+            {
+                QualityScore = double.NaN;
+                MaxEnvelopeScore = double.NaN;
+            }
+            else
+            {
+                double sw = scored.Sum(e => e.Intensity);
+                QualityScore = sw == 0
+                    ? scored.Average(e => e.Score)
+                    : scored.Sum(e => e.Score * e.Intensity) / sw;
+                MaxEnvelopeScore = scored.Max(e => e.Score);
+            }
         }
     }
 }

--- a/mzLib/MassSpectrometry/Deconvolution/Consensus/MassTrace.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Consensus/MassTrace.cs
@@ -26,8 +26,15 @@ namespace MassSpectrometry.Deconvolution.Consensus
         /// </summary>
         public double AnchorMass;
 
-        public List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity)> Envelopes
-            = new();
+        /// <summary>
+        /// One entry per observation of this species. <c>Score</c> is the deconvolution
+        /// quality score of the envelope that produced the entry, or <see cref="double.NaN"/>
+        /// when the trace was built without a scorer. NaN rather than 0 so that "not scored"
+        /// is distinguishable from "scored badly"; every consumer must treat it as missing
+        /// rather than as a low score.
+        /// </summary>
+        public List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity,
+                     double Score)> Envelopes = new();
 
         public int LastScanIndex => Envelopes[^1].ScanIndex;
         public double MinMass => Envelopes.Min(e => e.Mass);

--- a/mzLib/MassSpectrometry/Deconvolution/Consensus/MassTraceBuilder.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Consensus/MassTraceBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace MassSpectrometry.Deconvolution.Consensus
@@ -19,11 +20,20 @@ namespace MassSpectrometry.Deconvolution.Consensus
     /// </summary>
     public static class MassTraceBuilder
     {
+        /// <param name="envelopeScorer">
+        /// Optional per-envelope quality scorer, called once for each envelope with the scan it
+        /// came from. Supplied here rather than computed later because this is the only point in
+        /// the pipeline where an envelope and its spectrum are both in hand; recovering the pair
+        /// afterwards would mean re-reading the file. When null, scores are recorded as NaN and
+        /// every downstream aggregate reports NaN, which callers must treat as "not scored"
+        /// rather than as a score of zero.
+        /// </param>
         public static List<MassTrace> BuildTraces(
             IReadOnlyList<MsDataScan> ms1Scans,
             IReadOnlyList<IReadOnlyList<IsotopicEnvelope>> perScanEnvelopes,
             double toleranceDa,
-            int maxGap)
+            int maxGap,
+            Func<IsotopicEnvelope, MsDataScan, double> envelopeScorer = null)
         {
             if (perScanEnvelopes.Count != ms1Scans.Count)
                 throw new System.ArgumentException(
@@ -68,7 +78,10 @@ namespace MassSpectrometry.Deconvolution.Consensus
                                  ms1Scans[scanIdx].OneBasedScanNumber,
                                  ms1Scans[scanIdx].RetentionTime,
                                  env.MonoisotopicMass,
-                                 env.TotalIntensity);
+                                 env.TotalIntensity,
+                                 envelopeScorer is null
+                                     ? double.NaN
+                                     : envelopeScorer(env, ms1Scans[scanIdx]));
 
                     if (best != null)
                     {

--- a/mzLib/MassSpectrometry/Deconvolution/Consensus/TraceCorrector.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Consensus/TraceCorrector.cs
@@ -103,7 +103,7 @@ namespace MassSpectrometry.Deconvolution.Consensus
         /// </summary>
         private static void CorrectGroup(
             int id, int charge,
-            List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity)> envs,
+            List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity, double Score)> envs,
             EnvelopeWeight weight, double sigmaMultiple, List<CorrectedTrace> results)
         {
             double consensus = WeightedMedian(envs, weight, charge);
@@ -111,8 +111,8 @@ namespace MassSpectrometry.Deconvolution.Consensus
                 System.Math.Max(MinSigmaDa, EstimateSigma(envs, consensus)) * sigmaMultiple,
                 MaxWindowDa);
 
-            var belongs = new List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity)>();
-            var other = new List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity)>();
+            var belongs = new List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity, double Score)>();
+            var other = new List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity, double Score)>();
             foreach (var e in envs)
             {
                 double delta = e.Mass - consensus;
@@ -140,6 +140,7 @@ namespace MassSpectrometry.Deconvolution.Consensus
                     Charge = charge,
                     Intensity = e.Intensity,
                     WasCorrected = wasCorrected,
+                    Score = e.Score,
                 });
 
                 if (e.Mass < oMin) oMin = e.Mass;
@@ -167,7 +168,7 @@ namespace MassSpectrometry.Deconvolution.Consensus
         }
 
         private static double WeightedMedian(
-            List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity)> envs,
+            List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity, double Score)> envs,
             EnvelopeWeight weight, int charge)
         {
             var items = envs
@@ -202,7 +203,7 @@ namespace MassSpectrometry.Deconvolution.Consensus
         /// matters.
         /// </summary>
         private static double EstimateSigma(
-            List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity)> envs,
+            List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity, double Score)> envs,
             double consensus)
         {
             var devs = envs.Select(e => System.Math.Abs(e.Mass - consensus)).OrderBy(d => d).ToArray();

--- a/mzLib/MassSpectrometry/Deconvolution/Scoring/DeconvolutionScorer.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Scoring/DeconvolutionScorer.cs
@@ -277,6 +277,26 @@ namespace MassSpectrometry
             => ComputeScore(ComputeFeatures(envelope, model));
 
         /// <summary>
+        /// Builds a scorer that evaluates an envelope against the spectrum it was found in, for
+        /// callers that hold both. Consensus mass tracing uses this to score every envelope as it
+        /// traces, which is the only point at which the envelope and its spectrum are both
+        /// available without re-reading the file.
+        ///
+        /// This is the spectrum-aware path deliberately: the envelope-only score sees a shape in
+        /// isolation and cannot tell a clean envelope from a clean envelope sitting in a region
+        /// full of unexplained peaks. Because it reads the spectrum, its values are not comparable
+        /// across deconvolution algorithms whose peak picking differs; use the envelope-only
+        /// <see cref="ScoreEnvelope(IsotopicEnvelope, AverageResidue)"/> for cross-algorithm
+        /// comparisons.
+        /// </summary>
+        public static Func<IsotopicEnvelope, MsDataScan, double> SpectrumAwareScorer(AverageResidue model)
+        {
+            if (model == null) throw new ArgumentNullException(nameof(model));
+            return (envelope, scan) =>
+                ComputeScoreWithSpectrumContext(ComputeFeatures(envelope, model, scan.MassSpectrum));
+        }
+
+        /// <summary>
         /// Combines all six features (four envelope-only + two spectrum-aware) into a single
         /// quality score in [0, 1] using a logistic function. Use this in place of
         /// <see cref="ComputeScore"/> when

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1Feature.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1Feature.cs
@@ -71,6 +71,26 @@ namespace Readers
         public int FractionIdMax { get; set; }
 
         /// <summary>
+        /// Deconvolution quality of the feature this row came from: the intensity-weighted mean
+        /// envelope score, and the best single envelope score. Null when the producer did not
+        /// score its features, which is the case for any externally-generated TopFD or
+        /// FLASHDeconv file.
+        ///
+        /// These columns are NOT part of the TopFD / FLASHDeconv <c>_ms1.feature</c> schema. They
+        /// are read when present and are written only when a caller asks for them
+        /// (<see cref="ResultFiles.Ms1FeatureFile.WriteResults(string, bool)"/>), so the default
+        /// output stays byte-compatible with tools that expect the original column set.
+        /// </summary>
+        [Name("Quality_score")]
+        [Optional]
+        public double? QualityScore { get; set; }
+
+        /// <inheritdoc cref="QualityScore"/>
+        [Name("Max_envelope_score")]
+        [Optional]
+        public double? MaxEnvelopeScore { get; set; }
+
+        /// <summary>
         /// Expands this row into one <see cref="ISingleChargeMs1Feature"/> per charge in
         /// [<see cref="ChargeStateMin"/>, <see cref="ChargeStateMax"/>]. The per-charge
         /// <c>Intensity</c> is taken from <see cref="IntensityApex"/> (the apex intensity),

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1FeatureFromMassFeatureExtensions.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1FeatureFromMassFeatureExtensions.cs
@@ -126,6 +126,11 @@ namespace Readers
                 ChargeStateMax = chargeMax,
                 FractionIdMin = fractionId,
                 FractionIdMax = fractionId,
+                // A feature split across several contiguous-charge rows carries the same
+                // feature-level score on each row: the score describes the species, not the
+                // charge run. NaN becomes null so the column is empty rather than "NaN".
+                QualityScore = double.IsNaN(feature.QualityScore) ? null : feature.QualityScore,
+                MaxEnvelopeScore = double.IsNaN(feature.MaxEnvelopeScore) ? null : feature.MaxEnvelopeScore,
             };
     }
 }

--- a/mzLib/Readers/ExternalResults/ResultFiles/Ms1FeatureFile.cs
+++ b/mzLib/Readers/ExternalResults/ResultFiles/Ms1FeatureFile.cs
@@ -1,4 +1,5 @@
 ﻿using CsvHelper;
+using CsvHelper.Configuration;
 using MassSpectrometry;
 using MassSpectrometry.Deconvolution.Consensus;
 
@@ -109,12 +110,28 @@ namespace Readers
         /// Writes results to a specific output path
         /// </summary>
         /// <param name="outputPath">destination path</param>
-        public override void WriteResults(string outputPath)
+        public override void WriteResults(string outputPath) => WriteResults(outputPath, false);
+
+        /// <summary>
+        /// Writes results to a specific output path.
+        /// </summary>
+        /// <param name="outputPath">destination path</param>
+        /// <param name="includeQualityColumns">
+        /// When false (the default) the written columns are exactly the TopFD / FLASHDeconv
+        /// <c>_ms1.feature</c> set, so the file stays readable by tools that expect that schema.
+        /// When true, <c>Quality_score</c> and <c>Max_envelope_score</c> are appended. Those two
+        /// columns are an mzLib extension; a consumer that validates the header strictly will
+        /// reject a file written with them, which is why they are opt-in rather than default.
+        /// </param>
+        public void WriteResults(string outputPath, bool includeQualityColumns)
         {
             if (!CanRead(outputPath))
                 outputPath += FileType.GetFileExtension();
 
             using var csv = new CsvWriter(new StreamWriter(File.Create(outputPath)), Ms1Feature.CsvConfiguration);
+
+            if (!includeQualityColumns)
+                csv.Context.RegisterClassMap<Ms1FeatureTopFdSchemaMap>();
 
             csv.WriteHeader<Ms1Feature>();
             // Results returns the in-memory factory records as-is (may be empty -> header
@@ -124,6 +141,21 @@ namespace Readers
                 csv.NextRecord();
                 csv.WriteRecord(result);
             }
+        }
+    }
+
+    /// <summary>
+    /// Restricts the written columns to the TopFD / FLASHDeconv <c>_ms1.feature</c> schema by
+    /// unmapping the mzLib-only quality columns. Used for writing only; reading is unaffected,
+    /// since the quality columns are <c>[Optional]</c> and are picked up when present.
+    /// </summary>
+    internal sealed class Ms1FeatureTopFdSchemaMap : ClassMap<Ms1Feature>
+    {
+        public Ms1FeatureTopFdSchemaMap()
+        {
+            AutoMap(Ms1Feature.CsvConfiguration);
+            Map(m => m.QualityScore).Ignore();
+            Map(m => m.MaxEnvelopeScore).Ignore();
         }
     }
 }

--- a/mzLib/Test/MassSpectrometryTests/Deconvolution/JurkatMs1FeatureGeneratorViaXic.cs
+++ b/mzLib/Test/MassSpectrometryTests/Deconvolution/JurkatMs1FeatureGeneratorViaXic.cs
@@ -153,7 +153,8 @@ namespace Test.MassSpectrometryTests.Deconvolution
                     ms1Scans[p.ZeroBasedScanIndex].OneBasedScanNumber,
                     p.RetentionTime,
                     env.MonoisotopicMass,
-                    env.TotalIntensity));
+                    env.TotalIntensity,
+                    double.NaN));
             }
             return mt;
         }

--- a/mzLib/Test/MassSpectrometryTests/Deconvolution/TestConsensusFeatureQualityScore.cs
+++ b/mzLib/Test/MassSpectrometryTests/Deconvolution/TestConsensusFeatureQualityScore.cs
@@ -1,0 +1,236 @@
+using Chemistry;
+using MassSpectrometry;
+using MassSpectrometry.Deconvolution.Consensus;
+using NUnit.Framework;
+using Readers;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Test.MassSpectrometryTests.Deconvolution
+{
+    /// <summary>
+    /// Tests for the per-feature deconvolution quality score carried from envelope, through the
+    /// trace, onto <see cref="MassFeature"/>, and out to the <c>_ms1.feature</c> file.
+    ///
+    /// Groups:
+    ///   A — the score reaches the feature at all, and NaN means "not scored"
+    ///   B — the aggregate is intensity-weighted, and the maximum is reported alongside
+    ///   C — the file round-trips, and the default written schema is unchanged
+    /// </summary>
+    [TestFixture]
+    public class TestConsensusFeatureQualityScore
+    {
+        /// <summary>Two MS1 scans holding one species at one charge, so traces are predictable.</summary>
+        private static (List<MsDataScan> Scans, List<IReadOnlyList<IsotopicEnvelope>> Envelopes)
+            TwoScanFixture(double mass = 5000.0, int charge = 5,
+                           double i1 = 1000, double i2 = 9000)
+        {
+            var scans = new List<MsDataScan>();
+            var envs = new List<IReadOnlyList<IsotopicEnvelope>>();
+
+            for (int k = 0; k < 2; k++)
+            {
+                double mz = mass.ToMz(charge);
+                var spectrum = new MzSpectrum(
+                    new[] { mz, mz + Constants.C13MinusC12 / charge },
+                    new[] { 1e5, 5e4 }, false);
+                scans.Add(new MsDataScan(spectrum, k + 1, 1, true, Polarity.Positive,
+                    10.0 + k * 0.1, spectrum.Range, null, MZAnalyzerType.Orbitrap,
+                    spectrum.SumOfAllY, null, null, null));
+                envs.Add(new List<IsotopicEnvelope>
+                {
+                    new IsotopicEnvelope(mass, k == 0 ? i1 : i2, charge),
+                });
+            }
+            return (scans, envs);
+        }
+
+        private static MassFeature FeatureFrom(
+            List<MsDataScan> scans,
+            List<IReadOnlyList<IsotopicEnvelope>> envs,
+            Func<IsotopicEnvelope, MsDataScan, double> scorer)
+        {
+            var traces = MassTraceBuilder.BuildTraces(scans, envs, 0.05, 1, scorer);
+            var corrected = traces.SelectMany(t => TraceCorrector.Correct(t)).ToList();
+            var feature = new MassFeature { Id = 1 };
+            feature.Traces.AddRange(corrected);
+            feature.Finalise();
+            return feature;
+        }
+
+        // ── A: the score arrives, and NaN means not scored ─────────────────────
+
+        [Test]
+        public void A1_NoScorer_LeavesScoresNaN()
+        {
+            var (scans, envs) = TwoScanFixture();
+            var feature = FeatureFrom(scans, envs, null);
+
+            Assert.That(double.IsNaN(feature.QualityScore), Is.True,
+                "a feature traced without a scorer must report NaN, not 0");
+            Assert.That(double.IsNaN(feature.MaxEnvelopeScore), Is.True);
+            Assert.That(feature.Traces.SelectMany(t => t.Envelopes).All(e => double.IsNaN(e.Score)),
+                Is.True, "every envelope should also be NaN");
+        }
+
+        [Test]
+        public void A2_ScorerIsCalledOncePerEnvelope_AndValueReachesTheFeature()
+        {
+            var (scans, envs) = TwoScanFixture();
+            int calls = 0;
+            var feature = FeatureFrom(scans, envs, (e, s) => { calls++; return 0.75; });
+
+            Assert.That(calls, Is.EqualTo(2), "one call per envelope observation");
+            Assert.That(feature.QualityScore, Is.EqualTo(0.75).Within(1e-12));
+            Assert.That(feature.MaxEnvelopeScore, Is.EqualTo(0.75).Within(1e-12));
+        }
+
+        [Test]
+        public void A3_SpectrumAwareScorer_ProducesAScoreInRange()
+        {
+            var (scans, envs) = TwoScanFixture();
+            var feature = FeatureFrom(scans, envs,
+                DeconvolutionScorer.SpectrumAwareScorer(new Averagine()));
+
+            Assert.That(double.IsNaN(feature.QualityScore), Is.False,
+                "the real scorer should produce a value");
+            Assert.That(feature.QualityScore, Is.InRange(0.0, 1.0));
+        }
+
+        // ── B: aggregation ────────────────────────────────────────────────────
+
+        [Test]
+        public void B1_AggregateIsIntensityWeighted_NotAPlainMean()
+        {
+            // Intensities 1000 and 9000; scores 0.0 and 1.0 respectively.
+            // Plain mean would be 0.50; intensity-weighted is 9000/10000 = 0.90.
+            var (scans, envs) = TwoScanFixture(i1: 1000, i2: 9000);
+            var feature = FeatureFrom(scans, envs,
+                (e, s) => e.TotalIntensity > 5000 ? 1.0 : 0.0);
+
+            Assert.That(feature.QualityScore, Is.EqualTo(0.9).Within(1e-9),
+                "a faint bad envelope must not outweigh an abundant good one");
+            Assert.That(feature.QualityScore, Is.Not.EqualTo(0.5).Within(1e-3));
+        }
+
+        [Test]
+        public void B2_MaximumIsReportedAlongsideTheMean()
+        {
+            var (scans, envs) = TwoScanFixture(i1: 1000, i2: 9000);
+            var feature = FeatureFrom(scans, envs,
+                (e, s) => e.TotalIntensity > 5000 ? 0.2 : 0.95);
+
+            // One excellent faint envelope among abundant mediocre ones: the mean is dragged
+            // down but the maximum preserves the fact that the species was seen cleanly once.
+            Assert.That(feature.QualityScore, Is.LessThan(0.4));
+            Assert.That(feature.MaxEnvelopeScore, Is.EqualTo(0.95).Within(1e-12));
+        }
+
+        [Test]
+        public void B3_PartiallyScoredFeature_IgnoresTheUnscoredEnvelopes()
+        {
+            // A NaN must be excluded from the aggregate, not folded in as zero.
+            var (scans, envs) = TwoScanFixture(i1: 1000, i2: 1000);
+            var feature = FeatureFrom(scans, envs,
+                (e, s) => s.OneBasedScanNumber == 1 ? 0.8 : double.NaN);
+
+            Assert.That(feature.QualityScore, Is.EqualTo(0.8).Within(1e-12),
+                "the unscored envelope should be skipped, not treated as 0");
+            Assert.That(feature.MaxEnvelopeScore, Is.EqualTo(0.8).Within(1e-12));
+        }
+
+        // ── C: the file ───────────────────────────────────────────────────────
+
+        [Test]
+        public void C1_DefaultWrite_KeepsTheTopFdColumnSet()
+        {
+            var (scans, envs) = TwoScanFixture();
+            var feature = FeatureFrom(scans, envs, (e, s) => 0.66);
+            var file = Ms1FeatureFile.FromMassFeatures(new[] { feature });
+
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                $"qs_default_{Guid.NewGuid():N}_ms1.feature");
+            try
+            {
+                file.WriteResults(path);
+                string header = File.ReadLines(path).First();
+                Assert.That(header, Does.Not.Contain("Quality_score"),
+                    "the default schema must stay readable by tools expecting TopFD's columns");
+                Assert.That(header, Does.Not.Contain("Max_envelope_score"));
+                Assert.That(header, Does.Contain("Mass"));
+            }
+            finally { if (File.Exists(path)) File.Delete(path); }
+        }
+
+        [Test]
+        public void C2_OptInWrite_EmitsTheScoreAndItRoundTrips()
+        {
+            var (scans, envs) = TwoScanFixture();
+            var feature = FeatureFrom(scans, envs, (e, s) => 0.66);
+            var file = Ms1FeatureFile.FromMassFeatures(new[] { feature });
+
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                $"qs_optin_{Guid.NewGuid():N}_ms1.feature");
+            try
+            {
+                file.WriteResults(path, true);
+                string header = File.ReadLines(path).First();
+                Assert.That(header, Does.Contain("Quality_score"));
+
+                var reread = new Ms1FeatureFile(path);
+                var row = reread.Results.Single();
+                Assert.That(row.QualityScore, Is.Not.Null);
+                Assert.That(row.QualityScore.Value, Is.EqualTo(0.66).Within(1e-9));
+                Assert.That(row.MaxEnvelopeScore.Value, Is.EqualTo(0.66).Within(1e-9));
+            }
+            finally { if (File.Exists(path)) File.Delete(path); }
+        }
+
+        [Test]
+        public void C3_UnscoredFeature_WritesAnEmptyCellNotNaN()
+        {
+            // "NaN" in a numeric column breaks strict parsers; an empty cell is the honest
+            // encoding of "this producer did not score its features".
+            var (scans, envs) = TwoScanFixture();
+            var feature = FeatureFrom(scans, envs, null);
+            var file = Ms1FeatureFile.FromMassFeatures(new[] { feature });
+
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                $"qs_unscored_{Guid.NewGuid():N}_ms1.feature");
+            try
+            {
+                file.WriteResults(path, true);
+                string dataRow = File.ReadLines(path).Skip(1).First();
+                Assert.That(dataRow, Does.Not.Contain("NaN"));
+
+                var reread = new Ms1FeatureFile(path);
+                Assert.That(reread.Results.Single().QualityScore, Is.Null);
+            }
+            finally { if (File.Exists(path)) File.Delete(path); }
+        }
+
+        [Test]
+        public void C4_ExternalFileWithoutTheColumns_StillReads()
+        {
+            // A TopFD or FLASHDeconv file has no quality columns; reading one must not fail.
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                $"qs_external_{Guid.NewGuid():N}_ms1.feature");
+            try
+            {
+                File.WriteAllLines(path, new[]
+                {
+                    "Sample_ID\tID\tMass\tIntensity\tTime_begin\tTime_end\tTime_apex\tApex_intensity\tMinimum_charge_state\tMaximum_charge_state\tMinimum_fraction_id\tMaximum_fraction_id",
+                    "0\t1\t5000.0\t1000\t10.0\t10.2\t10.1\t900\t4\t6\t0\t0",
+                });
+
+                var reread = new Ms1FeatureFile(path);
+                var row = reread.Results.Single();
+                Assert.That(row.Mass, Is.EqualTo(5000.0).Within(1e-9));
+                Assert.That(row.QualityScore, Is.Null, "absent column reads as null, not 0");
+            }
+            finally { if (File.Exists(path)) File.Delete(path); }
+        }
+    }
+}

--- a/mzLib/Test/MassSpectrometryTests/Deconvolution/TestConsensusMassTracing.cs
+++ b/mzLib/Test/MassSpectrometryTests/Deconvolution/TestConsensusMassTracing.cs
@@ -439,7 +439,7 @@ namespace Test.MassSpectrometryTests.Deconvolution
         {
             var mt = new MassTrace { Id = 1, Charge = charge, AnchorMass = masses[0] };
             for (int i = 0; i < masses.Length; i++)
-                mt.Envelopes.Add((i, i + 1, 10.0 + i * 0.1, masses[i], intensity));
+                mt.Envelopes.Add((i, i + 1, 10.0 + i * 0.1, masses[i], intensity, double.NaN));
             return mt;
         }
 


### PR DESCRIPTION
<!-- project-of-origin -->
> **Project of origin:** `consensus-deconvolution-paper`

First of two PRs making the consensus feature pipeline usable end to end: this one gives every feature a quality score; the follow-up turns that score into a calibrated error rate.

## The problem

The consensus pipeline emits features carrying no quality signal at all. `MassFeature` has no score field and `Ms1Feature` has no score column, so the written file has nothing to rank on.

The only score being produced was a test-side sidecar computed with the **envelope-only** `DeconvolutionScorer.ScoreEnvelope(envelope, model)` overload. That overload ends in a logistic, which returns a value indistinguishable from its ceiling for anything roughly envelope-shaped. Measured on a 20-file Jurkat top-down set:

- **99.888%** of consensus features score above 0.99
- the median among **single-scan, singly-charged** features, which cannot be top-down proteoforms, is exactly **1.000**

A score pinned at its ceiling cannot rank anything, which is why the shipped file has no useful order and why sampling it lands on noise.

## The change

Score every envelope against the spectrum it was found in, through the existing spectrum-aware `ComputeFeatures(envelope, model, spectrum)` / `ComputeScoreWithSpectrumContext` path, and carry the value envelope → trace → `MassFeature` → `_ms1.feature`.

**Where the scoring happens.** Inside `MassTraceBuilder.BuildTraces`, because that is the only point in the pipeline where an envelope and its spectrum are both in hand. `CorrectedEnvelope` keeps no peak list, so recovering the pair afterwards would mean re-reading the file.

**Optional, and NaN means "not scored".** The scorer is an optional delegate, so existing callers are unaffected. Unscored envelopes record `NaN` rather than `0`, and the feature aggregate skips them: "not scored" must not be confusable with "scored badly", and folding NaN in as zero would silently penalise any feature traced without a scorer.

**`MassFeature` gains `QualityScore` and `MaxEnvelopeScore`.** The aggregate is intensity-weighted rather than a plain mean, so a tail of faint poorly-resolved observations cannot drag down a feature whose abundant envelopes are clean. The maximum is reported alongside because a feature with one excellent envelope among mediocre ones is a different object from a uniformly mediocre one, and the mean alone cannot tell them apart.

**`DeconvolutionScorer.SpectrumAwareScorer(model)`** is a small factory so callers do not hand-wire the two-call sequence.

## Format compatibility, which is the part worth reviewing

`Quality_score` and `Max_envelope_score` are **not** part of the TopFD / FLASHDeconv `_ms1.feature` schema. Appending columns unconditionally would produce files that a strict consumer rejects, so:

- they are `[Optional]` properties, read when present
- they are **written only** when a caller passes `WriteResults(path, includeQualityColumns: true)`
- the default `WriteResults(path)` emits exactly the original column set, via a `ClassMap` that unmaps the two
- an unscored feature writes an **empty cell**, not the string `NaN`, which breaks strict numeric parsers

A feature split across several contiguous-charge rows carries the same feature-level score on each row, since the score describes the species rather than the charge run.

## Breaking change, contained

`MassTrace.Envelopes` gains a `Score` element, so positional construction changes. Three sites in this repo were updated (`MassTraceBuilder`, and two test generators). Access by name (`e.Mass`, `e.Intensity`) is unchanged everywhere, and `TraceCorrector`'s internal signatures were widened to match.

## Tests

10 new, covering: NaN propagation with no scorer; exactly one scorer call per envelope; the real spectrum-aware scorer producing an in-range value; intensity weighting demonstrated against the plain mean it must not equal; the maximum surviving a low mean; partial scoring skipping NaN rather than zeroing it; the default write preserving the TopFD column set; the opt-in write round-tripping; empty-cell rather than `NaN` encoding; and reading an external file that has no quality columns at all.

Surrounding suites pass: **737 passed, 0 failed, 5 skipped** across the deconvolution, consensus and `Ms1Feature` tests.

## What this does not do

It does not turn the score into an error rate, rank the file, or change what is written by default. That is the follow-up PR, which adds decoy features and feature-level q-values on top of this. Splitting them keeps this one reviewable as "a number that varies now exists".
