### PR TITLE
Give each gz database load its own temp file instead of a fixed sibling

### DIFF
--- a/mzLib/Test/DatabaseTests/TestProteinDbLoaderConcurrency.cs
+++ b/mzLib/Test/DatabaseTests/TestProteinDbLoaderConcurrency.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Proteomics;
+using UsefulProteomicsDatabases;
+
+namespace Test.DatabaseTests
+{
+    [TestFixture]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public static class TestProteinDbLoaderConcurrency
+    {
+        /// <summary>
+        /// Several loads of one .gz at once used to fight over a single "temp.xml" beside the input,
+        /// and the losers threw IOException from File.Create.
+        /// </summary>
+        [Test]
+        public static void ConcurrentGzXmlLoadsDoNotShareATempFile()
+        {
+            string testDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, "ConcurrentGzXmlLoads");
+            if (Directory.Exists(testDirectory))
+            {
+                Directory.Delete(testDirectory, true);
+            }
+            Directory.CreateDirectory(testDirectory);
+            string gzDatabase = Path.Combine(testDirectory, "concurrent.xml.gz");
+
+            using (var uncompressed = new FileStream(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", "xml.xml"), FileMode.Open, FileAccess.Read))
+            using (var compressedFile = File.Create(gzDatabase))
+            using (var compressor = new GZipStream(compressedFile, CompressionMode.Compress))
+            {
+                uncompressed.CopyTo(compressor);
+            }
+
+            int expected = ProteinDbLoader.LoadProteinXML(gzDatabase, true, DecoyType.None, null, false, null, out _).Count;
+            Assert.That(expected, Is.GreaterThan(0));
+
+            var counts = new int[4];
+            var exceptions = new ConcurrentBag<Exception>();
+            Parallel.For(0, counts.Length, i =>
+            {
+                try
+                {
+                    counts[i] = ProteinDbLoader.LoadProteinXML(gzDatabase, true, DecoyType.None, null, false, null, out _).Count;
+                }
+                catch (Exception e)
+                {
+                    exceptions.Add(e);
+                }
+            });
+
+            Assert.That(exceptions.Select(e => e.ToString()).ToList(), Is.Empty);
+            Assert.That(counts, Is.All.EqualTo(expected));
+
+            // the decompressed file is cleaned up, so only the input is left
+            Assert.That(Directory.GetFiles(testDirectory).Select(Path.GetFileName).ToList(), Is.EqualTo(new List<string> { "concurrent.xml.gz" }));
+
+            Directory.Delete(testDirectory, true);
+        }
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/DecompressedDatabase.cs
+++ b/mzLib/UsefulProteomicsDatabases/DecompressedDatabase.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+
+namespace UsefulProteomicsDatabases
+{
+    /// <summary>
+    /// A gzipped database decompressed to a sibling of the input and deleted when disposed. The name
+    /// is unique per instance: a fixed one collides when two processes load the same database at once,
+    /// because File.Create takes FileShare.None while the reader holds FileShare.Read.
+    /// </summary>
+    internal sealed class DecompressedDatabase : IDisposable
+    {
+        private readonly string decompressed;
+
+        private DecompressedDatabase(string location, string decompressed)
+        {
+            Location = location;
+            this.decompressed = decompressed;
+        }
+
+        /// <summary>The path to read from: the input itself unless it was gzipped.</summary>
+        internal string Location { get; }
+
+        /// <summary>
+        /// A sibling rather than the system temp directory: the caller already needs the input's
+        /// directory writable and large enough for the whole database, so this adds no requirement.
+        /// The extension is cosmetic, and only keeps the copy recognisable while it exists.
+        /// </summary>
+        internal static DecompressedDatabase For(string dbLocation, string extension)
+        {
+            if (!dbLocation.EndsWith(".gz"))
+            {
+                return new DecompressedDatabase(dbLocation, null);
+            }
+
+            //we had trouble decompressing and streaming on the fly so we decompress completely first, then stream the file, then delete the decompressed file
+            string copy = Path.Combine(Path.GetDirectoryName(dbLocation), $"temp_{Guid.NewGuid():N}{extension}");
+            var database = new DecompressedDatabase(copy, copy);
+            try
+            {
+                using var stream = new FileStream(dbLocation, FileMode.Open, FileAccess.Read, FileShare.Read);
+                using FileStream outputFileStream = File.Create(copy);
+                using var decompressor = new GZipStream(stream, CompressionMode.Decompress);
+                decompressor.CopyTo(outputFileStream);
+            }
+            catch
+            {
+                //a corrupt gz throws part way through the copy, and a unique name would otherwise
+                //orphan one partial file per attempt rather than reusing a single one
+                database.Dispose();
+                throw;
+            }
+
+            return database;
+        }
+
+        public void Dispose()
+        {
+            if (decompressed != null)
+            {
+                File.Delete(decompressed);
+            }
+        }
+    }
+}

--- a/mzLib/UsefulProteomicsDatabases/ProteinDbLoader.cs
+++ b/mzLib/UsefulProteomicsDatabases/ProteinDbLoader.cs
@@ -103,17 +103,8 @@ namespace UsefulProteomicsDatabases
             List<Protein> decoys = new List<Protein>();
             unknownModifications = new Dictionary<string, Modification>();
 
-            string newProteinDbLocation = proteinDbLocation;
-
-            //we had trouble decompressing and streaming on the fly so we decompress completely first, then stream the file, then delete the decompressed file
-            if (proteinDbLocation.EndsWith(".gz"))
-            {
-                newProteinDbLocation = Path.Combine(Path.GetDirectoryName(proteinDbLocation),"temp.xml");
-                using var stream = new FileStream(proteinDbLocation, FileMode.Open, FileAccess.Read, FileShare.Read);
-                using FileStream outputFileStream = File.Create(newProteinDbLocation);
-                using var decompressor = new GZipStream(stream, CompressionMode.Decompress);
-                decompressor.CopyTo(outputFileStream);
-            }
+            using var database = DecompressedDatabase.For(proteinDbLocation, ".xml");
+            string newProteinDbLocation = database.Location;
 
             using (var uniprotXmlFileStream = new FileStream(newProteinDbLocation, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
@@ -155,11 +146,6 @@ namespace UsefulProteomicsDatabases
 
                     }
                 }
-            }
-
-            if (newProteinDbLocation != proteinDbLocation)
-            {
-                File.Delete(newProteinDbLocation);
             }
 
             // Expand the targets first, then mirror each expanded entry, so that every generated decoy is the
@@ -262,17 +248,8 @@ namespace UsefulProteomicsDatabases
             List<Protein> targets = new List<Protein>();
             List<Protein> decoys = new List<Protein>();
 
-            string newProteinDbLocation = proteinDbLocation;
-
-            //we had trouble decompressing and streaming on the fly so we decompress completely first, then stream the file, then delete the decompressed file
-            if (proteinDbLocation.EndsWith(".gz"))
-            {
-                newProteinDbLocation = Path.Combine(Path.GetDirectoryName(proteinDbLocation), "temp.fasta");
-                using var stream = new FileStream(proteinDbLocation, FileMode.Open, FileAccess.Read, FileShare.Read);
-                using FileStream outputFileStream = File.Create(newProteinDbLocation);
-                using var decompressor = new GZipStream(stream, CompressionMode.Decompress);
-                decompressor.CopyTo(outputFileStream);
-            }
+            using var database = DecompressedDatabase.For(proteinDbLocation, ".fasta");
+            string newProteinDbLocation = database.Location;
 
             using (var fastaFileStream = new FileStream(newProteinDbLocation, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
@@ -419,11 +396,6 @@ namespace UsefulProteomicsDatabases
                         break;
                     }
                 }
-            }
-
-            if (newProteinDbLocation != proteinDbLocation)
-            {
-                File.Delete(newProteinDbLocation);
             }
 
             if (!targets.Any())

--- a/mzLib/UsefulProteomicsDatabases/Transcriptomics/RnaDbLoader.cs
+++ b/mzLib/UsefulProteomicsDatabases/Transcriptomics/RnaDbLoader.cs
@@ -6,7 +6,6 @@ using Proteomics;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -174,17 +173,8 @@ namespace UsefulProteomicsDatabases.Transcriptomics
             string organism = null;
             string identifier = null;
 
-            string newDbLocation = rnaDbLocation;
-
-            //we had trouble decompressing and streaming on the fly so we decompress completely first, then stream the file, then delete the decompressed file
-            if (rnaDbLocation.EndsWith(".gz"))
-            {
-                newDbLocation = Path.Combine(Path.GetDirectoryName(rnaDbLocation), "temp.fasta");
-                using var stream = new FileStream(rnaDbLocation, FileMode.Open, FileAccess.Read, FileShare.Read);
-                using FileStream outputFileStream = File.Create(newDbLocation);
-                using var decompressor = new GZipStream(stream, CompressionMode.Decompress);
-                decompressor.CopyTo(outputFileStream);
-            }
+            using var database = DecompressedDatabase.For(rnaDbLocation, ".fasta");
+            string newDbLocation = database.Location;
 
             using (var fastaFileStream = new FileStream(newDbLocation, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
@@ -336,9 +326,6 @@ namespace UsefulProteomicsDatabases.Transcriptomics
                 }
             }
 
-            if (newDbLocation != rnaDbLocation)
-                File.Delete(newDbLocation);
-
             if (!targets.Any())
                 errors.Add("No targets were loaded from database: " + rnaDbLocation);
             decoys.AddRange(RnaDecoyGenerator.GenerateDecoys(targets, decoyType, maxThreads, decoyIdentifier));
@@ -388,17 +375,8 @@ namespace UsefulProteomicsDatabases.Transcriptomics
             unknownModifications = new Dictionary<string, Modification>();
             errors = new List<string>();
 
-            string newProteinDbLocation = rnaDbLocation;
-
-            //we had trouble decompressing and streaming on the fly so we decompress completely first, then stream the file, then delete the decompressed file
-            if (rnaDbLocation.EndsWith(".gz"))
-            {
-                newProteinDbLocation = Path.Combine(Path.GetDirectoryName(rnaDbLocation), "temp.xml");
-                using var stream = new FileStream(rnaDbLocation, FileMode.Open, FileAccess.Read, FileShare.Read);
-                using FileStream outputFileStream = File.Create(newProteinDbLocation);
-                using var decompressor = new GZipStream(stream, CompressionMode.Decompress);
-                decompressor.CopyTo(outputFileStream);
-            }
+            using var database = DecompressedDatabase.For(rnaDbLocation, ".xml");
+            string newProteinDbLocation = database.Location;
 
             using (var uniprotXmlFileStream = new FileStream(newProteinDbLocation, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
@@ -448,10 +426,6 @@ namespace UsefulProteomicsDatabases.Transcriptomics
                         }
                     }
                 }
-            }
-            if (newProteinDbLocation != rnaDbLocation)
-            {
-                File.Delete(newProteinDbLocation);
             }
 
             decoys.AddRange(RnaDecoyGenerator.GenerateDecoys(targets, decoyType, maxThreads, decoyIdentifier));


### PR DESCRIPTION
🤖 Four places decompress a gzipped database to a fixed path beside the input, read it, then delete it: `ProteinDbLoader.LoadProteinXML` (`temp.xml`), `ProteinDbLoader.LoadProteinFasta` (`temp.fasta`), and both `RnaDbLoader` entry points (`temp.fasta` and `temp.xml`). Two processes loading the same database at once use the same file, and the second cannot create it:

```
System.IO.IOException: The process cannot access the file
'/app/spritz/resources/uniprot/temp.xml' because it is being used by another process
   at System.IO.File.Create(String path)
   at UsefulProteomicsDatabases.ProteinDbLoader.LoadProteinXML(...)
```

`File.Create` opens with `FileShare.None` and the reader with `FileShare.Read`; on Unix .NET implements `FileShare` with `flock`, so whichever process arrives second fails. Reproduced with two processes against one 130 MB gzipped database: 20 of 20 pairs failed before this change, 20 of 20 return 2000 proteins each after, and every failure was at `File.Create` — never at the read or the delete.

The four sites shared only two filenames between them, so a protein database and an RNA database in the same directory could collide with each other as well.

## What this changes

One helper, `DecompressedDatabase`, which names the copy per instance and deletes it on disposal. Each call site becomes:

```csharp
using var database = DecompressedDatabase.For(proteinDbLocation, ".xml");
string newProteinDbLocation = database.Location;
```

A unique sibling rather than `Path.GetTempPath()`: the existing code already needs the input's directory writable and large enough for the whole decompressed database, so this adds no requirement, whereas the system temp directory would relocate a multi-gigabyte write onto whatever `/tmp` is — routinely a small tmpfs on containers and HPC nodes.

Cleanup no longer depends on reaching the end of the method, so neither an exception during the read nor one during the decompress leaves the copy behind. Both paths were checked: malformed XML inside a valid gz previously left a 60 MB `temp.xml`, and a corrupt deflate body throws inside the decompress before the instance exists, which is why `For` disposes explicitly there. That second path matters more with unique names than it did with a fixed one, not less — a retry loop over a corrupt download used to overwrite a single file, and would otherwise now orphan one partial copy per attempt.

The copy is deleted at method exit rather than immediately after the read, so it outlives decoy generation. Every site passes the original path downstream and never the temp one, so nothing observes it.

## Output is unchanged

A differential across 53 inputs — every gzipped fixture in the repo, plus a 326 MB synthetic and a genuine five-member concatenated gzip — compared the old fixed-name path against this one element-wise: accession, sequence, per-site modifications, sequence variations, truncation products and `unknownModifications`. No disagreement on any input. Sequential calls in one process were never affected: three sequential loads of the same `.gz` returned 2000 proteins each before and after.

## Tests

New `Test/DatabaseTests/TestProteinDbLoaderConcurrency.cs` loads a gzipped database four ways in parallel and asserts no exception, counts identical to a sequential baseline, and no leftover file. Confirmed failing against `master`, with three of the four parallel loads carrying the exact `IOException` above at `File.Create`.

The existing `XmlGzTest`, `FastaGzTest` and the RNA cases `TestDbReadingDifferentExtensions("20mer1.xml.gz")`, `("20mer1.fasta.gz")` and `TestModomicsUnmodifiedFasta("ModomicsUnmodifiedTrimmed.fasta.gz")` cover non-regression, the last three being the coverage for the two `RnaDbLoader` sites. Worth being straight about how thin that is: those fixtures decompress to a single RNA entry, so they confirm the helper is wired up correctly at those sites and nothing more.

## Deliberately not in this PR

Streaming straight from `GZipStream` into `XmlReader` would remove the temp file entirely and measured better on every axis. But that is what #715 replaced in 2023, for producing an incomplete database, and its mechanism was not recorded. The differential above found no disagreement between the fixed-name, unique-name and streaming paths, which is a negative result rather than a clearance — and `XmlGzTest` asserts no protein count, so nothing currently pins the symptom #715 fixed. Worth its own change, with a wider comparison.

Two smaller things noticed while here and left alone. `GetPtmListFromProteinXml` abandons its `GZipStream` undisposed, because `XmlReader.Create` defaults `CloseInput` to false and only the inner `FileStream` is in a `using`. And #715 also changed `EndsWith("gz")` to `EndsWith(".gz")`, dropping a comment about `.bgz` and `.tgz`, so those extensions are now read as raw XML.

Downstream context: `smith-chem-wisc/Spritz#283`, which works around this with a Snakemake resource token until a release carries the fix.
