### PR TITLE
Report a spectral count once per file, not once per isobaric channel

### DIFF
--- a/mzLib/Omics/BioPolymerGroup/BioPolymerGroupTsvSchema.cs
+++ b/mzLib/Omics/BioPolymerGroup/BioPolymerGroupTsvSchema.cs
@@ -117,7 +117,7 @@ public static class BioPolymerGroupTsvSchema
                 if (!countLabelByIdentity.ContainsKey(result.CountIdentity))
                 {
                     countIdentities.Add(result.CountIdentity);
-                    countLabelByIdentity[result.CountIdentity] = (result.CountLabel, result.CountLabelSourcePath);
+                    countLabelByIdentity[result.CountIdentity] = (result.CountLabel, result.LabelSourcePath);
                     samplesInCountSection[result.CountIdentity] = [];
                 }
 

--- a/mzLib/Omics/BioPolymerGroup/BioPolymerGroupTsvSchema.cs
+++ b/mzLib/Omics/BioPolymerGroup/BioPolymerGroupTsvSchema.cs
@@ -114,18 +114,23 @@ public static class BioPolymerGroupTsvSchema
         {
             foreach (var result in group.SampleGroupResults!)
             {
-                if (!countLabelByIdentity.ContainsKey(result.CountIdentity))
+                // A null CountIdentity means the result is its own count section, which is every
+                // design but the isobaric one. Resolved here rather than behind the property so the
+                // absent case reads the same way LabelSourcePath's does.
+                string countIdentity = result.CountIdentity ?? result.Identity;
+
+                if (!countLabelByIdentity.ContainsKey(countIdentity))
                 {
-                    countIdentities.Add(result.CountIdentity);
-                    countLabelByIdentity[result.CountIdentity] = (result.CountLabel, result.LabelSourcePath);
-                    samplesInCountSection[result.CountIdentity] = [];
+                    countIdentities.Add(countIdentity);
+                    countLabelByIdentity[countIdentity] = (result.CountLabel ?? result.Label, result.LabelSourcePath);
+                    samplesInCountSection[countIdentity] = [];
                 }
 
                 if (seen.Add(result.Identity))
                 {
                     identities.Add(result.Identity);
                     labelByIdentity[result.Identity] = (result.Label, result.LabelSourcePath);
-                    samplesInCountSection[result.CountIdentity].Add(result.Identity);
+                    samplesInCountSection[countIdentity].Add(result.Identity);
                 }
             }
         }
@@ -234,7 +239,7 @@ public static class BioPolymerGroupTsvSchema
                 foreach (var result in results)
                 {
                     _byIdentity.TryAdd(result.Identity, result);
-                    _byCountIdentity.TryAdd(result.CountIdentity, result);
+                    _byCountIdentity.TryAdd(result.CountIdentity ?? result.Identity, result);
                 }
             }
 

--- a/mzLib/Omics/BioPolymerGroup/BioPolymerGroupTsvSchema.cs
+++ b/mzLib/Omics/BioPolymerGroup/BioPolymerGroupTsvSchema.cs
@@ -71,9 +71,20 @@ public static class BioPolymerGroupTsvSchema
     }
 
     /// <summary>
-    /// One block of columns per sample group in the dataset: spectral count and count-based
-    /// occupancy always, plus intensity and intensity-based occupancy for any sample group that
-    /// carries intensity data in at least one of the groups being written.
+    /// The quantification block, emitted as two declared lists rather than one.
+    ///
+    /// A spectral count and its count-based occupancy describe an acquired FILE; an intensity and
+    /// its intensity-based occupancy describe a SAMPLE — which for an isobaric run is a channel,
+    /// and one file carries many. Each sample group result declares which count section it belongs
+    /// to (<see cref="SampleGroupResult.CountIdentity"/>), so the counting columns are emitted once
+    /// per section and the intensity columns once per sample within it, instead of every column
+    /// family being replicated across one shared key space.
+    ///
+    /// For a label-free design and for no design at all the two spaces coincide — a sample group
+    /// is its own count section — so each section holds exactly one sample and the emitted columns
+    /// are identical to before, name for name and in the same order. Only an isobaric table changes,
+    /// and it changes by losing the eleven identical <c>SpectralCount_</c> values and eleven
+    /// byte-identical <c>CountOccupancy_</c> strings an 11-plex row used to carry.
     /// </summary>
     private static IEnumerable<TsvColumn<BioPolymerGroup>> QuantificationColumns(
         IReadOnlyCollection<BioPolymerGroup> groups)
@@ -84,13 +95,17 @@ public static class BioPolymerGroupTsvSchema
                 group.PopulateSampleGroupResults();
         }
 
-        // Union of the dataset's sample groups, in first-seen order. 
+        // Union of the dataset's count sections and of its sample groups, each in first-seen order.
         //
-        // Sample groups are matched across records by Identity — the files they cover — never by
-        // Label and never by position. Labels are not unique (SampleGroupBuilder names a sample
-        // group after its first file whenever conditions are undefined or a file is missing from
-        // disk, so same-named files in different directories collide), and position is not stable
-        // across records because a record only has sample groups for the files it appears in.
+        // Both are matched across records by identity — never by Label and never by position.
+        // Labels are not unique (SampleGroupBuilder names a sample group after its first file
+        // whenever conditions are undefined or a file is missing from disk, so same-named files in
+        // different directories collide), and position is not stable across records because a record
+        // only has sample groups for the files it appears in.
+        var countIdentities = new List<string>();
+        var countLabelByIdentity = new Dictionary<string, (string Label, string? LabelSourcePath)>();
+        var samplesInCountSection = new Dictionary<string, List<string>>();
+
         var identities = new List<string>();
         var seen = new HashSet<string>();
         var labelByIdentity = new Dictionary<string, (string Label, string? LabelSourcePath)>();
@@ -99,12 +114,19 @@ public static class BioPolymerGroupTsvSchema
         {
             foreach (var result in group.SampleGroupResults!)
             {
+                if (!countLabelByIdentity.ContainsKey(result.CountIdentity))
+                {
+                    countIdentities.Add(result.CountIdentity);
+                    countLabelByIdentity[result.CountIdentity] = (result.CountLabel, result.CountLabelSourcePath);
+                    samplesInCountSection[result.CountIdentity] = [];
+                }
+
                 if (seen.Add(result.Identity))
                 {
                     identities.Add(result.Identity);
                     labelByIdentity[result.Identity] = (result.Label, result.LabelSourcePath);
+                    samplesInCountSection[result.CountIdentity].Add(result.Identity);
                 }
-
             }
         }
 
@@ -117,29 +139,42 @@ public static class BioPolymerGroupTsvSchema
         bool quantified = groups.Any(g => g.SamplesForQuantification is { Count: > 0 }
                                        && g.IntensitiesBySample is not null);
 
+        // Disambiguated independently, because a count section and a sample group are different
+        // things with different names: two files called sample.raw in different directories collide
+        // as count sections even though their channel labels already separate them as samples.
+        var countDisplayLabels = SampleGroupLabels.Disambiguate(countIdentities, countLabelByIdentity);
         var displayLabels = SampleGroupLabels.Disambiguate(identities, labelByIdentity);
 
         var index = new SampleGroupIndex();
         var columns = new List<TsvColumn<BioPolymerGroup>>();
 
-        foreach (var identity in identities)
+        foreach (var countIdentity in countIdentities)
         {
-            string thisIdentity = identity;
-            string display = displayLabels[thisIdentity];
+            string thisCountIdentity = countIdentity;
+            string countDisplay = countDisplayLabels[thisCountIdentity];
+            var samples = samplesInCountSection[thisCountIdentity];
 
-            columns.Add(new TsvColumn<BioPolymerGroup>($"SpectralCount_{display}",
-                g => index.ResultFor(g, thisIdentity)?.SpectralCount.ToString() ?? string.Empty));
-
-            if (quantified)
-                columns.Add(new TsvColumn<BioPolymerGroup>($"Intensity_{display}",
-                    g => index.ResultFor(g, thisIdentity) is { HasIntensityData: true } r ? r.Intensity.ToString() : string.Empty));
-
-            columns.Add(new TsvColumn<BioPolymerGroup>($"CountOccupancy_{display}",
-                g => Truncate(index.ResultFor(g, thisIdentity)?.FormatOccupancy(OccupancyKeys(g), IsParentLevel(g), intensityBased: false))));
+            columns.Add(new TsvColumn<BioPolymerGroup>($"SpectralCount_{countDisplay}",
+                g => index.ResultForCountSection(g, thisCountIdentity)?.SpectralCount.ToString() ?? string.Empty));
 
             if (quantified)
-                columns.Add(new TsvColumn<BioPolymerGroup>($"IntensityOccupancy_{display}",
-                    g => Truncate(index.ResultFor(g, thisIdentity)?.FormatOccupancy(OccupancyKeys(g), IsParentLevel(g), intensityBased: true))));
+                foreach (var identity in samples)
+                {
+                    string thisIdentity = identity;
+                    columns.Add(new TsvColumn<BioPolymerGroup>($"Intensity_{displayLabels[thisIdentity]}",
+                        g => index.ResultFor(g, thisIdentity) is { HasIntensityData: true } r ? r.Intensity.ToString() : string.Empty));
+                }
+
+            columns.Add(new TsvColumn<BioPolymerGroup>($"CountOccupancy_{countDisplay}",
+                g => Truncate(index.ResultForCountSection(g, thisCountIdentity)?.FormatOccupancy(OccupancyKeys(g), IsParentLevel(g), intensityBased: false))));
+
+            if (quantified)
+                foreach (var identity in samples)
+                {
+                    string thisIdentity = identity;
+                    columns.Add(new TsvColumn<BioPolymerGroup>($"IntensityOccupancy_{displayLabels[thisIdentity]}",
+                        g => Truncate(index.ResultFor(g, thisIdentity)?.FormatOccupancy(OccupancyKeys(g), IsParentLevel(g), intensityBased: true))));
+                }
         }
 
         return columns;
@@ -165,8 +200,22 @@ public static class BioPolymerGroupTsvSchema
     {
         private List<SampleGroupResult>? _source;
         private Dictionary<string, SampleGroupResult> _byIdentity = [];
+        private Dictionary<string, SampleGroupResult> _byCountIdentity = [];
 
         public SampleGroupResult? ResultFor(BioPolymerGroup group, string identity)
+            => Index(group)._byIdentity.GetValueOrDefault(identity);
+
+        /// <summary>
+        /// Any one result from a count section. Every result in a section reports the same
+        /// <see cref="SampleGroupResult.SpectralCount"/> and the same count-based occupancy by
+        /// construction — <see cref="SampleGroupBuilder"/> derives both from one file's PSM list and
+        /// hands that same list to each of the file's channels — so which one answers does not
+        /// matter, only that the section is reported once rather than once per channel.
+        /// </summary>
+        public SampleGroupResult? ResultForCountSection(BioPolymerGroup group, string countIdentity)
+            => Index(group)._byCountIdentity.GetValueOrDefault(countIdentity);
+
+        private SampleGroupIndex Index(BioPolymerGroup group)
         {
             if (group.SampleGroupResults is null)
                 group.PopulateSampleGroupResults();
@@ -177,14 +226,19 @@ public static class BioPolymerGroupTsvSchema
             {
                 _source = results;
                 _byIdentity = new Dictionary<string, SampleGroupResult>(results.Count);
+                _byCountIdentity = new Dictionary<string, SampleGroupResult>(results.Count);
 
                 // First wins, matching the FirstOrDefault this replaces — identities are unique
                 // within a group by construction, but TryAdd keeps a hand-built list from throwing.
+                // Count identities are deliberately NOT unique: a plex's channels share one.
                 foreach (var result in results)
+                {
                     _byIdentity.TryAdd(result.Identity, result);
+                    _byCountIdentity.TryAdd(result.CountIdentity, result);
+                }
             }
 
-            return _byIdentity.GetValueOrDefault(identity);
+            return this;
         }
     }
 

--- a/mzLib/Omics/BioPolymerGroup/SampleGroupBuilder.cs
+++ b/mzLib/Omics/BioPolymerGroup/SampleGroupBuilder.cs
@@ -14,6 +14,11 @@ public static class SampleGroupBuilder
     /// <summary>
     /// Groups by (Condition × BiologicalReplicate) for label-free samples, by (File × Channel)
     /// for isobaric samples, and by PSM source file when no experimental design is supplied.
+    ///
+    /// Isobaric results additionally declare a <see cref="SampleGroupResult.CountIdentity"/> of the
+    /// file they came from, because a spectral count is a property of the acquired file while an
+    /// intensity is a property of the channel. The other two designs leave it at its default, where
+    /// the two spaces coincide.
     /// </summary>
     /// <param name="samples">Samples contributing quantification, or null when no design exists.</param>
     /// <param name="intensitiesBySample">Measured intensities keyed by sample, or null when unavailable.
@@ -93,7 +98,13 @@ public static class SampleGroupBuilder
             {
                 var psmsInFile = psms.Where(p => p.FullFilePath.Equals(fileGroup.Key)).ToList();
 
-                foreach (var sample in fileGroup.OrderBy(p => p.ChannelLabel))
+                // Ascending reporter-ion m/z, which is the order the channels are acquired in and
+                // the canonical one for an isobaric plex. Ordering by ChannelLabel instead sorts
+                // "127C" before "127N" in every N/C pair, because C precedes N in an ordinal
+                // comparison but the C reporter is the heavier of the two. Label is the tiebreak so
+                // the order stays deterministic if a design gives two channels the same m/z.
+                foreach (var sample in fileGroup.OrderBy(p => p.ReporterIonMz)
+                                                .ThenBy(p => p.ChannelLabel, StringComparer.Ordinal))
                 {
                     string label = $"{Path.GetFileNameWithoutExtension(sample.FullFilePathWithExtension)}_{sample.ChannelLabel}";
 
@@ -106,6 +117,16 @@ public static class SampleGroupBuilder
                         Label = label,
                         Identity = $"{sample.FullFilePathWithExtension}|{sample.ChannelLabel}",
                         LabelSourcePath = sample.FullFilePathWithExtension,
+
+                        // The count belongs to the file, not to the channel: psmsInFile is one
+                        // file's PSMs and every channel of that file is handed the same list. Each
+                        // channel result still carries the value, because a result is what a column
+                        // reads from, but they all carry the SAME value and the schema renders it
+                        // once per file instead of once per channel.
+                        CountIdentity = fileGroup.Key,
+                        CountLabel = Path.GetFileNameWithoutExtension(fileGroup.Key),
+                        CountLabelSourcePath = fileGroup.Key,
+
                         SpectralCount = psmsInFile.Count,
                         FilesInGroup = new Dictionary<string, ISampleInfo> { { label, sample } },
                         IntensitiesBySample = channelIntensities

--- a/mzLib/Omics/BioPolymerGroup/SampleGroupBuilder.cs
+++ b/mzLib/Omics/BioPolymerGroup/SampleGroupBuilder.cs
@@ -98,11 +98,21 @@ public static class SampleGroupBuilder
             {
                 var psmsInFile = psms.Where(p => p.FullFilePath.Equals(fileGroup.Key)).ToList();
 
-                // Ascending reporter-ion m/z, which is the order the channels are acquired in and
-                // the canonical one for an isobaric plex. Ordering by ChannelLabel instead sorts
-                // "127C" before "127N" in every N/C pair, because C precedes N in an ordinal
-                // comparison but the C reporter is the heavier of the two. Label is the tiebreak so
-                // the order stays deterministic if a design gives two channels the same m/z.
+                // Ascending reporter-ion m/z, which is the order mzLib already declares canonical:
+                // SampleExperimentalDesign.FromSamples says to "pass isobaric channels already
+                // sorted the way the search writes them (ascending reporter m/z, for MetaMorpheus)",
+                // and QuantificationWriter's positional Reporter_n columns follow that same design
+                // array. Ordering by ChannelLabel instead sorts "127C" before "127N" in every N/C
+                // pair -- C precedes N ordinally, but the C reporter is the heavier ion -- so the
+                // grouped table disagreed with the raw one about which 127 came first.
+                //
+                // Sorting on an explicit key rather than OrderBy(p => p): IsobaricQuantSampleInfo's
+                // CompareTo does not look at ChannelLabel or ReporterIonMz at all, and returns 1 in
+                // both directions for two channels of one file, which is not a total order.
+                //
+                // Label is the tiebreak so the order stays deterministic when a design leaves
+                // ReporterIonMz at its default -- nothing validates it -- rather than permuting
+                // arbitrarily.
                 foreach (var sample in fileGroup.OrderBy(p => p.ReporterIonMz)
                                                 .ThenBy(p => p.ChannelLabel, StringComparer.Ordinal))
                 {
@@ -125,7 +135,6 @@ public static class SampleGroupBuilder
                         // once per file instead of once per channel.
                         CountIdentity = fileGroup.Key,
                         CountLabel = Path.GetFileNameWithoutExtension(fileGroup.Key),
-                        CountLabelSourcePath = fileGroup.Key,
 
                         SpectralCount = psmsInFile.Count,
                         FilesInGroup = new Dictionary<string, ISampleInfo> { { label, sample } },

--- a/mzLib/Omics/BioPolymerGroup/SampleGroupResult.cs
+++ b/mzLib/Omics/BioPolymerGroup/SampleGroupResult.cs
@@ -65,30 +65,26 @@ public sealed class SampleGroupResult
     /// strings, three of which sit beside a blank intensity while claiming <c>fraction=1.00(1/1)</c>.
     ///
     /// So the two spaces are declared separately and the schema is told which is which, rather than
-    /// inferring one from the other. Defaults to <see cref="Identity"/>, which is correct wherever
-    /// the two coincide: a label-free sample group and a design-less file are each their own count
-    /// section, and neither their columns nor their values move.
+    /// inferring one from the other.
     /// </summary>
-    public string CountIdentity
-    {
-        get => _countIdentity ?? Identity;
-        init => _countIdentity = value;
-    }
+    /// <remarks>
+    /// Null when this result is its own count section, which is the case for every design where the
+    /// two spaces coincide -- a label-free sample group and a design-less file each count only
+    /// themselves. The reader resolves null to <see cref="Identity"/>, so those designs keep their
+    /// column names and their order unchanged.
+    /// </remarks>
+    public string? CountIdentity { get; init; }
 
     /// <summary>
-    /// Display label for the count section, defaulting to <see cref="Label"/>. Like
-    /// <see cref="Label"/> it is not unique and is disambiguated before it reaches a column name,
-    /// widened with <see cref="LabelSourcePath"/> -- there is no separate path for the count
-    /// section, because the section a result counts under is always a file the result came from.
+    /// Display label for the count section, or null alongside a null <see cref="CountIdentity"/>,
+    /// where the reader resolves it to <see cref="Label"/>.
     /// </summary>
-    public string CountLabel
-    {
-        get => _countLabel ?? Label;
-        init => _countLabel = value;
-    }
-
-    private readonly string? _countIdentity;
-    private readonly string? _countLabel;
+    /// <remarks>
+    /// Like <see cref="Label"/> it is not unique, and is disambiguated before it reaches a column
+    /// name -- widened with <see cref="LabelSourcePath"/>, since there is no separate path for the
+    /// count section: the section a result counts under is always a file that result came from.
+    /// </remarks>
+    public string? CountLabel { get; init; }
 
     #endregion
 

--- a/mzLib/Omics/BioPolymerGroup/SampleGroupResult.cs
+++ b/mzLib/Omics/BioPolymerGroup/SampleGroupResult.cs
@@ -1,4 +1,4 @@
-using MassSpectrometry;
+﻿using MassSpectrometry;
 
 namespace Omics.BioPolymerGroup;
 
@@ -52,6 +52,52 @@ public sealed class SampleGroupResult
     /// groups in a dataset would otherwise present the same column name.
     /// </summary>
     public string? LabelSourcePath { get; init; }
+
+    /// <summary>
+    /// Identity of the section this result's <see cref="SpectralCount"/> and count-based occupancy
+    /// belong to, which is not always the section its intensity belongs to.
+    ///
+    /// A spectral count answers "how many spectra were acquired", so it is a property of the
+    /// acquired FILE. An intensity answers "how much was in this sample", so for an isobaric
+    /// experiment it is a property of the CHANNEL, and one file carries many. Reporting a count per
+    /// channel restates the file's count once per channel: an 11-plex protein row carries eleven
+    /// identical <c>SpectralCount_</c> values and eleven byte-identical <c>CountOccupancy_</c>
+    /// strings, three of which sit beside a blank intensity while claiming <c>fraction=1.00(1/1)</c>.
+    ///
+    /// So the two spaces are declared separately and the schema is told which is which, rather than
+    /// inferring one from the other. Defaults to <see cref="Identity"/>, which is correct wherever
+    /// the two coincide: a label-free sample group and a design-less file are each their own count
+    /// section, and neither their columns nor their values move.
+    /// </summary>
+    public string CountIdentity
+    {
+        get => _countIdentity ?? Identity;
+        init => _countIdentity = value;
+    }
+
+    /// <summary>
+    /// Display label for the count section, defaulting to <see cref="Label"/>. Like
+    /// <see cref="Label"/> it is not unique and is disambiguated before it reaches a column name.
+    /// </summary>
+    public string CountLabel
+    {
+        get => _countLabel ?? Label;
+        init => _countLabel = value;
+    }
+
+    /// <summary>
+    /// The file path <see cref="CountLabel"/> was derived from, for widening a colliding count
+    /// column name. Defaults to <see cref="LabelSourcePath"/>.
+    /// </summary>
+    public string? CountLabelSourcePath
+    {
+        get => _countLabelSourcePath ?? LabelSourcePath;
+        init => _countLabelSourcePath = value;
+    }
+
+    private readonly string? _countIdentity;
+    private readonly string? _countLabel;
+    private readonly string? _countLabelSourcePath;
 
     #endregion
 

--- a/mzLib/Omics/BioPolymerGroup/SampleGroupResult.cs
+++ b/mzLib/Omics/BioPolymerGroup/SampleGroupResult.cs
@@ -77,7 +77,9 @@ public sealed class SampleGroupResult
 
     /// <summary>
     /// Display label for the count section, defaulting to <see cref="Label"/>. Like
-    /// <see cref="Label"/> it is not unique and is disambiguated before it reaches a column name.
+    /// <see cref="Label"/> it is not unique and is disambiguated before it reaches a column name,
+    /// widened with <see cref="LabelSourcePath"/> -- there is no separate path for the count
+    /// section, because the section a result counts under is always a file the result came from.
     /// </summary>
     public string CountLabel
     {
@@ -85,19 +87,8 @@ public sealed class SampleGroupResult
         init => _countLabel = value;
     }
 
-    /// <summary>
-    /// The file path <see cref="CountLabel"/> was derived from, for widening a colliding count
-    /// column name. Defaults to <see cref="LabelSourcePath"/>.
-    /// </summary>
-    public string? CountLabelSourcePath
-    {
-        get => _countLabelSourcePath ?? LabelSourcePath;
-        init => _countLabelSourcePath = value;
-    }
-
     private readonly string? _countIdentity;
     private readonly string? _countLabel;
-    private readonly string? _countLabelSourcePath;
 
     #endregion
 

--- a/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupTests.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupTests.cs
@@ -538,6 +538,42 @@ namespace Test.Omics.BioPolymerGroupTests
         }
 
         /// <summary>
+        /// Every channel of a file reports the same count, which is what lets one column report it.
+        ///
+        /// The schema answers a count section from whichever of its results it indexed first, so
+        /// that is only sound while they agree. They do, by construction -- SampleGroupBuilder
+        /// computes psmsInFile once per file and hands that same list to each channel's
+        /// SpectralCount and to each channel's occupancy callback -- and this pins the agreement so
+        /// a later change that gave channels their own PSM lists cannot quietly make the rendered
+        /// count depend on indexing order.
+        /// </summary>
+        [Test]
+        public void SampleGroupResults_ChannelsOfOneFile_AgreeOnTheCountTheyReport()
+        {
+            var channel126 = new IsobaricQuantSampleInfo(@"C:\agree.raw", "Control", 1, 1, 0, 1, "126", 126.127, false);
+            var channel127N = new IsobaricQuantSampleInfo(@"C:\agree.raw", "Control", 1, 1, 0, 1, "127N", 127.124, false);
+            var channel127C = new IsobaricQuantSampleInfo(@"C:\agree.raw", "Control", 1, 1, 0, 1, "127C", 127.131, false);
+
+            _bioPolymerGroup.SamplesForQuantification = new List<ISampleInfo> { channel126, channel127N, channel127C };
+            _bioPolymerGroup.PopulateSampleGroupResults();
+
+            var results = _bioPolymerGroup.SampleGroupResults;
+
+            Assert.That(results, Has.Count.EqualTo(3), "one result per channel");
+
+            foreach (var section in results.GroupBy(r => r.CountIdentity))
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.That(section.Select(r => r.SpectralCount).Distinct().Count(), Is.EqualTo(1),
+                        $"channels of {section.Key} disagree on SpectralCount, so one count column cannot speak for them");
+                    Assert.That(section.Select(r => r.FormatOccupancy(new[] { "P12345" })).Distinct().Count(), Is.EqualTo(1),
+                        $"channels of {section.Key} disagree on count-based occupancy");
+                });
+            }
+        }
+
+        /// <summary>
         /// A run that quantified but measured nothing still advertises its intensity columns, empty.
         ///
         /// This is mzLib #1240's property stated as behaviour rather than as row width, and it is

--- a/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupTests.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupTests.cs
@@ -472,11 +472,15 @@ namespace Test.Omics.BioPolymerGroupTests
         }
 
         /// <summary>
-        /// Verifies isobaric header groups channels by file and orders by channel label.
-        /// Critical: Channel order in header must match intensity column order for TMT/iTRAQ data.
+        /// A spectral count describes the acquired FILE, so an isobaric header carries one
+        /// <c>SpectralCount_</c> and one <c>CountOccupancy_</c> per file — not one per channel.
+        ///
+        /// Every channel of a file is handed that file's whole PSM list, so a per-channel count
+        /// restates one number n times. Files keep their order; the channels within a file no longer
+        /// each open a counting column of their own.
         /// </summary>
         [Test]
-        public void GetTabSeparatedHeader_Isobaric_GroupsByFileAndOrdersByChannel()
+        public void GetTabSeparatedHeader_Isobaric_CountColumnsAreOnePerFile()
         {
             var sample126 = new IsobaricQuantSampleInfo(@"C:\fileA.raw", "Control", 1, 1, 0, 1, "126", 126.0, false);
             var sample127 = new IsobaricQuantSampleInfo(@"C:\fileA.raw", "Control", 1, 1, 0, 1, "127N", 127.0, false);
@@ -486,13 +490,122 @@ namespace Test.Omics.BioPolymerGroupTests
 
             var header = GroupTsv.Header(_bioPolymerGroup);
 
-            // Channels should be ordered by file path first, then by channel label
-            var index126 = header.IndexOf("fileA_126");
-            var index127 = header.IndexOf("fileA_127N");
-            var index128 = header.IndexOf("fileB_128C");
+            Assert.Multiple(() =>
+            {
+                Assert.That(header, Does.Contain("SpectralCount_fileA"), "fileA needs a count column");
+                Assert.That(header, Does.Contain("SpectralCount_fileB"), "fileB needs a count column");
 
-            Assert.That(index126, Is.LessThan(index127), "126 should come before 127N within same file");
-            Assert.That(index127, Is.LessThan(index128), "fileA channels should come before fileB channels");
+                Assert.That(header, Does.Not.Contain("SpectralCount_fileA_126"),
+                    "a count belongs to the file, so no channel may open one of its own");
+                Assert.That(header, Does.Not.Contain("SpectralCount_fileA_127N"),
+                    "a count belongs to the file, so no channel may open one of its own");
+                Assert.That(header, Does.Not.Contain("CountOccupancy_fileA_126"),
+                    "count-based occupancy is derived from the same per-file PSM list as the count");
+
+                Assert.That(header.IndexOf("SpectralCount_fileA", StringComparison.Ordinal),
+                    Is.LessThan(header.IndexOf("SpectralCount_fileB", StringComparison.Ordinal)),
+                    "fileA's columns should still come before fileB's");
+            });
+        }
+
+        /// <summary>
+        /// Channel columns are ordered by ascending reporter-ion m/z, not by channel label.
+        ///
+        /// TMT N/C pairs are the case that separates the two: 127N is 127.1248 and 127C is 127.1311,
+        /// so the N reporter is the lighter and comes first — but an ordinal comparison of the
+        /// LABELS puts "127C" before "127N", because C precedes N. Ordering by label therefore
+        /// inverts every N/C pair in a plex. The samples are supplied heaviest-first so the assertion
+        /// cannot pass merely by keeping input order.
+        /// </summary>
+        [Test]
+        public void GetTabSeparatedHeader_Isobaric_ChannelColumnsAreOrderedByReporterMz()
+        {
+            var channel127N = new IsobaricQuantSampleInfo(@"C:\fileA.raw", "Control", 1, 1, 0, 1, "127N", 127.124760, false);
+            var channel127C = new IsobaricQuantSampleInfo(@"C:\fileA.raw", "Control", 1, 1, 0, 1, "127C", 127.131079, false);
+
+            _bioPolymerGroup.SamplesForQuantification = new List<ISampleInfo> { channel127C, channel127N };
+            _bioPolymerGroup.IntensitiesBySample = new Dictionary<ISampleInfo, double>
+            {
+                { channel127N, 500.0 },
+                { channel127C, 750.0 }
+            };
+
+            var header = GroupTsv.Header(_bioPolymerGroup);
+
+            Assert.That(header.IndexOf("Intensity_fileA_127N", StringComparison.Ordinal),
+                Is.LessThan(header.IndexOf("Intensity_fileA_127C", StringComparison.Ordinal)),
+                "127N is the lighter reporter and must come first; ordering by label inverts the pair");
+        }
+
+        /// <summary>
+        /// A run that quantified but measured nothing still advertises its intensity columns, empty.
+        ///
+        /// This is mzLib #1240's property stated as behaviour rather than as row width, and it is
+        /// the assertion that keeps the run-level gate honest. Whether the intensity columns exist
+        /// is a property of the RUN — an engine either quantified these groups or it did not — not
+        /// of whether any particular sample group came back with a value. Swap the predicate in
+        /// BioPolymerGroupTsvSchema.QuantificationColumns for the per-sample-group
+        /// SampleGroupResult.HasIntensityData that #1240 rejected and this test goes red: the
+        /// columns disappear entirely instead of standing empty, which is how a group with no
+        /// measured intensity came to describe a narrower table than its neighbour.
+        ///
+        /// A width assertion cannot catch that. TsvWriter.RowLine joins the same schema the header
+        /// came from, so header and row agree by construction whatever the predicate says; only the
+        /// column's presence and its emptiness can still disagree.
+        /// </summary>
+        [Test]
+        public void GetTabSeparatedHeader_QuantifiedRunWithNoMeasuredIntensity_KeepsEmptyIntensityColumns()
+        {
+            var file = new SpectraFileInfo(@"C:\gated.raw", "Control", 0, 0, 0);
+
+            // The run quantified -- samples are declared and the intensity map exists -- but nothing
+            // was measured into it, so every sample group's own HasIntensityData is false.
+            _bioPolymerGroup.SamplesForQuantification = new List<ISampleInfo> { file };
+            _bioPolymerGroup.IntensitiesBySample = new Dictionary<ISampleInfo, double>();
+
+            var columns = GroupTsv.Header(_bioPolymerGroup).Split('\t');
+            var row = GroupTsv.Row(_bioPolymerGroup).Split('\t');
+
+            int intensity = Array.IndexOf(columns, "Intensity_gated");
+
+            // Not inside the Assert.Multiple below: the cell read needs this index, so a missing
+            // column should report itself rather than arrive as an IndexOutOfRangeException.
+            Assert.That(intensity, Is.GreaterThanOrEqualTo(0),
+                "the run quantified, so the intensity column must be advertised even with nothing in it");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(row[intensity], Is.Empty,
+                    "nothing was measured, so the cell must be present and empty rather than a zero");
+                Assert.That(columns, Has.Member("IntensityOccupancy_gated"));
+            });
+        }
+
+        /// <summary>
+        /// Two files of the same name in different directories are distinct count sections, and the
+        /// count columns must say which is which.
+        ///
+        /// The sample columns were already separated by their channel labels, so nothing forces the
+        /// count labels apart unless they are disambiguated in their own right — which is why the
+        /// two sections are widened independently rather than sharing one pass.
+        /// </summary>
+        [Test]
+        public void GetTabSeparatedHeader_Isobaric_SameNamedFilesGetDistinctCountColumns()
+        {
+            var rep1 = new IsobaricQuantSampleInfo(@"C:\Rep1\sample.raw", "Control", 1, 1, 0, 1, "126", 126.0, false);
+            var rep2 = new IsobaricQuantSampleInfo(@"C:\Rep2\sample.raw", "Control", 1, 1, 0, 1, "126", 126.0, false);
+
+            _bioPolymerGroup.SamplesForQuantification = new List<ISampleInfo> { rep1, rep2 };
+
+            var header = GroupTsv.Header(_bioPolymerGroup);
+            var columns = header.Split('\t');
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(columns, Has.Member("SpectralCount_Rep1_sample"));
+                Assert.That(columns, Has.Member("SpectralCount_Rep2_sample"));
+                Assert.That(columns, Is.Unique, "no two columns may share a name");
+            });
         }
 
         #endregion

--- a/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupTsvGoldenTests.cs
+++ b/mzLib/Test/Omics/BioPolymerGroupTests/BioPolymerGroupTsvGoldenTests.cs
@@ -160,6 +160,9 @@ namespace Test.Omics.BioPolymerGroupTests
         /// <summary>
         /// No experimental design: PSMs are grouped by their own file path and only spectral
         /// count and count-based occupancy are emitted (no intensity columns).
+        ///
+        /// Unchanged by the per-section split, for the same reason as the label-free case: with no
+        /// design, a file is both the count section and the sample.
         /// </summary>
         [Test]
         public void NoExperimentalDesign_HeaderAndRowAreUnchanged()
@@ -172,6 +175,10 @@ namespace Test.Omics.BioPolymerGroupTests
         /// <summary>
         /// Label-free with two conditions and intensities: four columns per sample group.
         /// goldenB's occupancy fields are empty because its only PSM carries no modification.
+        ///
+        /// Unchanged by the per-section split, and required to stay so: a label-free sample group is
+        /// its own count section, so the two key spaces coincide and every column keeps its name and
+        /// its position.
         /// </summary>
         [Test]
         public void LabelFreeWithIntensities_HeaderAndRowAreUnchanged()
@@ -188,20 +195,31 @@ namespace Test.Omics.BioPolymerGroupTests
         }
 
         /// <summary>
-        /// Isobaric (TMT/iTRAQ): one four-column block per channel, ordered by file then channel label.
-        /// Spectral count is per file, so both channels report all three PSMs.
+        /// Isobaric (TMT/iTRAQ): the counting columns are emitted once for the acquired file and the
+        /// intensity columns once per channel within it.
+        ///
+        /// This is the one table the per-section split changes, and the change is the point of it.
+        /// Before, each channel carried its own <c>SpectralCount_</c> and <c>CountOccupancy_</c>
+        /// — but a spectral count belongs to the file, and every channel of a file is handed the
+        /// same PSM list, so an n-plex row restated one count n times and one occupancy string n
+        /// times. Here that is 8 quantification columns reduced to 6; on an 11-plex it is 44 reduced
+        /// to 24.
         /// </summary>
         [Test]
-        public void Isobaric_HeaderAndRowAreUnchanged()
+        public void Isobaric_CountsAreOncePerFileAndIntensitiesOncePerChannel()
         {
             AssertTsv(BuildIsobaricGroup(),
                 Compose([
-                    "SpectralCount_goldenA_126", "Intensity_goldenA_126", "CountOccupancy_goldenA_126", "IntensityOccupancy_goldenA_126",
-                    "SpectralCount_goldenA_127N", "Intensity_goldenA_127N", "CountOccupancy_goldenA_127N", "IntensityOccupancy_goldenA_127N"
+                    "SpectralCount_goldenA",
+                    "Intensity_goldenA_126", "Intensity_goldenA_127N",
+                    "CountOccupancy_goldenA",
+                    "IntensityOccupancy_goldenA_126", "IntensityOccupancy_goldenA_127N"
                 ]),
                 ComposeRow([
-                    "3", "500", CountOccupancy, IntensityOccupancy,
-                    "3", "750", CountOccupancy, IntensityOccupancy
+                    "3",
+                    "500", "750",
+                    CountOccupancy,
+                    IntensityOccupancy, IntensityOccupancy
                 ]));
         }
 


### PR DESCRIPTION
Milestone **R5** of the reporting tranche, on top of #1285.

## The defect

A spectral count answers *how many spectra were acquired*, so it belongs to the acquired **file**. An intensity answers *how much of this was in the sample*, which for an isobaric run is the **channel** — and one file carries many. `BioPolymerGroupTsvSchema` had one key space for both, so it emitted every column family per channel.

On an 11-plex protein row that is eleven identical `SpectralCount_` values and eleven byte-identical `CountOccupancy_` strings. `SampleGroupBuilder` is explicit about why they agree: `psmsInFile` is computed once per file (`SampleGroupBuilder.cs:94`) and handed to every channel of that file, for both the count and the occupancy callback. Three of the eleven report a count and `fraction=1.00(1/1)` beside a **blank** `Intensity_` cell — a claimed measurement next to an absent one.

## The change

The two spaces are declared separately and the schema is **told** which is which, rather than inferring one from the other.

- `SampleGroupResult` gains `CountIdentity` and `CountLabel`, both `string?`. Null means *this result is its own count section*, which is every design but the isobaric one; the schema resolves null to `Identity` / `Label` where it builds the section list. This follows `LabelSourcePath`'s idiom — `string?`, a `<remarks>` saying what absence means, and the null resolved at the call site.
- Only the isobaric branch of `SampleGroupBuilder` sets them, to the file.
- The schema walks count sections and, within each, the samples belonging to it. The two lists are disambiguated independently, because two files named `sample.raw` in different directories collide as count sections even where their channel labels already separate them as samples. Both go through `SampleGroupLabels.Disambiguate` unchanged — its signature is already section-agnostic.

Eight quantification columns on the two-channel golden fixture become six; on an 11-plex it is 44 reduced to 24.

## Label-free and no-design output is unchanged, and that is structural

For those designs a sample group **is** its own count section, so each section holds exactly one sample. The emitted columns stay interleaved per section — `SpectralCount_`, `Intensity_`, `CountOccupancy_`, `IntensityOccupancy_` — rather than becoming family-major, so the names *and the order* are what they were. The goldens for both were already in the suite and pass untouched; only the isobaric golden moves, regenerated through the `[Explicit] DumpGoldenStrings` harness rather than hand-edited.

## Channel columns now order by reporter-ion m/z, and this is a restoration

`SampleGroupBuilder.cs:96` was `OrderBy(p => p.ChannelLabel)`. An ordinal sort puts `127C` before `127N` in **every TMT N/C pair**, because `C` precedes `N` as a character while the C reporter is the heavier ion. Carried over from pre-#1285 master (`BioPolymerGroup.cs:637` *at that ref* — the line means something else today), so it is long-standing rather than new.

The *values* were never wrong — intensities are looked up by sample object, not by position. But three separate places already declare ascending m/z canonical, and the builder was the one contradicting them:

- **mzLib says so in prose.** `SampleExperimentalDesign.FromSamples` instructs callers to *"pass isobaric channels already sorted the way the search writes them (ascending reporter m/z, for MetaMorpheus)"*.
- **mzLib's other table already follows it.** `QuantificationWriter`'s positional `Reporter_n` columns follow the design array, i.e. m/z order. So before this change mzLib's two tables disagreed about which 127 came first: `Reporter_2` meant 127N while the grouped table's first 127 column was 127C. They now agree.
- **MetaMorpheus hands us m/z order and calls it load-bearing.** `TmtExperimentalDesign.ToMzLibDesign` emits channels sorted ascending and says so, pinned by its own `ToMzLibDesign_OrdersChannelsByReporterMz_NotByDesignFileOrder`; `IsobaricMassTag.GetReporterIonLabels` lists N before C; and `EveryTagsLabelsNameTheChannelAtTheirOwnIndex` fails outright on a C-before-N pair. `OrderBy(ChannelLabel)` was destroying that order on the way back out.

The only enumerated TMT table in this repo, `Development/.../SpikeInExperimentalDesign.cs:27-28`, is m/z-ascending too.

**Why an explicit sort key rather than `OrderBy(p => p)`:** `IsobaricQuantSampleInfo.CompareTo` reads neither `ChannelLabel` nor `ReporterIonMz`, and returns `1` in both directions for two channels of one file — not a total order, so `OrderBy` would have yielded an arbitrary input-dependent permutation. Its XML doc claims it compares by channel label; that doc is wrong, and correcting `CompareTo` is a separate PR (it would break `CrossClassComparisonTests.cs:243` by design). The `ThenBy(ChannelLabel)` tiebreak exists because nothing validates `ReporterIonMz` — a design leaving it at `0` would otherwise permute arbitrarily.

## Adoptability

MetaMorpheus keeps every column it has today. It renders the protein table from its own `ProteinGroup.GetTabSeparatedHeader()` (`:243`), which iterates `SampleGroupResults` and reads `result.Label` — untouched here — so it still emits `SpectralCount_{file}_{channel}` per channel until R6 switches it onto the schema. Header and row are the same `foreach` over the same list, with every value read off the result object and never off a position, so a reorder moves a header cell and its value cell together. What changes for MetaMorpheus is the *order* of the per-channel blocks, into the order its own design producer already emits.

`integration` stays green: no MetaMorpheus test asserts the order of, or a hardcoded position in, `AllProteinGroups.tsv`'s per-channel columns. `AssertProteinTableKeepsItsColumnsAndGainsChannelIntensities` asserts membership. The suite's only positional channel assertions are against `QuantificationWriter`/`QuantMatrix` column ordering, which this PR does not touch — and they already require ascending m/z.

## Falsification, both directions

Three of the four new tests were demonstrated red before being demonstrated green:

| Revert | Test that goes red | How it fails |
|---|---|---|
| channel sort back to `OrderBy(ChannelLabel)` | `..._Isobaric_ChannelColumnsAreOrderedByReporterMz` | `127C` emitted before `127N` |
| run-level `quantified` back to per-sample-group `HasIntensityData` | `..._QuantifiedRunWithNoMeasuredIntensity_KeepsEmptyIntensityColumns` | `Intensity_gated` absent, index `-1` |
| give a file's channels their own PSM lists | `SampleGroupResults_ChannelsOfOneFile_AgreeOnTheCountTheyReport` | one column can no longer speak for the section |

The second is #1240's guard stated **as behaviour** — the column is present and its cell empty — rather than as row width, copying the shape of `SampleGroupColumnTests.cs:212-217`. A width assertion can no longer fail at all: `TsvWriter.RowLine` joins the same schema object the header came from, so it always emits exactly `schema.Count` fields.

That affects more of the suite than has been recorded. Six assertions are now tautological for that reason — `QuantificationDeliveryTests.cs:629`, `SampleGroupColumnTests.cs:291`, `BioPolymerGroupTsvGoldenTests.cs:223` and `:264-267`, `BioPolymerGroupTests.cs:263-272`, and `TsvWriterTests.cs:82-94`. None are touched here; flagging them because "the rectangularity test passes" is no longer evidence of anything, and re-aiming them belongs in its own PR.

## Known, and deliberately not fixed here

`IntensityOccupancy_` is emitted per channel, which is the right shape, but `ModificationOccupancyCalculator` reads `ISpectralMatch.Intensities` only when its length is 1 (`:83`, `:125`, `:169`, `:205`). On a real multi-reporter TMT PSM it therefore contributes nothing and every channel's cell is empty. Populating it per channel needs the channel-to-reporter-index mapping and is a change of its own.

## Conflicts with #1286

#1286 lifts `QuantificationColumns` into a generic `SampleGroupColumnBuilder.Build<T>` — same single identity list, same `quantified` predicate, same loop. Whichever of the two merges second has to carry the other's change, and the per-section split arguably belongs *in* `SampleGroupColumnBuilder` so peptide groups inherit it. #1286 is currently 6 commits behind master and does not contain #1285's merge, so it needs a rebase either way. Flagging rather than resolving — happy to follow whichever order @pcruzparri prefers.

## Tests

Full mzLib suite, `Category!=ExternalService`: **6027 passed, 0 failed, 31 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2ufKVnx7cXKFWZyJBBiWq
