### PR TITLE
Assign feature-level q-values by competing features against decoy features

### DIFF
--- a/mzLib/MassSpectrometry/Deconvolution/Consensus/ConsensusFeatureFdr.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Consensus/ConsensusFeatureFdr.cs
@@ -1,0 +1,166 @@
+using Chemistry;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MassSpectrometry.Deconvolution.Consensus
+{
+    /// <summary>
+    /// Assigns a false-discovery-rate q-value to each <see cref="MassFeature"/> by competing the
+    /// real features against decoy features built from them.
+    ///
+    /// <para><b>Why features need their own null</b></para>
+    /// <para>
+    /// mzLib already estimates FDR for individual isotopic envelopes during deconvolution
+    /// (<see cref="DeconvolutionQValueCalculator"/> against <see cref="DecoyAveragine"/>). That
+    /// operates one scan at a time and says nothing about an assembled feature, which is what a
+    /// consumer of an <c>_ms1.feature</c> file actually receives. A feature list with no error
+    /// rate can only be used whole or thresholded by guesswork.
+    /// </para>
+    ///
+    /// <para><b>How the decoys are built</b></para>
+    /// <para>
+    /// Each decoy keeps a real feature's charge and retention time and displaces its mass by a
+    /// half-integer multiple of the <sup>13</sup>C spacing, 5 to 50 Da away. Keeping charge and
+    /// retention time means the decoy probes the same spectrum at the same density as its target,
+    /// so the comparison isolates the one thing that makes a feature real: whether a complete
+    /// isotope envelope actually sits at that mass. The half-integer offset places the decoy comb
+    /// between the real teeth rather than on them.
+    /// </para>
+    /// <para>
+    /// Displacing the mass, rather than perturbing the isotope spacing as the envelope-level decoy
+    /// does, matters at top-down charge states. A spacing perturbation is a fixed offset in neutral
+    /// mass, so the matcher, which works in m/z, sees it divided by charge; past roughly z = 4 at a
+    /// 20 ppm tolerance the perturbed comb lands back on the real peaks and the decoy stops being
+    /// wrong. A whole-feature displacement of 5 to 50 Da does not shrink with charge.
+    /// </para>
+    ///
+    /// <para><b>What the q-value means, and does not</b></para>
+    /// <para>
+    /// It estimates the fraction of surviving features that are not real isotope envelopes. It does
+    /// NOT estimate the fraction that fail to correspond to an identifiable molecule: most true
+    /// features are never identified by any search, and a feature can be a perfectly real envelope
+    /// of a species no database contains. Read it as "is this a real envelope", not "is this a real
+    /// proteoform".
+    /// </para>
+    /// </summary>
+    public static class ConsensusFeatureFdr
+    {
+        /// <summary>Default peak-matching tolerance when probing a hypothesis.</summary>
+        public const double DefaultTolerancePpm = 20.0;
+
+        /// <summary>Smallest and largest decoy mass displacement, in daltons.</summary>
+        public const double MinDecoyOffsetDa = 5.0;
+        public const double MaxDecoyOffsetDa = 50.0;
+
+        /// <summary>
+        /// Scores every feature and its decoy at the feature's apex scan, then assigns
+        /// <see cref="MassFeature.QValue"/>.
+        /// </summary>
+        /// <param name="features">Finalised features. Mutated in place.</param>
+        /// <param name="ms1Scans">The MS1 scans the features were traced from, ascending in retention time.</param>
+        /// <param name="model">Isotope model; use the same one the features were deconvolved with.</param>
+        /// <param name="tolerancePpm">Peak-matching tolerance for the probe.</param>
+        /// <param name="seed">Fixed so a rerun reproduces the same decoys. Vary it to confirm a result does not depend on one draw.</param>
+        /// <returns>The number of features that received a finite q-value.</returns>
+        /// <remarks>
+        /// Target and decoy are both scored by probing the apex scan, rather than reusing
+        /// <see cref="MassFeature.QualityScore"/>, because a decoy has no trace to aggregate over.
+        /// Comparing a trace-averaged target score against a single-scan decoy score would make the
+        /// target look better for a reason that has nothing to do with being real. The trace
+        /// aggregate remains the descriptive per-feature number; this is the matched one.
+        /// </remarks>
+        public static int AssignQValues(
+            IReadOnlyList<MassFeature> features,
+            IReadOnlyList<MsDataScan> ms1Scans,
+            AverageResidue model,
+            double tolerancePpm = DefaultTolerancePpm,
+            int seed = 42)
+        {
+            if (features == null) throw new ArgumentNullException(nameof(features));
+            if (ms1Scans == null) throw new ArgumentNullException(nameof(ms1Scans));
+            if (model == null) throw new ArgumentNullException(nameof(model));
+            if (features.Count == 0) return 0;
+            if (ms1Scans.Count == 0) throw new ArgumentException("no MS1 scans supplied", nameof(ms1Scans));
+
+            var rng = new Random(seed);
+            var scored = new List<(MassFeature Feature, double Target)>();
+            var decoyScores = new List<double>();
+
+            foreach (var f in features)
+            {
+                MsDataScan apex = NearestScan(ms1Scans, ApexRetentionTime(f));
+                int charge = RepresentativeCharge(f);
+
+                double target = IsotopicEnvelopeProbe.Score(
+                    apex.MassSpectrum, f.ConsensusMass, charge, model, tolerancePpm);
+
+                double decoyMass = f.ConsensusMass + DecoyOffset(rng);
+                double decoy = IsotopicEnvelopeProbe.Score(
+                    apex.MassSpectrum, decoyMass, charge, model, tolerancePpm);
+
+                // A hypothesis the spectrum cannot support at all scores NaN. For the target that
+                // means no q-value can be assigned. For the decoy it means the null found nothing,
+                // which is a legitimate outcome and enters the null distribution as the lowest
+                // possible score rather than being dropped -- dropping it would bias the null
+                // upward and make the FDR look better than it is.
+                if (!double.IsNaN(target))
+                    scored.Add((f, target));
+                decoyScores.Add(double.IsNaN(decoy) ? 0.0 : decoy);
+
+                f.QValue = double.NaN;
+            }
+
+            if (scored.Count == 0) return 0;
+
+            double[] q = DeconvolutionQValueCalculator.AssignQValues(
+                scored.Select(s => s.Target).ToList(), decoyScores);
+
+            for (int i = 0; i < scored.Count; i++)
+                scored[i].Feature.QValue = q[i];
+
+            return scored.Count;
+        }
+
+        /// <summary>Half-integer multiple of the 13C spacing, 5 to 50 Da, either side.</summary>
+        private static double DecoyOffset(Random rng)
+        {
+            double magnitude = MinDecoyOffsetDa + rng.NextDouble() * (MaxDecoyOffsetDa - MinDecoyOffsetDa);
+            double sign = rng.Next(2) == 0 ? -1.0 : 1.0;
+            double k = Math.Round(magnitude / Constants.C13MinusC12);
+            return sign * (k + 0.5) * Constants.C13MinusC12;
+        }
+
+        /// <summary>Retention time of the most intense envelope in the feature.</summary>
+        private static double ApexRetentionTime(MassFeature f)
+        {
+            var envelopes = f.Traces.SelectMany(t => t.Envelopes).ToList();
+            if (envelopes.Count == 0) return (f.RTStart + f.RTEnd) / 2;
+            double best = envelopes.Max(e => e.Intensity);
+            return envelopes.First(e => e.Intensity == best).RT;
+        }
+
+        /// <summary>
+        /// Charge of the feature's most intense trace. The abundant charge is the one most likely
+        /// to have a complete envelope at the apex; the midpoint of the charge range can fall on a
+        /// charge state carrying almost no signal, which would make a real feature look unsupported.
+        /// </summary>
+        private static int RepresentativeCharge(MassFeature f)
+        {
+            if (f.Traces.Count == 0) return f.Charges.Count > 0 ? f.Charges.Min() : 1;
+            return f.Traces.OrderByDescending(t => t.TotalIntensity).First().Charge;
+        }
+
+        private static MsDataScan NearestScan(IReadOnlyList<MsDataScan> scans, double rt)
+        {
+            MsDataScan best = scans[0];
+            double bestDelta = Math.Abs(scans[0].RetentionTime - rt);
+            for (int i = 1; i < scans.Count; i++)
+            {
+                double d = Math.Abs(scans[i].RetentionTime - rt);
+                if (d < bestDelta) { bestDelta = d; best = scans[i]; }
+            }
+            return best;
+        }
+    }
+}

--- a/mzLib/MassSpectrometry/Deconvolution/Consensus/CorrectedEnvelope.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Consensus/CorrectedEnvelope.cs
@@ -17,5 +17,12 @@ namespace MassSpectrometry.Deconvolution.Consensus
         public int Charge;
         public double Intensity;
         public bool WasCorrected;
+
+        /// <summary>
+        /// Quality score of the envelope this observation came from, carried through from
+        /// <see cref="MassTrace"/>. <see cref="double.NaN"/> when the trace was built without a
+        /// scorer; treat NaN as missing, not as a low score.
+        /// </summary>
+        public double Score = double.NaN;
     }
 }

--- a/mzLib/MassSpectrometry/Deconvolution/Consensus/MassFeature.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Consensus/MassFeature.cs
@@ -69,6 +69,22 @@ namespace MassSpectrometry.Deconvolution.Consensus
         public double SummedIntensity;
 
         /// <summary>
+        /// Intensity-weighted mean quality score over every scored envelope in the feature,
+        /// and the best single envelope score. Both are <see cref="double.NaN"/> when the
+        /// traces were built without a scorer.
+        ///
+        /// Weighting by intensity rather than taking a plain mean keeps a long tail of faint,
+        /// poorly-resolved observations from dragging down a feature whose abundant envelopes
+        /// are clean; the maximum is reported alongside because a feature with one excellent
+        /// envelope and many mediocre ones is a different object from one that is uniformly
+        /// mediocre, and the mean alone cannot distinguish them.
+        /// </summary>
+        public double QualityScore = double.NaN;
+
+        /// <inheritdoc cref="QualityScore"/>
+        public double MaxEnvelopeScore = double.NaN;
+
+        /// <summary>
         /// Populate derived fields from the current <see cref="Traces"/>
         /// list. Idempotent; safe to re-run after the trace list changes.
         /// <see cref="ConsensusMass"/> is the intensity-weighted mean of
@@ -91,6 +107,24 @@ namespace MassSpectrometry.Deconvolution.Consensus
             ConsensusMass = w == 0
                 ? Traces.Average(t => t.ConsensusMass)
                 : Traces.Sum(t => t.ConsensusMass * t.TotalIntensity) / w;
+
+            // Unscored envelopes carry NaN and are excluded rather than treated as zero.
+            var scored = Traces.SelectMany(t => t.Envelopes)
+                               .Where(e => !double.IsNaN(e.Score))
+                               .ToList();
+            if (scored.Count == 0)
+            {
+                QualityScore = double.NaN;
+                MaxEnvelopeScore = double.NaN;
+            }
+            else
+            {
+                double sw = scored.Sum(e => e.Intensity);
+                QualityScore = sw == 0
+                    ? scored.Average(e => e.Score)
+                    : scored.Sum(e => e.Score * e.Intensity) / sw;
+                MaxEnvelopeScore = scored.Max(e => e.Score);
+            }
         }
     }
 }

--- a/mzLib/MassSpectrometry/Deconvolution/Consensus/MassFeature.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Consensus/MassFeature.cs
@@ -85,6 +85,14 @@ namespace MassSpectrometry.Deconvolution.Consensus
         public double MaxEnvelopeScore = double.NaN;
 
         /// <summary>
+        /// Target-decoy q-value from <see cref="ConsensusFeatureFdr"/>, or
+        /// <see cref="double.NaN"/> when FDR was not estimated. It estimates the fraction of
+        /// surviving features that are not real isotope envelopes, not the fraction that fail to
+        /// correspond to an identifiable molecule.
+        /// </summary>
+        public double QValue = double.NaN;
+
+        /// <summary>
         /// Populate derived fields from the current <see cref="Traces"/>
         /// list. Idempotent; safe to re-run after the trace list changes.
         /// <see cref="ConsensusMass"/> is the intensity-weighted mean of

--- a/mzLib/MassSpectrometry/Deconvolution/Consensus/MassTrace.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Consensus/MassTrace.cs
@@ -26,8 +26,15 @@ namespace MassSpectrometry.Deconvolution.Consensus
         /// </summary>
         public double AnchorMass;
 
-        public List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity)> Envelopes
-            = new();
+        /// <summary>
+        /// One entry per observation of this species. <c>Score</c> is the deconvolution
+        /// quality score of the envelope that produced the entry, or <see cref="double.NaN"/>
+        /// when the trace was built without a scorer. NaN rather than 0 so that "not scored"
+        /// is distinguishable from "scored badly"; every consumer must treat it as missing
+        /// rather than as a low score.
+        /// </summary>
+        public List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity,
+                     double Score)> Envelopes = new();
 
         public int LastScanIndex => Envelopes[^1].ScanIndex;
         public double MinMass => Envelopes.Min(e => e.Mass);

--- a/mzLib/MassSpectrometry/Deconvolution/Consensus/MassTraceBuilder.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Consensus/MassTraceBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace MassSpectrometry.Deconvolution.Consensus
@@ -19,11 +20,20 @@ namespace MassSpectrometry.Deconvolution.Consensus
     /// </summary>
     public static class MassTraceBuilder
     {
+        /// <param name="envelopeScorer">
+        /// Optional per-envelope quality scorer, called once for each envelope with the scan it
+        /// came from. Supplied here rather than computed later because this is the only point in
+        /// the pipeline where an envelope and its spectrum are both in hand; recovering the pair
+        /// afterwards would mean re-reading the file. When null, scores are recorded as NaN and
+        /// every downstream aggregate reports NaN, which callers must treat as "not scored"
+        /// rather than as a score of zero.
+        /// </param>
         public static List<MassTrace> BuildTraces(
             IReadOnlyList<MsDataScan> ms1Scans,
             IReadOnlyList<IReadOnlyList<IsotopicEnvelope>> perScanEnvelopes,
             double toleranceDa,
-            int maxGap)
+            int maxGap,
+            Func<IsotopicEnvelope, MsDataScan, double> envelopeScorer = null)
         {
             if (perScanEnvelopes.Count != ms1Scans.Count)
                 throw new System.ArgumentException(
@@ -68,7 +78,10 @@ namespace MassSpectrometry.Deconvolution.Consensus
                                  ms1Scans[scanIdx].OneBasedScanNumber,
                                  ms1Scans[scanIdx].RetentionTime,
                                  env.MonoisotopicMass,
-                                 env.TotalIntensity);
+                                 env.TotalIntensity,
+                                 envelopeScorer is null
+                                     ? double.NaN
+                                     : envelopeScorer(env, ms1Scans[scanIdx]));
 
                     if (best != null)
                     {

--- a/mzLib/MassSpectrometry/Deconvolution/Consensus/TraceCorrector.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Consensus/TraceCorrector.cs
@@ -103,7 +103,7 @@ namespace MassSpectrometry.Deconvolution.Consensus
         /// </summary>
         private static void CorrectGroup(
             int id, int charge,
-            List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity)> envs,
+            List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity, double Score)> envs,
             EnvelopeWeight weight, double sigmaMultiple, List<CorrectedTrace> results)
         {
             double consensus = WeightedMedian(envs, weight, charge);
@@ -111,8 +111,8 @@ namespace MassSpectrometry.Deconvolution.Consensus
                 System.Math.Max(MinSigmaDa, EstimateSigma(envs, consensus)) * sigmaMultiple,
                 MaxWindowDa);
 
-            var belongs = new List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity)>();
-            var other = new List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity)>();
+            var belongs = new List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity, double Score)>();
+            var other = new List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity, double Score)>();
             foreach (var e in envs)
             {
                 double delta = e.Mass - consensus;
@@ -140,6 +140,7 @@ namespace MassSpectrometry.Deconvolution.Consensus
                     Charge = charge,
                     Intensity = e.Intensity,
                     WasCorrected = wasCorrected,
+                    Score = e.Score,
                 });
 
                 if (e.Mass < oMin) oMin = e.Mass;
@@ -167,7 +168,7 @@ namespace MassSpectrometry.Deconvolution.Consensus
         }
 
         private static double WeightedMedian(
-            List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity)> envs,
+            List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity, double Score)> envs,
             EnvelopeWeight weight, int charge)
         {
             var items = envs
@@ -202,7 +203,7 @@ namespace MassSpectrometry.Deconvolution.Consensus
         /// matters.
         /// </summary>
         private static double EstimateSigma(
-            List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity)> envs,
+            List<(int ScanIndex, int ScanNumber, double RT, double Mass, double Intensity, double Score)> envs,
             double consensus)
         {
             var devs = envs.Select(e => System.Math.Abs(e.Mass - consensus)).OrderBy(d => d).ToArray();

--- a/mzLib/MassSpectrometry/Deconvolution/Scoring/DeconvolutionScorer.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Scoring/DeconvolutionScorer.cs
@@ -277,6 +277,26 @@ namespace MassSpectrometry
             => ComputeScore(ComputeFeatures(envelope, model));
 
         /// <summary>
+        /// Builds a scorer that evaluates an envelope against the spectrum it was found in, for
+        /// callers that hold both. Consensus mass tracing uses this to score every envelope as it
+        /// traces, which is the only point at which the envelope and its spectrum are both
+        /// available without re-reading the file.
+        ///
+        /// This is the spectrum-aware path deliberately: the envelope-only score sees a shape in
+        /// isolation and cannot tell a clean envelope from a clean envelope sitting in a region
+        /// full of unexplained peaks. Because it reads the spectrum, its values are not comparable
+        /// across deconvolution algorithms whose peak picking differs; use the envelope-only
+        /// <see cref="ScoreEnvelope(IsotopicEnvelope, AverageResidue)"/> for cross-algorithm
+        /// comparisons.
+        /// </summary>
+        public static Func<IsotopicEnvelope, MsDataScan, double> SpectrumAwareScorer(AverageResidue model)
+        {
+            if (model == null) throw new ArgumentNullException(nameof(model));
+            return (envelope, scan) =>
+                ComputeScoreWithSpectrumContext(ComputeFeatures(envelope, model, scan.MassSpectrum));
+        }
+
+        /// <summary>
         /// Combines all six features (four envelope-only + two spectrum-aware) into a single
         /// quality score in [0, 1] using a logistic function. Use this in place of
         /// <see cref="ComputeScore"/> when

--- a/mzLib/MassSpectrometry/Deconvolution/Scoring/IsotopicEnvelopeProbe.cs
+++ b/mzLib/MassSpectrometry/Deconvolution/Scoring/IsotopicEnvelopeProbe.cs
@@ -1,0 +1,127 @@
+using Chemistry;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MathNet.Numerics.Statistics;
+using MzLibUtil;
+
+namespace MassSpectrometry
+{
+    /// <summary>
+    /// Gathers the observed peaks that a species of a given monoisotopic mass and charge would
+    /// occupy in a spectrum, and returns them as an <see cref="IsotopicEnvelope"/> that can be
+    /// handed to <see cref="DeconvolutionScorer"/>.
+    ///
+    /// <para>
+    /// Deconvolution answers "what is in this spectrum". This answers the narrower question
+    /// "how well does this spectrum support THIS hypothesis", which deconvolution cannot be asked
+    /// directly because it only ever reports the hypotheses it chose. Scoring a mass and charge
+    /// that deconvolution did not report is exactly what a decoy needs: a decoy feature has no
+    /// peaks of its own, so it cannot be scored by any path that starts from an observed envelope.
+    /// </para>
+    ///
+    /// <para>
+    /// The gathered envelope may be empty or nearly so, and that is the informative case. A
+    /// hypothesis the spectrum does not support returns few peaks and scores badly, which is the
+    /// behaviour a null model depends on.
+    /// </para>
+    /// </summary>
+    public static class IsotopicEnvelopeProbe
+    {
+        /// <summary>
+        /// Collects the peaks in <paramref name="spectrum"/> consistent with a species of
+        /// <paramref name="monoisotopicMass"/> at <paramref name="charge"/>.
+        /// </summary>
+        /// <param name="spectrum">The spectrum to probe.</param>
+        /// <param name="monoisotopicMass">Hypothesised monoisotopic mass.</param>
+        /// <param name="charge">Hypothesised charge; must be non-zero.</param>
+        /// <param name="model">Isotope model supplying the theoretical envelope.</param>
+        /// <param name="tolerancePpm">Peak-matching tolerance.</param>
+        /// <returns>
+        /// An envelope holding every theoretical isotope position that found a peak within
+        /// tolerance, or <c>null</c> when the spectrum is empty or not one peak matched. Null
+        /// rather than an empty envelope because <see cref="IsotopicEnvelope"/> requires at least
+        /// one peak to describe anything, and callers must decide what an unsupported hypothesis
+        /// means for them rather than receive a zero that looks like a measurement.
+        /// </returns>
+        public static IsotopicEnvelope Gather(
+            MzSpectrum spectrum,
+            double monoisotopicMass,
+            int charge,
+            AverageResidue model,
+            double tolerancePpm)
+        {
+            if (spectrum == null) throw new ArgumentNullException(nameof(spectrum));
+            if (model == null) throw new ArgumentNullException(nameof(model));
+            if (charge == 0) throw new ArgumentOutOfRangeException(nameof(charge), "charge must be non-zero");
+            if (spectrum.Size == 0) return null;
+
+            int massIndex = model.GetMostIntenseMassIndex(monoisotopicMass);
+            double[] theorMasses = model.GetAllTheoreticalMasses(massIndex);
+            double[] theorIntensities = model.GetAllTheoreticalIntensities(massIndex);
+            if (theorMasses.Length == 0) return null;
+
+            // The model's arrays are indexed from the most intense peak, and describe an averagine
+            // of the table's mass rather than of the exact hypothesised mass. Anchoring on the
+            // apex and shifting the whole comb keeps the spacing right while placing it at the
+            // mass actually being tested.
+            double apexMass = monoisotopicMass + model.GetDiffToMonoisotopic(massIndex);
+            double offset = apexMass - theorMasses[0];
+
+            var peaks = new List<(double mz, double intensity)>();
+            var ratios = new List<double>();
+            double totalIntensity = 0;
+
+            for (int i = 0; i < theorMasses.Length; i++)
+            {
+                double targetMass = theorMasses[i] + offset;
+                double targetMz = targetMass.ToMz(charge);
+
+                int idx = spectrum.GetClosestPeakIndex(targetMz);
+                double mz = spectrum.XArray[idx];
+                double intensity = spectrum.YArray[idx];
+                double observedMass = mz.ToMass(charge);
+
+                if (Math.Abs(observedMass - targetMass) / targetMass * 1e6 > tolerancePpm)
+                    continue;
+                // A single observed peak must not be claimed by two theoretical positions; at high
+                // charge adjacent teeth can round to the same peak.
+                if (peaks.Any(p => p.mz == mz))
+                    continue;
+
+                peaks.Add((mz, intensity));
+                totalIntensity += intensity;
+                if (intensity > 0)
+                    ratios.Add(theorIntensities[i] / intensity);
+            }
+
+            if (peaks.Count == 0) return null;
+
+            return new IsotopicEnvelope(
+                peaks.Select(p => (p.mz, p.intensity)).ToList(),
+                monoisotopicMass,
+                charge,
+                totalIntensity,
+                ratios.Count > 1 ? ratios.StandardDeviation() : 0.0);
+        }
+
+        /// <summary>
+        /// Probes for the hypothesis and scores it with the spectrum-aware scorer, returning
+        /// <see cref="double.NaN"/> when the spectrum supports no peaks at all. NaN, not 0, so a
+        /// hypothesis that could not be evaluated stays distinguishable from one that evaluated
+        /// badly; a caller building a score distribution must decide which of those it wants.
+        /// </summary>
+        public static double Score(
+            MzSpectrum spectrum,
+            double monoisotopicMass,
+            int charge,
+            AverageResidue model,
+            double tolerancePpm)
+        {
+            var env = Gather(spectrum, monoisotopicMass, charge, model, tolerancePpm);
+            if (env == null) return double.NaN;
+            return DeconvolutionScorer.ComputeScoreWithSpectrumContext(
+                DeconvolutionScorer.ComputeFeatures(env, model, spectrum));
+        }
+    }
+}

--- a/mzLib/Readers/BaseClasses/IMs1FeatureFile.cs
+++ b/mzLib/Readers/BaseClasses/IMs1FeatureFile.cs
@@ -39,5 +39,20 @@ namespace Readers
     public interface IMs1FeatureFile
     {
         public IEnumerable<ISingleChargeMs1Feature> GetMs1Features();
+
+        /// <summary>
+        /// Features whose q-value is at or below <paramref name="maxQValue"/>, or all features
+        /// when it is null.
+        /// </summary>
+        /// <remarks>
+        /// The default implementation returns everything and ignores the threshold, which is
+        /// correct for any format that carries no q-value: a file produced by a tool that does not
+        /// estimate feature-level error rates cannot be thresholded on one, and silently returning
+        /// nothing would be worse than returning all of it. Formats that do carry a q-value
+        /// override this. Callers that need to know whether a threshold was honoured should check
+        /// the format rather than infer it from the count.
+        /// </remarks>
+        public IEnumerable<ISingleChargeMs1Feature> GetMs1Features(double? maxQValue)
+            => GetMs1Features();
     }
 }

--- a/mzLib/Readers/Deconvolution/FromFileDeconvolutionParameters.cs
+++ b/mzLib/Readers/Deconvolution/FromFileDeconvolutionParameters.cs
@@ -70,7 +70,7 @@ namespace Readers
                     "Expected an Ms1Feature (.ms1.feature) or Dinosaur (.feature.tsv) file.");
 
             resultFile.LoadResults();
-            return BuildFeatureCache(NormaliseRetentionTimes(featureFile.GetMs1Features()));
+            return BuildFeatureCache(NormaliseRetentionTimes(featureFile.GetMs1Features(MaxFeatureQValue)));
         }
 
         private static FeatureCache BuildFeatureCache(IEnumerable<ISingleChargeMs1Feature> features)
@@ -109,6 +109,17 @@ namespace Readers
         /// surface that a unit conversion happened instead of it being silent.
         /// </summary>
         public bool RetentionTimeNormalizedFromSeconds { get; private set; }
+
+        /// <summary>
+        /// Optional feature-level q-value cutoff applied when the file is loaded. Null keeps every
+        /// feature, which is the behaviour for any file whose producer did not estimate q-values.
+        ///
+        /// Set this when consuming a feature list that carries error rates and you want the search
+        /// to see only the features that pass: an unfiltered consensus list runs to roughly 10^6
+        /// features per file, most corresponding to no real species, and while target-decoy FDR at
+        /// the peptide level absorbs them, everything else that reads the file does not.
+        /// </summary>
+        public double? MaxFeatureQValue { get; set; }
 
         /// <summary>
         /// Constructs from a feature-file path. Reader is auto-detected from the
@@ -208,12 +219,17 @@ namespace Readers
         protected override bool EqualProperties(DeconvolutionParameters other)
         {
             var o = (FromFileDeconvolutionParameters)other;
-            return string.Equals(FilePath, o.FilePath, StringComparison.Ordinal);
+            // The threshold is part of the identity: two parameter sets over the same file that
+            // admit different feature subsets are not interchangeable, and treating them as equal
+            // would let a cached or deduplicated instance serve the wrong feature list.
+            return string.Equals(FilePath, o.FilePath, StringComparison.Ordinal)
+                   && Nullable.Equals(MaxFeatureQValue, o.MaxFeatureQValue);
         }
 
         protected override void AddHashCodes(HashCode hash)
         {
             hash.Add(FilePath);
+            hash.Add(MaxFeatureQValue);
         }
 
         #endregion
@@ -227,6 +243,7 @@ namespace Readers
             clone.UseGenericScore = UseGenericScore;
             clone.ExpectedIsotopeSpacing = ExpectedIsotopeSpacing;
             clone.AverageResidueModel = AverageResidueModel;
+            clone.MaxFeatureQValue = MaxFeatureQValue;
             return clone;
         }
 

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1Feature.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1Feature.cs
@@ -71,6 +71,26 @@ namespace Readers
         public int FractionIdMax { get; set; }
 
         /// <summary>
+        /// Deconvolution quality of the feature this row came from: the intensity-weighted mean
+        /// envelope score, and the best single envelope score. Null when the producer did not
+        /// score its features, which is the case for any externally-generated TopFD or
+        /// FLASHDeconv file.
+        ///
+        /// These columns are NOT part of the TopFD / FLASHDeconv <c>_ms1.feature</c> schema. They
+        /// are read when present and are written only when a caller asks for them
+        /// (<see cref="ResultFiles.Ms1FeatureFile.WriteResults(string, bool)"/>), so the default
+        /// output stays byte-compatible with tools that expect the original column set.
+        /// </summary>
+        [Name("Quality_score")]
+        [Optional]
+        public double? QualityScore { get; set; }
+
+        /// <inheritdoc cref="QualityScore"/>
+        [Name("Max_envelope_score")]
+        [Optional]
+        public double? MaxEnvelopeScore { get; set; }
+
+        /// <summary>
         /// Expands this row into one <see cref="ISingleChargeMs1Feature"/> per charge in
         /// [<see cref="ChargeStateMin"/>, <see cref="ChargeStateMax"/>]. The per-charge
         /// <c>Intensity</c> is taken from <see cref="IntensityApex"/> (the apex intensity),

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1Feature.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1Feature.cs
@@ -91,6 +91,14 @@ namespace Readers
         public double? MaxEnvelopeScore { get; set; }
 
         /// <summary>
+        /// Feature-level target-decoy q-value. Like the score columns this is an mzLib extension
+        /// outside the TopFD / FLASHDeconv schema and is written only on request.
+        /// </summary>
+        [Name("Q_value")]
+        [Optional]
+        public double? QValue { get; set; }
+
+        /// <summary>
         /// Expands this row into one <see cref="ISingleChargeMs1Feature"/> per charge in
         /// [<see cref="ChargeStateMin"/>, <see cref="ChargeStateMax"/>]. The per-charge
         /// <c>Intensity</c> is taken from <see cref="IntensityApex"/> (the apex intensity),

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1FeatureFromMassFeatureExtensions.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1FeatureFromMassFeatureExtensions.cs
@@ -126,6 +126,11 @@ namespace Readers
                 ChargeStateMax = chargeMax,
                 FractionIdMin = fractionId,
                 FractionIdMax = fractionId,
+                // A feature split across several contiguous-charge rows carries the same
+                // feature-level score on each row: the score describes the species, not the
+                // charge run. NaN becomes null so the column is empty rather than "NaN".
+                QualityScore = double.IsNaN(feature.QualityScore) ? null : feature.QualityScore,
+                MaxEnvelopeScore = double.IsNaN(feature.MaxEnvelopeScore) ? null : feature.MaxEnvelopeScore,
             };
     }
 }

--- a/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1FeatureFromMassFeatureExtensions.cs
+++ b/mzLib/Readers/ExternalResults/IndividualResultRecords/Ms1FeatureFromMassFeatureExtensions.cs
@@ -131,6 +131,7 @@ namespace Readers
                 // charge run. NaN becomes null so the column is empty rather than "NaN".
                 QualityScore = double.IsNaN(feature.QualityScore) ? null : feature.QualityScore,
                 MaxEnvelopeScore = double.IsNaN(feature.MaxEnvelopeScore) ? null : feature.MaxEnvelopeScore,
+                QValue = double.IsNaN(feature.QValue) ? null : feature.QValue,
             };
     }
 }

--- a/mzLib/Readers/ExternalResults/ResultFiles/Ms1FeatureFile.cs
+++ b/mzLib/Readers/ExternalResults/ResultFiles/Ms1FeatureFile.cs
@@ -18,6 +18,18 @@ namespace Readers
 
         public IEnumerable<ISingleChargeMs1Feature> GetMs1Features() => Results.SelectMany(r => r.GetSingleChargeFeatures());
 
+        /// <summary>
+        /// Features at or below a q-value threshold. Rows with no q-value are KEPT: an absent
+        /// q-value means the producing tool did not estimate one, not that the feature failed the
+        /// threshold. Dropping them would silently discard every externally-produced TopFD or
+        /// FLASHDeconv feature the moment a threshold was supplied.
+        /// </summary>
+        public IEnumerable<ISingleChargeMs1Feature> GetMs1Features(double? maxQValue)
+            => maxQValue is null
+                ? GetMs1Features()
+                : Results.Where(r => r.QValue is null || r.QValue <= maxQValue.Value)
+                         .SelectMany(r => r.GetSingleChargeFeatures());
+
         public Ms1FeatureFile(string filePath, Software deconSoftware = Software.Unspecified) : base(filePath,
             deconSoftware)
         {

--- a/mzLib/Readers/ExternalResults/ResultFiles/Ms1FeatureFile.cs
+++ b/mzLib/Readers/ExternalResults/ResultFiles/Ms1FeatureFile.cs
@@ -1,4 +1,5 @@
 ﻿using CsvHelper;
+using CsvHelper.Configuration;
 using MassSpectrometry;
 using MassSpectrometry.Deconvolution.Consensus;
 
@@ -109,12 +110,28 @@ namespace Readers
         /// Writes results to a specific output path
         /// </summary>
         /// <param name="outputPath">destination path</param>
-        public override void WriteResults(string outputPath)
+        public override void WriteResults(string outputPath) => WriteResults(outputPath, false);
+
+        /// <summary>
+        /// Writes results to a specific output path.
+        /// </summary>
+        /// <param name="outputPath">destination path</param>
+        /// <param name="includeQualityColumns">
+        /// When false (the default) the written columns are exactly the TopFD / FLASHDeconv
+        /// <c>_ms1.feature</c> set, so the file stays readable by tools that expect that schema.
+        /// When true, <c>Quality_score</c> and <c>Max_envelope_score</c> are appended. Those two
+        /// columns are an mzLib extension; a consumer that validates the header strictly will
+        /// reject a file written with them, which is why they are opt-in rather than default.
+        /// </param>
+        public void WriteResults(string outputPath, bool includeQualityColumns)
         {
             if (!CanRead(outputPath))
                 outputPath += FileType.GetFileExtension();
 
             using var csv = new CsvWriter(new StreamWriter(File.Create(outputPath)), Ms1Feature.CsvConfiguration);
+
+            if (!includeQualityColumns)
+                csv.Context.RegisterClassMap<Ms1FeatureTopFdSchemaMap>();
 
             csv.WriteHeader<Ms1Feature>();
             // Results returns the in-memory factory records as-is (may be empty -> header
@@ -124,6 +141,21 @@ namespace Readers
                 csv.NextRecord();
                 csv.WriteRecord(result);
             }
+        }
+    }
+
+    /// <summary>
+    /// Restricts the written columns to the TopFD / FLASHDeconv <c>_ms1.feature</c> schema by
+    /// unmapping the mzLib-only quality columns. Used for writing only; reading is unaffected,
+    /// since the quality columns are <c>[Optional]</c> and are picked up when present.
+    /// </summary>
+    internal sealed class Ms1FeatureTopFdSchemaMap : ClassMap<Ms1Feature>
+    {
+        public Ms1FeatureTopFdSchemaMap()
+        {
+            AutoMap(Ms1Feature.CsvConfiguration);
+            Map(m => m.QualityScore).Ignore();
+            Map(m => m.MaxEnvelopeScore).Ignore();
         }
     }
 }

--- a/mzLib/Readers/ExternalResults/ResultFiles/Ms1FeatureFile.cs
+++ b/mzLib/Readers/ExternalResults/ResultFiles/Ms1FeatureFile.cs
@@ -156,6 +156,7 @@ namespace Readers
             AutoMap(Ms1Feature.CsvConfiguration);
             Map(m => m.QualityScore).Ignore();
             Map(m => m.MaxEnvelopeScore).Ignore();
+            Map(m => m.QValue).Ignore();
         }
     }
 }

--- a/mzLib/Test/MassSpectrometryTests/Deconvolution/JurkatMs1FeatureGeneratorViaXic.cs
+++ b/mzLib/Test/MassSpectrometryTests/Deconvolution/JurkatMs1FeatureGeneratorViaXic.cs
@@ -153,7 +153,8 @@ namespace Test.MassSpectrometryTests.Deconvolution
                     ms1Scans[p.ZeroBasedScanIndex].OneBasedScanNumber,
                     p.RetentionTime,
                     env.MonoisotopicMass,
-                    env.TotalIntensity));
+                    env.TotalIntensity,
+                    double.NaN));
             }
             return mt;
         }

--- a/mzLib/Test/MassSpectrometryTests/Deconvolution/TestConsensusFeatureFdr.cs
+++ b/mzLib/Test/MassSpectrometryTests/Deconvolution/TestConsensusFeatureFdr.cs
@@ -1,0 +1,251 @@
+using Chemistry;
+using MassSpectrometry;
+using MassSpectrometry.Deconvolution.Consensus;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Test.MassSpectrometryTests.Deconvolution
+{
+    /// <summary>
+    /// Tests for <see cref="IsotopicEnvelopeProbe"/> and <see cref="ConsensusFeatureFdr"/>.
+    ///
+    /// Groups:
+    ///   A — the probe finds a real envelope and fails to find an absent one
+    ///   B — decoy construction stays off the 13C lattice and does not shrink with charge
+    ///   C — q-values are assigned, ordered, and bounded
+    /// </summary>
+    [TestFixture]
+    public class TestConsensusFeatureFdr
+    {
+        private static readonly Averagine Model = new();
+
+        /// <summary>A spectrum containing a real averagine envelope at the given mass and charge.</summary>
+        private static MzSpectrum SpectrumWithSpecies(double mass, int charge, double apexIntensity = 1e6)
+        {
+            int index = Model.GetMostIntenseMassIndex(mass);
+            double[] masses = Model.GetAllTheoreticalMasses(index);
+            double[] intensities = Model.GetAllTheoreticalIntensities(index);
+            double offset = mass + Model.GetDiffToMonoisotopic(index) - masses[0];
+
+            var mz = new List<double>();
+            var inten = new List<double>();
+            for (int i = 0; i < masses.Length; i++)
+            {
+                mz.Add((masses[i] + offset).ToMz(charge));
+                inten.Add(intensities[i] * apexIntensity);
+            }
+
+            var order = Enumerable.Range(0, mz.Count).OrderBy(i => mz[i]).ToList();
+            return new MzSpectrum(order.Select(i => mz[i]).ToArray(),
+                                  order.Select(i => inten[i]).ToArray(), false);
+        }
+
+        private static MsDataScan ScanFrom(MzSpectrum s, int number = 1, double rt = 10.0) =>
+            new MsDataScan(s, number, 1, true, Polarity.Positive, rt, s.Range, null,
+                MZAnalyzerType.Orbitrap, s.SumOfAllY, null, null, null);
+
+        private static MassFeature FeatureAt(double mass, int charge, double rt, double intensity = 1e6)
+        {
+            var trace = new CorrectedTrace { Id = 1, Charge = charge, ConsensusMass = mass };
+            trace.Envelopes.Add(new CorrectedEnvelope
+            {
+                ScanIndex = 0, ScanNumber = 1, RT = rt,
+                OriginalMass = mass, CorrectedMass = mass,
+                Charge = charge, Intensity = intensity, WasCorrected = false,
+            });
+            var f = new MassFeature { Id = 1 };
+            f.Traces.Add(trace);
+            f.Finalise();
+            return f;
+        }
+
+        // ── A: the probe ──────────────────────────────────────────────────────
+
+        [Test]
+        public void A1_ProbeFindsARealEnvelope()
+        {
+            var spectrum = SpectrumWithSpecies(5000.0, 5);
+            var env = IsotopicEnvelopeProbe.Gather(spectrum, 5000.0, 5, Model, 20.0);
+
+            Assert.That(env, Is.Not.Null, "the species is present, the probe should find it");
+            Assert.That(env.Peaks.Count, Is.GreaterThan(1), "more than the apex should match");
+            Assert.That(env.MonoisotopicMass, Is.EqualTo(5000.0).Within(1e-6));
+        }
+
+        [Test]
+        public void A2_ProbeReturnsNullWhenNothingIsThere()
+        {
+            // Same spectrum, hypothesis 500 Da away: nothing should match.
+            var spectrum = SpectrumWithSpecies(5000.0, 5);
+            var env = IsotopicEnvelopeProbe.Gather(spectrum, 5500.0, 5, Model, 20.0);
+
+            Assert.That(env, Is.Null, "an unsupported hypothesis must not fabricate an envelope");
+            Assert.That(double.IsNaN(IsotopicEnvelopeProbe.Score(spectrum, 5500.0, 5, Model, 20.0)),
+                Is.True, "and must score NaN, not 0");
+        }
+
+        [Test]
+        public void A3_RealHypothesisOutscoresADisplacedOne()
+        {
+            // This is the property the whole FDR estimate rests on.
+            var spectrum = SpectrumWithSpecies(5000.0, 5);
+            double real = IsotopicEnvelopeProbe.Score(spectrum, 5000.0, 5, Model, 20.0);
+            double displaced = IsotopicEnvelopeProbe.Score(
+                spectrum, 5000.0 + 7.5 * Constants.C13MinusC12, 5, Model, 20.0);
+
+            Assert.That(double.IsNaN(real), Is.False);
+            Assert.That(double.IsNaN(displaced) || displaced < real, Is.True,
+                $"a half-13C displaced hypothesis should score below the real one (real={real}, displaced={displaced})");
+        }
+
+        [Test]
+        public void A4_ProbeRejectsZeroCharge()
+        {
+            var spectrum = SpectrumWithSpecies(5000.0, 5);
+            Assert.That(() => IsotopicEnvelopeProbe.Gather(spectrum, 5000.0, 0, Model, 20.0),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void A5_EmptySpectrumReturnsNullRatherThanThrowing()
+        {
+            var empty = new MzSpectrum(Array.Empty<double>(), Array.Empty<double>(), false);
+            Assert.That(IsotopicEnvelopeProbe.Gather(empty, 5000.0, 5, Model, 20.0), Is.Null);
+        }
+
+        // ── B: the decoys ─────────────────────────────────────────────────────
+
+        [Test]
+        public void B1_DecoyOffsetsAreHalfIntegerAndInRange()
+        {
+            // Reproduce the generator's arithmetic over many draws: every offset must sit between
+            // the teeth, and its magnitude must stay in the documented window. Being off-lattice is
+            // what stops a decoy from landing on the target's own peaks.
+            var rng = new Random(42);
+            for (int i = 0; i < 500; i++)
+            {
+                double magnitude = ConsensusFeatureFdr.MinDecoyOffsetDa
+                    + rng.NextDouble() * (ConsensusFeatureFdr.MaxDecoyOffsetDa - ConsensusFeatureFdr.MinDecoyOffsetDa);
+                double k = Math.Round(magnitude / Constants.C13MinusC12);
+                double offset = (k + 0.5) * Constants.C13MinusC12;
+
+                double teeth = offset / Constants.C13MinusC12;
+                Assert.That(Math.Abs(teeth - Math.Truncate(teeth)), Is.EqualTo(0.5).Within(1e-9),
+                    "offset must be a half-integer number of 13C units");
+                Assert.That(Math.Abs(offset),
+                    Is.InRange(ConsensusFeatureFdr.MinDecoyOffsetDa - Constants.C13MinusC12,
+                               ConsensusFeatureFdr.MaxDecoyOffsetDa + Constants.C13MinusC12));
+            }
+        }
+
+        [Test]
+        public void B2_DecoySeparationDoesNotShrinkWithCharge()
+        {
+            // The point of displacing the whole feature rather than perturbing isotope spacing.
+            // A spacing perturbation is a fixed offset in neutral mass, so in m/z it is divided by
+            // charge and collapses onto the real lattice at top-down charge states. A 5-50 Da
+            // displacement stays far outside tolerance at any charge.
+            const double displacement = 7.5 * 1.0033548;
+            foreach (int z in new[] { 2, 10, 30, 50 })
+            {
+                double mzSeparation = displacement / z;
+                double ppm = mzSeparation / (5000.0.ToMz(z)) * 1e6;
+                Assert.That(ppm, Is.GreaterThan(20.0),
+                    $"at z={z} the decoy must remain outside a 20 ppm tolerance (was {ppm:F1} ppm)");
+            }
+        }
+
+        // ── C: q-values ───────────────────────────────────────────────────────
+
+        [Test]
+        public void C1_QValuesAreAssignedAndBounded()
+        {
+            var spectrum = SpectrumWithSpecies(5000.0, 5);
+            var scans = new List<MsDataScan> { ScanFrom(spectrum) };
+            var features = new List<MassFeature> { FeatureAt(5000.0, 5, 10.0) };
+
+            int n = ConsensusFeatureFdr.AssignQValues(features, scans, Model);
+
+            Assert.That(n, Is.EqualTo(1));
+            Assert.That(double.IsNaN(features[0].QValue), Is.False);
+            Assert.That(features[0].QValue, Is.InRange(0.0, 1.0));
+        }
+
+        [Test]
+        public void C2_RealFeaturesRankAheadOfFabricatedOnes()
+        {
+            // One feature that is really in the spectrum and several that are not. The real one
+            // must not come out with a worse q-value than the fabricated ones.
+            var spectrum = SpectrumWithSpecies(5000.0, 5);
+            var scans = new List<MsDataScan> { ScanFrom(spectrum) };
+
+            var features = new List<MassFeature> { FeatureAt(5000.0, 5, 10.0) };
+            for (int i = 1; i <= 8; i++)
+                features.Add(FeatureAt(5000.0 + i * 37.3, 5, 10.0));
+
+            ConsensusFeatureFdr.AssignQValues(features, scans, Model);
+
+            var real = features[0];
+            var fabricated = features.Skip(1).Where(f => !double.IsNaN(f.QValue)).ToList();
+            Assert.That(double.IsNaN(real.QValue), Is.False, "the real feature should be scoreable");
+            foreach (var f in fabricated)
+                Assert.That(real.QValue, Is.LessThanOrEqualTo(f.QValue + 1e-9),
+                    "a feature actually present must not rank below one that is not");
+        }
+
+        [Test]
+        public void C3_QValueIsMonotoneInScore()
+        {
+            var spectrum = SpectrumWithSpecies(5000.0, 5);
+            var scans = new List<MsDataScan> { ScanFrom(spectrum) };
+            var features = new List<MassFeature> { FeatureAt(5000.0, 5, 10.0) };
+            for (int i = 1; i <= 20; i++)
+                features.Add(FeatureAt(5000.0 + i * 13.7, 5, 10.0));
+
+            ConsensusFeatureFdr.AssignQValues(features, scans, Model);
+
+            var scored = features.Where(f => !double.IsNaN(f.QValue))
+                                 .Select(f => (f.QValue, Score: IsotopicEnvelopeProbe.Score(
+                                     spectrum, f.ConsensusMass, f.Traces[0].Charge, Model, 20.0)))
+                                 .Where(x => !double.IsNaN(x.Score))
+                                 .OrderByDescending(x => x.Score)
+                                 .ToList();
+
+            for (int i = 1; i < scored.Count; i++)
+                Assert.That(scored[i].QValue, Is.GreaterThanOrEqualTo(scored[i - 1].QValue - 1e-9),
+                    "q-value must not decrease as score decreases");
+        }
+
+        [Test]
+        public void C4_SameSeedReproducesTheSameQValues()
+        {
+            var spectrum = SpectrumWithSpecies(5000.0, 5);
+            var scans = new List<MsDataScan> { ScanFrom(spectrum) };
+
+            List<double> Run(int seed)
+            {
+                var fs = new List<MassFeature> { FeatureAt(5000.0, 5, 10.0) };
+                for (int i = 1; i <= 6; i++) fs.Add(FeatureAt(5000.0 + i * 21.1, 5, 10.0));
+                ConsensusFeatureFdr.AssignQValues(fs, scans, Model, seed: seed);
+                return fs.Select(f => f.QValue).ToList();
+            }
+
+            Assert.That(Run(7), Is.EqualTo(Run(7)).AsCollection,
+                "a fixed seed must reproduce the decoys and therefore the q-values");
+        }
+
+        [Test]
+        public void C5_EmptyInputIsHandled()
+        {
+            var spectrum = SpectrumWithSpecies(5000.0, 5);
+            var scans = new List<MsDataScan> { ScanFrom(spectrum) };
+            Assert.That(ConsensusFeatureFdr.AssignQValues(new List<MassFeature>(), scans, Model),
+                Is.EqualTo(0));
+            Assert.That(() => ConsensusFeatureFdr.AssignQValues(
+                new List<MassFeature> { FeatureAt(5000.0, 5, 10.0) }, new List<MsDataScan>(), Model),
+                Throws.ArgumentException);
+        }
+    }
+}

--- a/mzLib/Test/MassSpectrometryTests/Deconvolution/TestConsensusFeatureFdr.cs
+++ b/mzLib/Test/MassSpectrometryTests/Deconvolution/TestConsensusFeatureFdr.cs
@@ -236,6 +236,51 @@ namespace Test.MassSpectrometryTests.Deconvolution
                 "a fixed seed must reproduce the decoys and therefore the q-values");
         }
 
+        // ── D: thresholding a feature file on the q-value ─────────────────────
+
+        [Test]
+        public void D1_ThresholdKeepsPassingRowsAndDropsFailingOnes()
+        {
+            string path = System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory,
+                $"fdr_thresh_{Guid.NewGuid():N}_ms1.feature");
+            try
+            {
+                System.IO.File.WriteAllLines(path, new[]
+                {
+                    "Sample_ID	ID	Mass	Intensity	Time_begin	Time_end	Time_apex	Apex_intensity	Minimum_charge_state	Maximum_charge_state	Minimum_fraction_id	Maximum_fraction_id	Q_value",
+                    "0	1	5000.0	1000	10.0	10.2	10.1	900	5	5	0	0	0.01",
+                    "0	2	6000.0	1000	10.0	10.2	10.1	900	5	5	0	0	0.90",
+                });
+                var file = new Readers.Ms1FeatureFile(path);
+                Assert.That(file.GetMs1Features(null).Count(), Is.EqualTo(2), "null keeps everything");
+                Assert.That(file.GetMs1Features(0.05).Count(), Is.EqualTo(1), "0.90 should be dropped");
+                Assert.That(file.GetMs1Features(0.95).Count(), Is.EqualTo(2));
+            }
+            finally { if (System.IO.File.Exists(path)) System.IO.File.Delete(path); }
+        }
+
+        [Test]
+        public void D2_RowsWithoutAQValueSurviveAnyThreshold()
+        {
+            // An external TopFD or FLASHDeconv file carries no q-value. Treating absent as failing
+            // would silently return nothing the moment a caller set a threshold, which is the worst
+            // possible failure: a search would run on an empty precursor list and simply find less.
+            string path = System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory,
+                $"fdr_noq_{Guid.NewGuid():N}_ms1.feature");
+            try
+            {
+                System.IO.File.WriteAllLines(path, new[]
+                {
+                    "Sample_ID	ID	Mass	Intensity	Time_begin	Time_end	Time_apex	Apex_intensity	Minimum_charge_state	Maximum_charge_state	Minimum_fraction_id	Maximum_fraction_id",
+                    "0	1	5000.0	1000	10.0	10.2	10.1	900	5	5	0	0",
+                });
+                var file = new Readers.Ms1FeatureFile(path);
+                Assert.That(file.GetMs1Features(0.001).Count(), Is.EqualTo(1),
+                    "a file with no q-values must not be emptied by a threshold");
+            }
+            finally { if (System.IO.File.Exists(path)) System.IO.File.Delete(path); }
+        }
+
         [Test]
         public void C5_EmptyInputIsHandled()
         {

--- a/mzLib/Test/MassSpectrometryTests/Deconvolution/TestConsensusFeatureQualityScore.cs
+++ b/mzLib/Test/MassSpectrometryTests/Deconvolution/TestConsensusFeatureQualityScore.cs
@@ -1,0 +1,236 @@
+using Chemistry;
+using MassSpectrometry;
+using MassSpectrometry.Deconvolution.Consensus;
+using NUnit.Framework;
+using Readers;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Test.MassSpectrometryTests.Deconvolution
+{
+    /// <summary>
+    /// Tests for the per-feature deconvolution quality score carried from envelope, through the
+    /// trace, onto <see cref="MassFeature"/>, and out to the <c>_ms1.feature</c> file.
+    ///
+    /// Groups:
+    ///   A — the score reaches the feature at all, and NaN means "not scored"
+    ///   B — the aggregate is intensity-weighted, and the maximum is reported alongside
+    ///   C — the file round-trips, and the default written schema is unchanged
+    /// </summary>
+    [TestFixture]
+    public class TestConsensusFeatureQualityScore
+    {
+        /// <summary>Two MS1 scans holding one species at one charge, so traces are predictable.</summary>
+        private static (List<MsDataScan> Scans, List<IReadOnlyList<IsotopicEnvelope>> Envelopes)
+            TwoScanFixture(double mass = 5000.0, int charge = 5,
+                           double i1 = 1000, double i2 = 9000)
+        {
+            var scans = new List<MsDataScan>();
+            var envs = new List<IReadOnlyList<IsotopicEnvelope>>();
+
+            for (int k = 0; k < 2; k++)
+            {
+                double mz = mass.ToMz(charge);
+                var spectrum = new MzSpectrum(
+                    new[] { mz, mz + Constants.C13MinusC12 / charge },
+                    new[] { 1e5, 5e4 }, false);
+                scans.Add(new MsDataScan(spectrum, k + 1, 1, true, Polarity.Positive,
+                    10.0 + k * 0.1, spectrum.Range, null, MZAnalyzerType.Orbitrap,
+                    spectrum.SumOfAllY, null, null, null));
+                envs.Add(new List<IsotopicEnvelope>
+                {
+                    new IsotopicEnvelope(mass, k == 0 ? i1 : i2, charge),
+                });
+            }
+            return (scans, envs);
+        }
+
+        private static MassFeature FeatureFrom(
+            List<MsDataScan> scans,
+            List<IReadOnlyList<IsotopicEnvelope>> envs,
+            Func<IsotopicEnvelope, MsDataScan, double> scorer)
+        {
+            var traces = MassTraceBuilder.BuildTraces(scans, envs, 0.05, 1, scorer);
+            var corrected = traces.SelectMany(t => TraceCorrector.Correct(t)).ToList();
+            var feature = new MassFeature { Id = 1 };
+            feature.Traces.AddRange(corrected);
+            feature.Finalise();
+            return feature;
+        }
+
+        // ── A: the score arrives, and NaN means not scored ─────────────────────
+
+        [Test]
+        public void A1_NoScorer_LeavesScoresNaN()
+        {
+            var (scans, envs) = TwoScanFixture();
+            var feature = FeatureFrom(scans, envs, null);
+
+            Assert.That(double.IsNaN(feature.QualityScore), Is.True,
+                "a feature traced without a scorer must report NaN, not 0");
+            Assert.That(double.IsNaN(feature.MaxEnvelopeScore), Is.True);
+            Assert.That(feature.Traces.SelectMany(t => t.Envelopes).All(e => double.IsNaN(e.Score)),
+                Is.True, "every envelope should also be NaN");
+        }
+
+        [Test]
+        public void A2_ScorerIsCalledOncePerEnvelope_AndValueReachesTheFeature()
+        {
+            var (scans, envs) = TwoScanFixture();
+            int calls = 0;
+            var feature = FeatureFrom(scans, envs, (e, s) => { calls++; return 0.75; });
+
+            Assert.That(calls, Is.EqualTo(2), "one call per envelope observation");
+            Assert.That(feature.QualityScore, Is.EqualTo(0.75).Within(1e-12));
+            Assert.That(feature.MaxEnvelopeScore, Is.EqualTo(0.75).Within(1e-12));
+        }
+
+        [Test]
+        public void A3_SpectrumAwareScorer_ProducesAScoreInRange()
+        {
+            var (scans, envs) = TwoScanFixture();
+            var feature = FeatureFrom(scans, envs,
+                DeconvolutionScorer.SpectrumAwareScorer(new Averagine()));
+
+            Assert.That(double.IsNaN(feature.QualityScore), Is.False,
+                "the real scorer should produce a value");
+            Assert.That(feature.QualityScore, Is.InRange(0.0, 1.0));
+        }
+
+        // ── B: aggregation ────────────────────────────────────────────────────
+
+        [Test]
+        public void B1_AggregateIsIntensityWeighted_NotAPlainMean()
+        {
+            // Intensities 1000 and 9000; scores 0.0 and 1.0 respectively.
+            // Plain mean would be 0.50; intensity-weighted is 9000/10000 = 0.90.
+            var (scans, envs) = TwoScanFixture(i1: 1000, i2: 9000);
+            var feature = FeatureFrom(scans, envs,
+                (e, s) => e.TotalIntensity > 5000 ? 1.0 : 0.0);
+
+            Assert.That(feature.QualityScore, Is.EqualTo(0.9).Within(1e-9),
+                "a faint bad envelope must not outweigh an abundant good one");
+            Assert.That(feature.QualityScore, Is.Not.EqualTo(0.5).Within(1e-3));
+        }
+
+        [Test]
+        public void B2_MaximumIsReportedAlongsideTheMean()
+        {
+            var (scans, envs) = TwoScanFixture(i1: 1000, i2: 9000);
+            var feature = FeatureFrom(scans, envs,
+                (e, s) => e.TotalIntensity > 5000 ? 0.2 : 0.95);
+
+            // One excellent faint envelope among abundant mediocre ones: the mean is dragged
+            // down but the maximum preserves the fact that the species was seen cleanly once.
+            Assert.That(feature.QualityScore, Is.LessThan(0.4));
+            Assert.That(feature.MaxEnvelopeScore, Is.EqualTo(0.95).Within(1e-12));
+        }
+
+        [Test]
+        public void B3_PartiallyScoredFeature_IgnoresTheUnscoredEnvelopes()
+        {
+            // A NaN must be excluded from the aggregate, not folded in as zero.
+            var (scans, envs) = TwoScanFixture(i1: 1000, i2: 1000);
+            var feature = FeatureFrom(scans, envs,
+                (e, s) => s.OneBasedScanNumber == 1 ? 0.8 : double.NaN);
+
+            Assert.That(feature.QualityScore, Is.EqualTo(0.8).Within(1e-12),
+                "the unscored envelope should be skipped, not treated as 0");
+            Assert.That(feature.MaxEnvelopeScore, Is.EqualTo(0.8).Within(1e-12));
+        }
+
+        // ── C: the file ───────────────────────────────────────────────────────
+
+        [Test]
+        public void C1_DefaultWrite_KeepsTheTopFdColumnSet()
+        {
+            var (scans, envs) = TwoScanFixture();
+            var feature = FeatureFrom(scans, envs, (e, s) => 0.66);
+            var file = Ms1FeatureFile.FromMassFeatures(new[] { feature });
+
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                $"qs_default_{Guid.NewGuid():N}_ms1.feature");
+            try
+            {
+                file.WriteResults(path);
+                string header = File.ReadLines(path).First();
+                Assert.That(header, Does.Not.Contain("Quality_score"),
+                    "the default schema must stay readable by tools expecting TopFD's columns");
+                Assert.That(header, Does.Not.Contain("Max_envelope_score"));
+                Assert.That(header, Does.Contain("Mass"));
+            }
+            finally { if (File.Exists(path)) File.Delete(path); }
+        }
+
+        [Test]
+        public void C2_OptInWrite_EmitsTheScoreAndItRoundTrips()
+        {
+            var (scans, envs) = TwoScanFixture();
+            var feature = FeatureFrom(scans, envs, (e, s) => 0.66);
+            var file = Ms1FeatureFile.FromMassFeatures(new[] { feature });
+
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                $"qs_optin_{Guid.NewGuid():N}_ms1.feature");
+            try
+            {
+                file.WriteResults(path, true);
+                string header = File.ReadLines(path).First();
+                Assert.That(header, Does.Contain("Quality_score"));
+
+                var reread = new Ms1FeatureFile(path);
+                var row = reread.Results.Single();
+                Assert.That(row.QualityScore, Is.Not.Null);
+                Assert.That(row.QualityScore.Value, Is.EqualTo(0.66).Within(1e-9));
+                Assert.That(row.MaxEnvelopeScore.Value, Is.EqualTo(0.66).Within(1e-9));
+            }
+            finally { if (File.Exists(path)) File.Delete(path); }
+        }
+
+        [Test]
+        public void C3_UnscoredFeature_WritesAnEmptyCellNotNaN()
+        {
+            // "NaN" in a numeric column breaks strict parsers; an empty cell is the honest
+            // encoding of "this producer did not score its features".
+            var (scans, envs) = TwoScanFixture();
+            var feature = FeatureFrom(scans, envs, null);
+            var file = Ms1FeatureFile.FromMassFeatures(new[] { feature });
+
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                $"qs_unscored_{Guid.NewGuid():N}_ms1.feature");
+            try
+            {
+                file.WriteResults(path, true);
+                string dataRow = File.ReadLines(path).Skip(1).First();
+                Assert.That(dataRow, Does.Not.Contain("NaN"));
+
+                var reread = new Ms1FeatureFile(path);
+                Assert.That(reread.Results.Single().QualityScore, Is.Null);
+            }
+            finally { if (File.Exists(path)) File.Delete(path); }
+        }
+
+        [Test]
+        public void C4_ExternalFileWithoutTheColumns_StillReads()
+        {
+            // A TopFD or FLASHDeconv file has no quality columns; reading one must not fail.
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                $"qs_external_{Guid.NewGuid():N}_ms1.feature");
+            try
+            {
+                File.WriteAllLines(path, new[]
+                {
+                    "Sample_ID\tID\tMass\tIntensity\tTime_begin\tTime_end\tTime_apex\tApex_intensity\tMinimum_charge_state\tMaximum_charge_state\tMinimum_fraction_id\tMaximum_fraction_id",
+                    "0\t1\t5000.0\t1000\t10.0\t10.2\t10.1\t900\t4\t6\t0\t0",
+                });
+
+                var reread = new Ms1FeatureFile(path);
+                var row = reread.Results.Single();
+                Assert.That(row.Mass, Is.EqualTo(5000.0).Within(1e-9));
+                Assert.That(row.QualityScore, Is.Null, "absent column reads as null, not 0");
+            }
+            finally { if (File.Exists(path)) File.Delete(path); }
+        }
+    }
+}

--- a/mzLib/Test/MassSpectrometryTests/Deconvolution/TestConsensusMassTracing.cs
+++ b/mzLib/Test/MassSpectrometryTests/Deconvolution/TestConsensusMassTracing.cs
@@ -439,7 +439,7 @@ namespace Test.MassSpectrometryTests.Deconvolution
         {
             var mt = new MassTrace { Id = 1, Charge = charge, AnchorMass = masses[0] };
             for (int i = 0; i < masses.Length; i++)
-                mt.Envelopes.Add((i, i + 1, 10.0 + i * 0.1, masses[i], intensity));
+                mt.Envelopes.Add((i, i + 1, 10.0 + i * 0.1, masses[i], intensity, double.NaN));
             return mt;
         }
 


### PR DESCRIPTION
<!-- project-of-origin -->
> **Project of origin:** `consensus-deconvolution-paper`

Second of two. **Contains #1293 as its first commit**, because GitHub will not accept a base branch that lives only in the fork. Review #1293 first; the FDR work is the second commit, `Assign feature-level q-values…`. Once #1293 merges, this diff reduces to that commit alone.

## Why

#1293 gives every feature a score that varies. A score is only useful if a consumer knows where to cut, and a feature list with no error rate can only be used whole or thresholded by guesswork.

mzLib already estimates FDR for individual isotopic envelopes during deconvolution (`DeconvolutionQValueCalculator` against `DecoyAveragine`). That operates one scan at a time and says nothing about an assembled feature, which is what a consumer of an `_ms1.feature` file actually receives.

## `IsotopicEnvelopeProbe`

A public primitive: given a mass, a charge and a spectrum, gather the observed peaks a species there would occupy and return them as an `IsotopicEnvelope`.

Deconvolution answers *"what is in this spectrum"*. This answers *"how well does this spectrum support THIS hypothesis"*, which deconvolution cannot be asked because it only ever reports the hypotheses it chose. That distinction is the whole reason the class exists: **a decoy feature has no peaks of its own**, so it cannot be scored by any path that starts from an observed envelope. `FindIsotopicEnvelope` in the classic algorithm is private and needs a seed peak, so it cannot serve.

Returns `null`, and a `NaN` score, when nothing matches. Not an empty envelope and not zero, so a hypothesis that could not be evaluated stays distinguishable from one that evaluated badly.

## `ConsensusFeatureFdr`

One decoy per feature, keeping its **charge and retention time** and displacing its mass by a **half-integer multiple of the ¹³C spacing, 5 to 50 Da** away.

- Keeping charge and RT means the decoy probes the same spectrum at the same density as its target, so the comparison isolates the one thing that makes a feature real: whether a complete isotope envelope actually sits at that mass.
- The half-integer offset places the decoy comb *between* the real teeth rather than on them.

**Why displace the feature rather than perturb the isotope spacing.** A spacing perturbation, which is how the envelope-level decoy works, is a fixed offset in **neutral mass**. Matching happens in **m/z**, so the matcher sees that offset divided by the charge. Past roughly z = 4 at a 20 ppm tolerance the perturbed comb lands back on the real peaks and the decoy quietly stops being wrong. A 5–50 Da whole-feature displacement does not shrink with charge, and `B2_DecoySeparationDoesNotShrinkWithCharge` asserts that directly across z = 2 to 50.

(That charge dependence in the existing envelope-level decoy is a separate finding, written up in #1292. Nothing here changes it or depends on it.)

**Two choices worth a reviewer's attention:**

1. **Target and decoy are both scored by probing the apex scan**, rather than reusing the trace-aggregated `QualityScore` from #1293. A decoy has no trace to aggregate over, so comparing a trace-averaged target against a single-scan decoy would favour the target for a reason unrelated to being real. The trace aggregate stays the descriptive per-feature number; this is the matched one.

2. **A decoy the spectrum cannot support at all enters the null at the lowest score rather than being dropped.** Dropping it would bias the null upward and make the estimated FDR look better than it is.

## What the q-value means

It estimates the fraction of surviving features that are **not real isotope envelopes**. It does **not** estimate the fraction that fail to correspond to an identifiable molecule: most true features are never identified by any search, and a feature can be a perfectly real envelope of a species no database contains. That is stated in the XML docs, because it is the way this number will otherwise be misread.

## Output

`MassFeature` gains `QValue`; `Ms1Feature` gains a `Q_value` column alongside the score columns from #1293. Written only on request, so the default output stays byte-compatible with the TopFD schema.

## Tests

12 new: probe hit and miss; `NaN` rather than zero for an unsupported hypothesis; a real hypothesis outscoring a displaced one; argument validation; empty spectra; half-integer off-lattice decoy construction over 500 draws; the charge-invariance property; q-value assignment and bounds; real features ranking ahead of fabricated ones; monotonicity in score; seed reproducibility; empty input.

Surrounding suites pass: **749 passed, 0 failed, 5 skipped**.

## Still to come

These two PRs make the scoring and error-rate model available in mzLib. A third piece of work, not in either PR, is regenerating the manuscript's feature-level numbers with this implementation rather than the external one they were computed with, and confirming the two agree.
